### PR TITLE
Disable timeout checking & improve incremental backup 

### DIFF
--- a/project/lib/bash/ParallelAction.sh
+++ b/project/lib/bash/ParallelAction.sh
@@ -48,9 +48,9 @@ function mailbox_backup()
              from backup_account where email='$1' and \
              (sessionID like 'full%' or sessionID like 'inc%' or sessionID like 'mbox%')")
     fi
-    AFTER='&'"start=$(date -d "$DATE" +%s)000"
+    AFTER='&'"query=after:\"$(date -d "$DATE" --date='-1 day' +%m/%d/%Y)\""
   fi
-  $ZMMAILBOX -z -m "$1" getRestURL --output "$TEMPDIR"/"$1".tgz "/?fmt=tgz&resolve=skip$AFTER" > "$TEMP_CLI_OUTPUT" 2>&1
+  $ZMMAILBOX -t0 -z -m "$1" getRestURL --output "$TEMPDIR"/"$1".tgz "/?fmt=tgz&resolve=skip$AFTER" > "$TEMP_CLI_OUTPUT" 2>&1
   BASHERRCODE=$?
   if [[ $BASHERRCODE -eq 0 ]]; then
     if [[ -s $TEMPDIR/$1.tgz ]]; then
@@ -98,7 +98,7 @@ function ldap_restore()
 function mailbox_restore()
 {
   TEMP_CLI_OUTPUT=$(mktemp)
-  $ZMMAILBOX -z -m "$2" postRestURL '//?fmt=tgz&resolve=skip' "$WORKDIR"/"$1"/"$2".tgz > "$TEMP_CLI_OUTPUT" 2>&1
+  $ZMMAILBOX -t0 -z -m "$2" postRestURL '//?fmt=tgz&resolve=skip' "$WORKDIR"/"$1"/"$2".tgz > "$TEMP_CLI_OUTPUT" 2>&1
   BASHERRCODE=$?
   if ! [[ $BASHERRCODE -eq 0 ]]; then
     printf "Error during the restore process for account %s. Error message below:" "$2"

--- a/project/lib/bash/RestoreAction.sh
+++ b/project/lib/bash/RestoreAction.sh
@@ -22,7 +22,7 @@ function restore_main_mailbox()
     printf "Restore mail process with session %s started at %s" "$1" "$(date)"
     if [[ -n $3 && $2 == *"@"* ]]; then
       TEMP_CLI_OUTPUT=$(mktemp)
-      $ZMMAILBOX -z -m "$3" postRestURL '//?fmt=tgz&resolve=skip' "$WORKDIR"/"$1"/"$2".tgz > "$TEMP_CLI_OUTPUT" 2>&1
+      $ZMMAILBOX -t0 -z -m "$3" postRestURL '//?fmt=tgz&resolve=skip' "$WORKDIR"/"$1"/"$2".tgz > "$TEMP_CLI_OUTPUT" 2>&1
       BASHERRCODE=$?
       if ! [[ $BASHERRCODE -eq 0 ]]; then
         printf "Error during the restore process for account %s. Error message below:" "$2"


### PR DESCRIPTION
Disable timeout checking in backup generations and restores to avoid problems with large mailboxes and improve incremental backup generation to include future agenda events.