### PR TITLE
Added cron reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ $ zmbackup -m
 
 **REMEMBER:** at this moment, this migration activity is a only one way road. There is no rollback, and, if you try to do a rollback, you will lost your sessions file.
 
+Scheduling backups
+------------
+
+The installer script automatically creates a cron config file in `/etc/cron.d/zmbackup`. You can customize backup routines editing that file.
+
 Get Involved
 ------------------
 * You can participate in our [Google Group](https://groups.google.com/forum/#!forum/zmbackup) - you are free to post anything there, but please follow the Guidelines! This group will be used to discuss new features planed to be created in the future, answer any question about how to use the software, discuss about the latest release, and so on.


### PR DESCRIPTION
I noticed that backup are automatically scheduled by the installer, but it is not mentioned anywhere how they are scheduled and how to edit that schedule.