### PR TITLE
Use .ldif extension for LDIF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Restore Backup Options:
  -a,   --account                  : Execute a backup of only a set of accounts, comma separated
 ```
 
-To execute a full backup routine, which include by default the mailbox and the ldiff, just run the script with the option **-f** or **--full**. Depending of the ammount of accounts or the number of proccess you set in the option **MAX_PARALLEL_PROCESS**, this will take sometime before conclude.
+To execute a full backup routine, which include by default the mailbox and the ldif, just run the script with the option **-f** or **--full**. Depending of the ammount of accounts or the number of proccess you set in the option **MAX_PARALLEL_PROCESS**, this will take sometime before conclude.
 
 ```
 $ zmbackup -f

--- a/project/lib/bash/NotifyAction.sh
+++ b/project/lib/bash/NotifyAction.sh
@@ -50,7 +50,7 @@ function notify_finish()
         if [[ "$1" == "mbox"* ]]; then
           QTDE=$(ls $WORKDIR/$1/*.tgz | wc -l)
         else
-          QTDE=$(ls $WORKDIR/$1/*.ldiff | wc -l)
+          QTDE=$(ls $WORKDIR/$1/*.ldif | wc -l)
         fi
       else
         SIZE=0

--- a/project/lib/bash/ParallelAction.sh
+++ b/project/lib/bash/ParallelAction.sh
@@ -15,7 +15,7 @@
 function ldap_backup()
 {
   ERR=$((ldapsearch -x -H $LDAPSERVER -D $LDAPADMIN -w $LDAPPASS -b '' \
-             -LLL "(&(|(mail=$1)(uid=$1))$2)" > $TEMPDIR/$1.ldiff)2>&1)
+             -LLL "(&(|(mail=$1)(uid=$1))$2)" > $TEMPDIR/$1.ldif)2>&1)
   if [[ $? -eq 0 ]]; then
     logger -i -p local7.info "Zmbackup: LDAP - Backup for account $1 finished."
     export ERRCODE=0
@@ -71,9 +71,9 @@ function mailbox_backup()
 function ldap_restore()
 {
   ldapdelete -r -x -H $LDAPSERVER -D $LDAPADMIN -c -w $LDAPPASS \
-    $(grep ^dn: $WORKDIR/$1/$2.ldiff | awk '{print $2}') > /dev/null 2>&1
+    $(grep ^dn: $WORKDIR/$1/$2.ldif | awk '{print $2}') > /dev/null 2>&1
   ERR=$((ldapadd -x -H $LDAPSERVER -D $LDAPADMIN \
-           -c -w $LDAPPASS -f $WORKDIR/$1/$2.ldiff) 2>&1)
+           -c -w $LDAPPASS -f $WORKDIR/$1/$2.ldif) 2>&1)
   if ! [[ $? -eq 0 ]]; then
     printf "\nError during the restore process for account $2. Error message below:"
     printf "\n$2: $ERR"

--- a/project/lib/bash/SessionAction.sh
+++ b/project/lib/bash/SessionAction.sh
@@ -32,7 +32,7 @@ function list_sessions_txt ()
     if [[ $i == "mbox"* ]]; then
       QTDE=$(ls $WORKDIR/$i/*.tgz | wc -l)
     else
-      QTDE=$(ls $WORKDIR/$i/*.ldiff | wc -l)
+      QTDE=$(ls $WORKDIR/$i/*.ldif | wc -l)
     fi
     OPT=$(echo $i | cut -d"-" -f1 )
     case $OPT in


### PR DESCRIPTION
The file extension currently used is `.ldiff`, and should be `.ldif` as the file format is LDIF (see https://en.wikipedia.org/wiki/LDAP_Data_Interchange_Format)

This is a very minor issue but can annoy people working with LDAP all the day, like me ;)