### PR TITLE
Better handling of stale PID files

### DIFF
--- a/project/lib/bash/DeleteAction.sh
+++ b/project/lib/bash/DeleteAction.sh
@@ -20,6 +20,7 @@ function delete_one(){
   else
     echo "Session $1 not found in database - ignoring."
   fi
+  rm -rf $PID
   exit 2
 }
 

--- a/project/lib/bash/MiscAction.sh
+++ b/project/lib/bash/MiscAction.sh
@@ -200,10 +200,17 @@ function validate_config(){
 ################################################################################
 function checkpid(){
   if [[ -f "$PID" ]]; then
-    echo "FATAL: could not write lock file '/opt/zimbra/log/zmbackup.pid': File already exist"
-    echo "This file exist as a secure measurement to protect your system to run two zmbackup"
-    echo "instances at the same time."
-    exit 3
+    PIDP=`cat $PID`
+    PIDR=`ps -efa | awk '{print $2}' | grep -c "^$PIDP$"`
+    if [ $PIDR -gt 0 ]; then
+      echo "FATAL: could not write lock file '/opt/zimbra/log/zmbackup.pid': File already exist"
+      echo "This file exist as a secure measurement to protect your system to run two zmbackup"
+      echo "instances at the same time."
+      exit 3
+    else
+      echo 'Found stale PID file. Proceeding'
+      echo $$ > $PID
+    fi
   else
     echo $$ > $PID
   fi


### PR DESCRIPTION
`delete_one` in `DeleteAction.sh` is leaving behind a stale PID file due to the `exit 2` (which appears to be present to suppress meaningless errors). This PID file should be deleted prior to the exit.

Additionally, stale PID files can occur from time to time for various reasons. Have `checkpid` in `MiscActions.sh` investigate if the PID is stale or not and act accordingly.