### PR TITLE
Fix for Issue #31 - Error RestoreonAccount

### DIFF
--- a/src/zmbackup
+++ b/src/zmbackup
@@ -133,7 +133,7 @@ build_restore_list()
       echo $i >> $TEMPACCOUNT
     done
   else
-    grep $1 /backup/sessions.txt | grep -v "SESSION" | cut -d: -f2 > $TEMPACCOUNT
+    grep $1 $WORKDIR/sessions.txt | grep -v "SESSION" | cut -d: -f2 > $TEMPACCOUNT
   fi
   if [[ "$1" == "full-"* ]]; then
     for i in $(egrep 'SESSION:' $WORKDIR/sessions.txt | egrep 'started' |  awk '{print $2}' | sort | uniq); do


### PR DESCRIPTION
This merge fix the following bug:

1 - Restore wasn't working out of the folder /backup because session.txt was hard coded in /backup.