### PR TITLE
[DEV]Zmbackup wasn't doing the restore because it loads the wrong config file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![](http://www.beyeler.com.br/wp-content/uploads/2017/03/logo.png)
+
 zmbackup
 =========
 

--- a/src/zmbackup
+++ b/src/zmbackup
@@ -279,7 +279,7 @@ backup_full()
 
 loop_inc()
 {
-  source /etc/zmbkpose/zmbackup.conf
+  source /etc/zmbackup/zmbackup.conf
   source /opt/zimbra/.bashrc
   AFTER=$(grep $1 $WORKDIR/sessions.txt | tail -1 | awk -F: '{print $3}')
   wget --quiet -O $TEMPDIR/$1.tgz \
@@ -387,7 +387,7 @@ restore_accounts_mail ()
 
 loop_ldap()
 {
-  source /etc/zmbkpose/zmbackup.conf
+  source /etc/zmbackup/zmbackup.conf
   source /opt/zimbra/.bashrc
   ldapdelete -r -x -H $LDAPSERVER -D $LDAPADMIN -c \
               -w $LDAPPASS \

--- a/src/zmbackup
+++ b/src/zmbackup
@@ -36,7 +36,7 @@
 ################################################################################
 # zmbackup:
 #
-# 13/03/2017 - Version 1.0.1  - By Lucas Costa Beyeler
+# 22/03/2017 - Version 1.0.2  - By Lucas Costa Beyeler
 #                               <lucas.beyeler@4linux.com.br>
 #                               <lucas.costab@outlook.com>
 ################################################################################
@@ -529,7 +529,7 @@ case "$1" in
     show_help
   ;;
   "-v"|"--version" )
-    echo "zmbackup version: 1.0.1"
+    echo "zmbackup version: 1.0.2"
   ;;
   * )
     show_help

--- a/src/zmbackup-share/zmbackup-validate-config-file
+++ b/src/zmbackup-share/zmbackup-validate-config-file
@@ -22,9 +22,9 @@
 ################################################################################
 # zmbackup-validate-config-file:
 #
-# 13/03/2017 - Version 1.0.1 -  By Lucas Costa Beyeler
-#                               <lucas.beyeler@4linux.com.br>
-#                               <lucas.costab@outlook.com>
+# 13/03/2017 - Version 1.0 -  By Lucas Costa Beyeler
+#                             <lucas.beyeler@4linux.com.br>
+#                             <lucas.costab@outlook.com>
 ################################################################################
 # parallel:
 #


### PR DESCRIPTION
When someone run the zmbackup -r -ldp, the following error occur:

`-su: /etc/zmbkpose/zmbackup.conf: No such file or directory`

This happens because the correct folder is zmbackup, and zmbkpose was used before zmbackup reached its first stable release.

This merge is to correct this issue.