### PR TITLE
BETA 3 Bugfix and partially new function

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Zmbackup is a reliable Bash shell script developed to help you in your daily tas
 [![Zimbra Version](https://img.shields.io/badge/Zimbra%20OSE-8.7.11-orange.svg)](https://www.zimbra.com/downloads/zimbra-collaboration-open-source/)
 ![Linux Distro](https://img.shields.io/badge/platform-CentOS%20%7C%20Red%20Hat%20%7C%20Ubuntu-blue.svg)
 ![Branch](https://img.shields.io/badge/Branch-Development-red.svg)
-![Release](https://img.shields.io/badge/Release-1.2.0%20BETA-green.svg)
+![Release](https://img.shields.io/badge/Release-1.2.0%20BETA-3-green.svg)
 
 Features
 ------------
@@ -67,7 +67,7 @@ Inside the project folder, execute the script **install.sh** and follow all the 
 # cd zmbackup
 # ./wizard.sh
 $ zmbackup -v
-  zmbackup version: 1.2.0 BETA
+  zmbackup version: 1.2.0 BETA 3
 ```
 
 Usage

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Zmbackup is a reliable Bash shell script developed to help you in your daily tas
 [![Zimbra Version](https://img.shields.io/badge/Zimbra%20OSE-8.7.11-orange.svg)](https://www.zimbra.com/downloads/zimbra-collaboration-open-source/)
 ![Linux Distro](https://img.shields.io/badge/platform-CentOS%20%7C%20Red%20Hat%20%7C%20Ubuntu-blue.svg)
 ![Branch](https://img.shields.io/badge/Branch-Development-red.svg)
-![Release](https://img.shields.io/badge/Release-1.2.0%20BETA-3-green.svg)
+![Release](https://img.shields.io/badge/Release-1.2.0%20BETA%203-green.svg)
 
 Features
 ------------

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ source installScript/vars.sh
 #  Uninstall code
 ################################################################################
 if [[ $1 == "--remove" ]] || [[ $1 == "-r" ]]; then
-  check_env
+  check_env $1
   if [[ $SO = "ubuntu" ]]; then
     remove_ubuntu
   else

--- a/installScript/check.sh
+++ b/installScript/check.sh
@@ -18,7 +18,7 @@ function check_env() {
   if [ $? != 0 ]; then
     printf "[NEW INSTALL]\n"
     UPGRADE="N"
-  elif [[ $1 == '--remove' ]] && [[ $1 == '-r' ]]; then
+  elif [[ $1 == '--remove' ]] || [[ $1 == '-r' ]]; then
     printf "[UNINSTALL] - EXECUTING UNINSTALL ROUTINE\n"
     UPGRADE="N"
   elif [[ $VERSION != $ZMBKP_VERSION ]]; then

--- a/installScript/check.sh
+++ b/installScript/check.sh
@@ -14,13 +14,19 @@ function check_env() {
     printf "[ROOT]\n"
   fi
   printf "  Old Zmbackup Install...	  "
-  su - $OSE_USER -c "which zmbackup" > /dev/null 2>&1
+  VERSION=$((su - $OSE_USER -c "zmbackup -v") 2> /dev/null)
   if [ $? != 0 ]; then
     printf "[NEW INSTALL]\n"
     UPGRADE="N"
-  else
+  elif [[ $1 = '--remove' ]] && [[ $1 = '-r' ]]; then
+    printf "[UNINSTALL] - EXECUTING UNINSTALL ROUTINE\n"
+    UPGRADE="N"
+  elif [[ $VERSION = $ZMBKP_VERSION ]]; then
     printf "[OLD VERSION] - EXECUTING UPGRADE ROUTINE\n"
     UPGRADE="Y"
+  else
+    printf "[NEWEST VERSION] - Nothing to do..."
+    exit 0
   fi
   printf "  Checking OS...	          "
   which apt > /dev/null 2>&1

--- a/installScript/check.sh
+++ b/installScript/check.sh
@@ -18,7 +18,7 @@ function check_env() {
   if [ $? != 0 ]; then
     printf "[NEW INSTALL]\n"
     UPGRADE="N"
-  elif [[ $1 = '--remove' ]] && [[ $1 = '-r' ]]; then
+  elif [[ $1 == '--remove' ]] && [[ $1 == '-r' ]]; then
     printf "[UNINSTALL] - EXECUTING UNINSTALL ROUTINE\n"
     UPGRADE="N"
   elif [[ $VERSION != $ZMBKP_VERSION ]]; then

--- a/installScript/check.sh
+++ b/installScript/check.sh
@@ -21,7 +21,7 @@ function check_env() {
   elif [[ $1 = '--remove' ]] && [[ $1 = '-r' ]]; then
     printf "[UNINSTALL] - EXECUTING UNINSTALL ROUTINE\n"
     UPGRADE="N"
-  elif [[ $VERSION = $ZMBKP_VERSION ]]; then
+  elif [[ $VERSION != $ZMBKP_VERSION ]]; then
     printf "[OLD VERSION] - EXECUTING UPGRADE ROUTINE\n"
     UPGRADE="Y"
   else

--- a/installScript/check.sh
+++ b/installScript/check.sh
@@ -25,7 +25,7 @@ function check_env() {
     printf "[OLD VERSION] - EXECUTING UPGRADE ROUTINE\n"
     UPGRADE="Y"
   else
-    printf "[NEWEST VERSION] - Nothing to do..."
+    echo "[NEWEST VERSION] - Nothing to do..."
     exit 0
   fi
   printf "  Checking OS...	          "

--- a/installScript/check.sh
+++ b/installScript/check.sh
@@ -69,6 +69,7 @@ function check_config() {
   echo "Zmbackup Backups Days Max: $ROTATE_TIME"
   echo "Zmbackup Number of Threads: $MAX_PARALLEL_PROCESS"
   echo "Zmbackup Backup Lock: $LOCK_BACKUP"
+  echo "Zmbackup Session Default Type: $SESSION_TYPE"
   echo ""
   echo "Press ENTER to continue or CTRL+C to cancel."
   read

--- a/installScript/depDownload.sh
+++ b/installScript/depDownload.sh
@@ -46,7 +46,7 @@ function remove_ubuntu() {
   echo "Removing dependencies. Please wait..."
   apt-get --purge remove -y parallel wget httpie > /dev/null 2>&1
   if [[ $? -eq 0 ]]; then
-    echo "Dependencies installed with success!"
+    echo "Dependencies removed with success!"
   else
     echo "Dependencies wasn't removed in your server"
     echo "Please check if you have connection with the internet and apt-get is"

--- a/installScript/deploy.sh
+++ b/installScript/deploy.sh
@@ -112,6 +112,7 @@ function uninstall() {
   echo "Removing... Please wait while we made some changes."
   echo -ne '                     (0%)\r'
   rm -rf $ZMBKP_SHARE $ZMBKP_SRC/zmbhousekeep > /dev/null 2>&1
+  rm -rf $OSE_INSTALL_DIR/.parallel
   echo -ne '#####                 (25%)\r'
   rm -rf $ZMBKP_LIB $ZMBKP_CONF $ZMBKP_SRC/zmbackup
   echo -ne '##########            (50%)\r'

--- a/installScript/deploy.sh
+++ b/installScript/deploy.sh
@@ -6,15 +6,15 @@
 ################################################################################
 function blacklist_gen(){
   for ACCOUNT in $(sudo -H -u $OSE_USER bash -c "/opt/zimbra/bin/zmprov -l gaa"); do
-    if  [[ "$ACCOUNT" = "galsync."* ]] || \
-    [[ "$ACCOUNT" = "virus-"* ]] || \
-    [[ "$ACCOUNT" = "ham."* ]] || \
-    [[ "$ACCOUNT" = "admin@"* ]] || \
-    [[ "$ACCOUNT" = "spam."* ]] || \
-    [[ "$ACCOUNT" = "zmbackup@"* ]] || \
-    [[ "$ACCOUNT" = "postmaster@"* ]] || \
-    [[ "$ACCOUNT" = "root@"* ]]; then
-      echo $ACCOUNT >> /etc/zmbackup.conf
+    if  [[ "$ACCOUNT" = "galsync"* ]] || \
+    [[ "$ACCOUNT" = "virus"* ]] || \
+    [[ "$ACCOUNT" = "ham"* ]] || \
+    [[ "$ACCOUNT" = "admin"* ]] || \
+    [[ "$ACCOUNT" = "spam"* ]] || \
+    [[ "$ACCOUNT" = "zmbackup"* ]] || \
+    [[ "$ACCOUNT" = "postmaster"* ]] || \
+    [[ "$ACCOUNT" = "root"* ]]; then
+      echo $ACCOUNT >> $ZMBKP_CONF/blacklist.conf
     fi
   done
 }

--- a/installScript/deploy.sh
+++ b/installScript/deploy.sh
@@ -66,6 +66,7 @@ function deploy_new() {
   sed -i "s|{OSE_INSTALL_ADDRESS}|${OSE_INSTALL_ADDRESS}|g" $ZMBKP_CONF/zmbackup.conf
   echo -ne '##############        (70%)\r'
   sed -i "s|{OSE_INSTALL_LDAPPASS}|${OSE_INSTALL_LDAPPASS}|g" $ZMBKP_CONF/zmbackup.conf
+  sed -i "s|{SESSION_TYPE}|${SESSION_TYPE}|g" $ZMBKP_CONF/zmbackup.conf
   echo -ne '###############       (75%)\r'
   sed -i "s|{OSE_USER}|${OSE_USER}|g" $ZMBKP_CONF/zmbackup.conf
   sed -i "s|{MAX_PARALLEL_PROCESS}|${MAX_PARALLEL_PROCESS}|g" $ZMBKP_CONF/zmbackup.conf

--- a/installScript/deploy.sh
+++ b/installScript/deploy.sh
@@ -17,6 +17,7 @@ function blacklist_gen(){
       echo $ACCOUNT >> $ZMBKP_CONF/blacklist.conf
     fi
   done
+  echo $ZMBKP_ACCOUNT >> $ZMBKP_CONF/blacklist.conf
 }
 
 ################################################################################

--- a/installScript/deploy.sh
+++ b/installScript/deploy.sh
@@ -79,7 +79,7 @@ function deploy_new() {
   echo -ne '###################   (95%)\r'
 
   # Creating Zmbackup backup user
-  sudo -H -u $OSE_USER bash -c "/opt/zimbra/bin/zmprov ca zmbackup@$DOMAIN '$ZMBKP_PASSWORD' zimbraIsAdminAccount TRUE zimbraAdminAuthTokenLifetime 1" > /dev/null 2>&1
+  sudo -H -u $OSE_USER bash -c "/opt/zimbra/bin/zmprov ca '$ZMBKP_ACCOUNT' '$ZMBKP_PASSWORD' zimbraIsAdminAccount TRUE zimbraAdminAuthTokenLifetime 1" > /dev/null 2>&1
   echo -ne '####################  (100%)\r'
 }
 
@@ -114,6 +114,6 @@ function uninstall() {
   echo -ne '##########            (50%)\r'
   rm -rf $ZMBKP_LIB $ZMBKP_CONF $ZMBKP_SRC/zmbackup
   echo -ne '###############       (75%)\r'
-  sudo -H -u $OSE_USER bash -c "/opt/zimbra/bin/zmprov da zmbackup@$DOMAIN" > /dev/null 2>&1
+  sudo -H -u $OSE_USER bash -c "/opt/zimbra/bin/zmprov da $ZMBKP_ACCOUNT" > /dev/null 2>&1
   echo -ne '####################  (100%)\r'
 }

--- a/installScript/deploy.sh
+++ b/installScript/deploy.sh
@@ -6,13 +6,13 @@
 ################################################################################
 function blacklist_gen(){
   for ACCOUNT in $(sudo -H -u $OSE_USER bash -c "/opt/zimbra/bin/zmprov -l gaa"); do
-    if  [[ "$ACCOUNT" = "galsync."* ]] && \
-    [[ "$ACCOUNT" = "virus-"* ]] && \
-    [[ "$ACCOUNT" = "ham."* ]] && \
-    [[ "$ACCOUNT" = "admin@"* ]] && \
-    [[ "$ACCOUNT" = "spam."* ]] && \
-    [[ "$ACCOUNT" = "zmbackup@"* ]] && \
-    [[ "$ACCOUNT" = "postmaster@"* ]] && \
+    if  [[ "$ACCOUNT" = "galsync."* ]] || \
+    [[ "$ACCOUNT" = "virus-"* ]] || \
+    [[ "$ACCOUNT" = "ham."* ]] || \
+    [[ "$ACCOUNT" = "admin@"* ]] || \
+    [[ "$ACCOUNT" = "spam."* ]] || \
+    [[ "$ACCOUNT" = "zmbackup@"* ]] || \
+    [[ "$ACCOUNT" = "postmaster@"* ]] || \
     [[ "$ACCOUNT" = "root@"* ]]; then
       echo $ACCOUNT >> /etc/zmbackup.conf
     fi

--- a/installScript/deploy.sh
+++ b/installScript/deploy.sh
@@ -36,7 +36,8 @@ function deploy_new() {
   echo -ne '####                  (20%)\r'
 
   # Copy files
-  echo "will cite" | parallel --bibtex > /dev/null 2>&1
+  mkdir $OSE_INSTALL_DIR/.parallel && touch $OSE_INSTALL_DIR/.parallel/will_cite
+  chown -R zimbra. $OSE_INSTALL_DIR/.parallel
   install -o $OSE_USER -m 700 $MYDIR/project/zmbackup $ZMBKP_SRC
   echo -ne '#####                 (25%)\r'
   cp -R $MYDIR/project/lib/* $ZMBKP_LIB

--- a/installScript/deploy.sh
+++ b/installScript/deploy.sh
@@ -35,9 +35,11 @@ function deploy_new() {
   test -d $ZMBKP_LIB || mkdir -p $ZMBKP_LIB
   echo -ne '####                  (20%)\r'
 
-  # Copy files
+  # Disable Parallel's message - Zmbackup remind the user about GNU Parallel
   mkdir $OSE_INSTALL_DIR/.parallel && touch $OSE_INSTALL_DIR/.parallel/will_cite
   chown -R zimbra. $OSE_INSTALL_DIR/.parallel
+
+  # Copy file
   install -o $OSE_USER -m 700 $MYDIR/project/zmbackup $ZMBKP_SRC
   echo -ne '#####                 (25%)\r'
   cp -R $MYDIR/project/lib/* $ZMBKP_LIB
@@ -94,8 +96,11 @@ function deploy_upgrade(){
   rm -rf $ZMBKP_SHARE $ZMBKP_SRC/zmbhousekeep > /dev/null 2>&1
   echo -ne '##########            (50%)\r'
 
+  # Disable Parallel's message - Zmbackup remind the user about GNU Parallel
+  mkdir $OSE_INSTALL_DIR/.parallel && touch $OSE_INSTALL_DIR/.parallel/will_cite
+  chown -R zimbra. $OSE_INSTALL_DIR/.parallel
+
   # Copy files
-  echo "will cite" | parallel --bibtex > /dev/null 2>&1
   install -o $OSE_USER -m 700 $MYDIR/project/zmbackup $ZMBKP_SRC
   echo -ne '###############       (75%)\r'
   test -d $ZMBKP_LIB || mkdir -p $ZMBKP_LIB

--- a/installScript/deploy.sh
+++ b/installScript/deploy.sh
@@ -36,7 +36,7 @@ function deploy_new() {
   echo -ne '####                  (20%)\r'
 
   # Disable Parallel's message - Zmbackup remind the user about GNU Parallel
-  mkdir $OSE_INSTALL_DIR/.parallel && touch $OSE_INSTALL_DIR/.parallel/will_cite
+  mkdir $OSE_INSTALL_DIR/.parallel && touch $OSE_INSTALL_DIR/.parallel/will-cite
   chown -R zimbra. $OSE_INSTALL_DIR/.parallel
 
   # Copy file
@@ -97,7 +97,7 @@ function deploy_upgrade(){
   echo -ne '##########            (50%)\r'
 
   # Disable Parallel's message - Zmbackup remind the user about GNU Parallel
-  mkdir $OSE_INSTALL_DIR/.parallel && touch $OSE_INSTALL_DIR/.parallel/will_cite
+  mkdir $OSE_INSTALL_DIR/.parallel && touch $OSE_INSTALL_DIR/.parallel/will-cite
   chown -R zimbra. $OSE_INSTALL_DIR/.parallel
 
   # Copy files

--- a/installScript/deploy.sh
+++ b/installScript/deploy.sh
@@ -6,14 +6,14 @@
 ################################################################################
 function blacklist_gen(){
   for ACCOUNT in $(sudo -H -u $OSE_USER bash -c "/opt/zimbra/bin/zmprov -l gaa"); do
-    if  [[ "$ACCOUNT" == "galsync."* ]] && \
-    [[ "$ACCOUNT" == "virus-"* ]] && \
-    [[ "$ACCOUNT" == "ham."* ]] && \
-    [[ "$ACCOUNT" == "admin@"* ]] && \
-    [[ "$ACCOUNT" == "spam."* ]] && \
-    [[ "$ACCOUNT" == "zmbackup@"* ]] && \
-    [[ "$ACCOUNT" == "postmaster@"* ]] && \
-    [[ "$ACCOUNT" == "root@"* ]]; then
+    if  [[ "$ACCOUNT" = "galsync."* ]] && \
+    [[ "$ACCOUNT" = "virus-"* ]] && \
+    [[ "$ACCOUNT" = "ham."* ]] && \
+    [[ "$ACCOUNT" = "admin@"* ]] && \
+    [[ "$ACCOUNT" = "spam."* ]] && \
+    [[ "$ACCOUNT" = "zmbackup@"* ]] && \
+    [[ "$ACCOUNT" = "postmaster@"* ]] && \
+    [[ "$ACCOUNT" = "root@"* ]]; then
       echo $ACCOUNT >> /etc/zmbackup.conf
     fi
   done
@@ -111,8 +111,13 @@ function uninstall() {
   echo "Removing... Please wait while we made some changes."
   echo -ne '                     (0%)\r'
   rm -rf $ZMBKP_SHARE $ZMBKP_SRC/zmbhousekeep > /dev/null 2>&1
-  echo -ne '##########            (50%)\r'
+  echo -ne '#####                 (25%)\r'
   rm -rf $ZMBKP_LIB $ZMBKP_CONF $ZMBKP_SRC/zmbackup
+  echo -ne '##########            (50%)\r'
+  if [[ -f $ZMBKP_CONF/blacklist.conf ]]; then
+    install --backup=numbered -o $OSE_USER -m 600 $MYDIR/project/config/blacklist.conf $ZMBKP_CONF
+    blacklist_gen
+  fi
   echo -ne '###############       (75%)\r'
   sudo -H -u $OSE_USER bash -c "/opt/zimbra/bin/zmprov da $ZMBKP_ACCOUNT" > /dev/null 2>&1
   echo -ne '####################  (100%)\r'

--- a/installScript/menu.sh
+++ b/installScript/menu.sh
@@ -102,6 +102,12 @@ function set_values() {
   printf "\nZmbackup should limit backups for one per day? - DEFAULT [$LOCK_BACKUP]:"
   read TMP
   LOCK_BACKUP=${TMP:-$LOCK_BACKUP}
+
+  # Configure mail alert
+  printf "\nWhere you want to store Zmbackup's sessions? TXT or SQLITE3 - DEFAULT [$SESSION_TYPE]:"
+  read TMP
+  SESSION_TYPE=${TMP:-$SESSION_TYPE}
+
   echo -e "\n\n"
   echo "##################################################################################"
   echo "#                                                                                #"

--- a/installScript/vars.sh
+++ b/installScript/vars.sh
@@ -26,4 +26,5 @@ ZMBKP_PASSWORD=$(date +%s | sha256sum | base64 | head -c 32 ; echo)    # Zmbacku
 MAX_PARALLEL_PROCESS="3"                                               # Zmbackup's number of threads
 ROTATE_TIME="30"                                                       # Zmbackup's max of days before housekeeper
 LOCK_BACKUP=true                                                       # Zmbackup's backup lock
-ZMBKP_VERSION="zmbackup version: 1.2.0 - BETA 3"                         # Zmbackup's latest version
+ZMBKP_VERSION="zmbackup version: 1.2.0 - BETA 3"                       # Zmbackup's latest version
+SESSION_TYPE="TXT"                                                     # Zmbackup's default session type

--- a/installScript/vars.sh
+++ b/installScript/vars.sh
@@ -26,4 +26,4 @@ ZMBKP_PASSWORD=$(date +%s | sha256sum | base64 | head -c 32 ; echo)    # Zmbacku
 MAX_PARALLEL_PROCESS="3"                                               # Zmbackup's number of threads
 ROTATE_TIME="30"                                                       # Zmbackup's max of days before housekeeper
 LOCK_BACKUP=true                                                       # Zmbackup's backup lock
-ZMBKP_VERSION="zmbackup version: 1.2.0 - BETA"                         # Zmbackup's latest version
+ZMBKP_VERSION="zmbackup version: 1.2.0 - BETA 3"                         # Zmbackup's latest version

--- a/installScript/vars.sh
+++ b/installScript/vars.sh
@@ -26,3 +26,4 @@ ZMBKP_PASSWORD=$(date +%s | sha256sum | base64 | head -c 32 ; echo)    # Zmbacku
 MAX_PARALLEL_PROCESS="3"                                               # Zmbackup's number of threads
 ROTATE_TIME="30"                                                       # Zmbackup's max of days before housekeeper
 LOCK_BACKUP=true                                                       # Zmbackup's backup lock
+ZMBKP_VERSION="zmbackup version: 1.2.0 - BETA"                         # Zmbackup's latest version

--- a/project/config/zmbackup.conf
+++ b/project/config/zmbackup.conf
@@ -90,3 +90,10 @@ ROTATE_TIME={ROTATE_TIME}
 #               DEFAULT: true
 
 LOCK_BACKUP={LOCK_BACKUP}
+
+# SESSION_TYPE - This option define the default place where zmbackup should store the
+#                information of each session. Valid values can be TXT - for session.txt
+#                - or SQLITE3 - for SQLite3 driver.
+#                DEFAULT: TXT
+
+SESSION_TYPE={SESSION_TYPE}

--- a/project/lib/bash/HelpAction.sh
+++ b/project/lib/bash/HelpAction.sh
@@ -12,6 +12,7 @@ function show_help (){
   printf "\n       zmbackup [-r] [options] <session> <mail>"
   printf "\n       zmbackup [-r] [-ro] <session> <mail_origin> <mail_destination>"
   printf "\n       zmbackup [-d] <session>"
+  printf "\n       zmbackup [-m]"
 
   # All the basic options.
   printf "\n\nOptions:\n"
@@ -22,6 +23,7 @@ function show_help (){
   printf "\n -r, --restore                  : Restore the backup inside the users account."
   printf "\n -d, --delete                   : Delete a session of backup."
   printf "\n -hp, --housekeep               : Execute the Housekeep to remove old sessions - Zmbhousekeep"
+  printf "\n -m, --migrate                  : Migrate the database from TXT to SQLITE3 and vice versa."
   printf "\n -v, --version                  : Show the zmbackup version."
 
   # All the options related to Full Backups

--- a/project/lib/bash/MigrationAction.sh
+++ b/project/lib/bash/MigrationAction.sh
@@ -79,3 +79,21 @@ function importaccounts(){
     done
   done
 }
+
+###############################################################################
+# migration: Execute migration action
+###############################################################################
+function migration(){
+  create_session
+  if [[ $SESSION_TYPE == "SQLITE3" ]] && ! [[ -f $WORKDIR/sessions.sqlite3 ]]; then
+    echo "Starting the migration - please wait until the conclusion"
+    importsession
+    importaccounts
+    echo "Migration completed"
+    rm $WORKDIR/sessions.txt
+  elif [[ $SESSION_TYPE == "TXT" ]] && ! [[ -f $WORKDIR/sessions.txt ]]; then
+    rm $WORKDIR/sessions.sqlite3
+  else
+    echo "Nothing to do."
+  fi
+}

--- a/project/lib/bash/MigrationAction.sh
+++ b/project/lib/bash/MigrationAction.sh
@@ -84,14 +84,15 @@ function importaccounts(){
 # migration: Execute migration action
 ###############################################################################
 function migration(){
-  create_session
   if [[ $SESSION_TYPE == "SQLITE3" ]] && ! [[ -f $WORKDIR/sessions.sqlite3 ]]; then
     echo "Starting the migration - please wait until the conclusion"
+    create_session
     importsession
     importaccounts
     echo "Migration completed"
     rm $WORKDIR/sessions.txt
   elif [[ $SESSION_TYPE == "TXT" ]] && ! [[ -f $WORKDIR/sessions.txt ]]; then
+    create_session
     rm $WORKDIR/sessions.sqlite3
   else
     echo "Nothing to do."

--- a/project/lib/bash/MiscAction.sh
+++ b/project/lib/bash/MiscAction.sh
@@ -241,6 +241,12 @@ function validate_config(){
     logger -i -p local7.err "Zmbackup: You need to define the variable ROTATE_TIME."
     exit 2
   fi
+
+  if [ -z "$SESSION_TYPE" ]; then
+    echo "You need to define the variable SESSION_TYPE."
+    logger -i -p local7.err "Zmbackup: You need to define the variable SESSION_TYPE."
+    exit 2
+  fi
 }
 
 ################################################################################

--- a/project/lib/bash/MiscAction.sh
+++ b/project/lib/bash/MiscAction.sh
@@ -282,4 +282,5 @@ function export_vars(){
   export LDAPPASS
   export MAILHOST
   export WORKDIR
+  export LOCK_BACKUP
 }

--- a/project/lib/bash/ParallelAction.sh
+++ b/project/lib/bash/ParallelAction.sh
@@ -109,7 +109,7 @@ function ldap_filter()
   grep -Fxq $1 /etc/zmbackup/blacklist.conf
   if [[ $? -eq 0 ]]; then
     echo "WARN: $1 found inside blacklist - Nothing to do."
-  elif [[ "$EXIST" = "$(date +%m/%d/%y)" && "$LOCK_BACKUP" == "TRUE" ]]; then
+  elif [[ "$EXIST" = "$(date +%m/%d/%y)" && "$LOCK_BACKUP" == "true" ]]; then
     echo "WARN: $1 already has backup today. Nothing to do."
   else
     echo $1 >> $TEMPACCOUNT

--- a/project/lib/bash/SqliteAction.sh
+++ b/project/lib/bash/SqliteAction.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+################################################################################
+# Database Actions - Sqlite Drive
+################################################################################
+
+###############################################################################
+# create_session: Migrate the entire sessions.txt to SQLite database
+###############################################################################
+function create_session(){
+  if [[ $SESSION_TYPE == 'TXT' ]]; then
+    touch $WORKDIR/sessions.txt
+    echo "Session file recreated"
+  elif [[ $SESSION_TYPE == "SQLITE3" ]]; then
+    sqlite3 $WORKDIR/sessions.sqlite3 < /usr/local/lib/zmbackup/sqlite3/database.sql
+  else
+    echo "Invalid File Format - Nothing to do."
+  fi
+}
+
+###############################################################################
+# importsession: Migrate the sessions from the txt file to the sqlite3 database
+###############################################################################
+function importsession(){
+  for i in $(egrep 'SESSION:' $WORKDIR/sessions.txt | egrep 'started' |  awk '{print $2}' | sort | uniq); do
+    SESSIONID=$i
+    OPT=$(echo $i | cut -d"-" -f1 )
+    case $OPT in
+      "full")
+          OPT="Full Backup"
+          YEAR=$(echo $i | cut -c6-9)
+          MONTH=$(echo $i | cut -c10-11)
+          DAY=$(echo $i | cut -c12-13)
+      ;;
+      "inc")
+          OPT="Incremental Backup"
+          YEAR=$(echo $i | cut -c5-8)
+          MONTH=$(echo $i | cut -c9-10)
+          DAY=$(echo $i | cut -c11-12)
+      ;;
+      "distlist")
+          OPT="Distribution List Backup"
+          YEAR=$(echo $i | cut -c10-13)
+          MONTH=$(echo $i | cut -c14-15)
+          DAY=$(echo $i | cut -c16-17)
+      ;;
+      "alias")
+          OPT="Alias Backup"
+          YEAR=$(echo $i | cut -c7-10)
+          MONTH=$(echo $i | cut -c11-12)
+          DAY=$(echo $i | cut -c13-14)
+      ;;
+      "ldap")
+          OPT="Account Backup - Only LDAP"
+          YEAR=$(echo $i | cut -c6-9)
+          MONTH=$(echo $i | cut -c10-11)
+          DAY=$(echo $i | cut -c12-13)
+      ;;
+    esac
+    INITIAL=$YEAR'-'$MONTH'-'$DAY"T00:00:00.000"
+    CONCLUSION=$YEAR'-'$MONTH'-'$DAY"T00:00:00.000"
+    SIZE=$(du -h $WORKDIR/$i | awk {'print $1'})
+    STATUS="FINISHED"
+    sqlite3 $DATABASE "insert into backup_session values ('$SESSIONID','$INITIAL','$CONCLUSION','$SIZE','$OPT','$STATUS')"
+  done
+}
+
+###############################################################################
+# importaccounts: Migrate the accounts from the txt file to the sqlite3 database
+###############################################################################
+function importaccounts(){
+  for i in $(egrep 'SESSION:' $WORKDIR/sessions.txt | egrep 'started' |  awk '{print $2}' | sort | uniq); do
+    SESSIONID=$i
+    for j in $(egrep $i $WORKDIR/sessions.txt | grep -v 'SESSION:' | sort | uniq); do
+      EMAIL=$(echo $j | cut -d":" -f2)
+      SIZE=$(du -h $WORKDIR/$i/$EMAIL.tgz | awk {'print $1'})
+      sqlite3 $DATABASE "insert into backup_account (email) values ('$EMAIL')" > /dev/null
+      ID=$(sqlite3 $DATABASE "select accountID from backup_account where email='$EMAIL'")
+      sqlite3 $DATABASE "insert into session_account (accountID,sessionID,account_size) values ('$ID','$SESSIONID','$SIZE')" > /dev/null
+    done
+  done
+}

--- a/project/lib/sqlite3/database.sql
+++ b/project/lib/sqlite3/database.sql
@@ -1,0 +1,29 @@
+  create table backup_session(
+    sessionID varchar primary key,
+    initial_date timestamp not null,
+    conclusion_date timestamp not null,
+    size varchar not null,
+    type varchar not null,
+    status varchar not null
+  );
+
+  create table backup_account(
+    accountID integer primary key autoincrement unique,
+    email varchar not null);
+
+  create table session_account(
+    id integer primary key autoincrement,
+    accountID int not null,
+    sessionID varchar not null,
+    account_size varchar not null,
+    foreign key (accountID) references backup_account(accountID),
+    foreign key (sessionID) references backup_session(sessionID)
+  );
+
+  create table backup_queue(
+    id integer primary key autoincrement,
+    accountID int not null,
+    sessionID varchar not null,
+    foreign key (accountID) references backup_account(accountID),
+    foreign key (sessionID) references backup_session(sessionID)
+  );

--- a/project/zmbackup
+++ b/project/zmbackup
@@ -56,6 +56,7 @@ source /usr/local/lib/zmbackup/bash/ListAction.sh
 source /usr/local/lib/zmbackup/bash/BackupAction.sh
 source /usr/local/lib/zmbackup/bash/RestoreAction.sh
 source /usr/local/lib/zmbackup/bash/DeleteAction.sh
+source /usr/local/lib/zmbackup/bash/MigrationAction.sh
 
 ################################################################################
 # ZMBACKUP MAIN CODE
@@ -175,6 +176,9 @@ case "$1" in
   ;;
   "-v"|"--version" )
     echo "zmbackup version: 1.2.0 - BETA 3"
+  ;;
+  "-m"|"--migrate" )
+    migration
   ;;
   * )
     show_help

--- a/project/zmbackup
+++ b/project/zmbackup
@@ -174,7 +174,7 @@ case "$1" in
     show_help
   ;;
   "-v"|"--version" )
-    echo "zmbackup version: 1.2.0 - BETA"
+    echo "zmbackup version: 1.2.0 - BETA 3"
   ;;
   * )
     show_help


### PR DESCRIPTION
The following fixes are made in Zmbackup BETA 3:

- LOCK_BACKUP stopped working after the 1.2 upgrade;
- Install.sh now create the blacklist;
- Fix messages about remove - now it doesn't inform you that you are trying to do a upgrade;
- Install.sh now creates the zmbackup account;
- Parallel can't create will-cite in Zimbra's home - Zmbackup now create it manually;
- (Ubuntu Server) Uninstall says that the dependencies are installed with success, when shoud say "are removed";

And the following function is still in development:

- Zmbackup migration from TXT to SQLITE3;