### PR TITLE
Fix GNU Parallel pidtable bug on RHEL7 (issue #180)

### DIFF
--- a/installScript/depDownload.sh
+++ b/installScript/depDownload.sh
@@ -26,10 +26,15 @@ function install_ubuntu() {
 ################################################################################
 function install_redhat() {
   echo "Installing dependencies. Please wait..."
-  grep 6 /etc/redhat-release > /dev/null 2>&1
-  BASHERRCODE=$?
-  if [[ $BASHERRCODE -eq 0 ]]; then
+  if grep -E "release 6" /etc/redhat-release > /dev/null 2>&1; then
     wget -O "/etc/yum.repos.d/tange.repo" "$OLE_TANGE" > /dev/null 2>&1
+    BASHERRCODE=$?
+    if [[ $BASHERRCODE -ne 0 ]]; then
+      echo "Failure - Can't install Tange's repository for Parallel"
+      exit "$ERR_NO_CONNECTION"
+    fi
+  elif grep -E "release 7" /etc/redhat-release > /dev/null 2>&1; then
+    wget -O "/etc/yum.repos.d/tange.repo" "$OLE_TANGE_RHEL7" > /dev/null 2>&1
     BASHERRCODE=$?
     if [[ $BASHERRCODE -ne 0 ]]; then
       echo "Failure - Can't install Tange's repository for Parallel"

--- a/installScript/vars.sh
+++ b/installScript/vars.sh
@@ -36,6 +36,7 @@ SESSION_TYPE="TXT"                                                              
 
 # REPOSITORIES FOR PACKAGES
 OLE_TANGE="http://download.opensuse.org/repositories/home:/tange/CentOS_CentOS-6/home:tange.repo"
+OLE_TANGE_RHEL7="http://download.opensuse.org/repositories/home:/tange/CentOS_7/home:tange.repo"
 
 # Force a terminal type - Issue #90
 export TERM="linux"

--- a/project/lib/bash/MiscAction.sh
+++ b/project/lib/bash/MiscAction.sh
@@ -244,10 +244,30 @@ function validate_config(){
     zmlog local7.warn "No value was found for SSL_ENABLE. Setting 'true' for the value."
   fi
 
+  check_parallel_version
+
   if [ "$ERR" == "true" ]; then
     echo "Some errors are found inside the config file. Please fix then and try again later."
     zmlog local7.err "Zmbackup: Configuration validation failed — check the errors above."
     exit 3
+  fi
+}
+
+################################################################################
+# check_parallel_version: Warn if GNU Parallel is too old (version <= 20160222
+# has a known "pidtable format" bug that causes backup failures).
+################################################################################
+function check_parallel_version(){
+  local parallel_version
+  parallel_version=$(parallel --version 2>/dev/null | head -1 | grep -oE '[0-9]{8}')
+  if [[ -n "$parallel_version" ]] && [[ "$parallel_version" -le "20160222" ]]; then
+    echo "WARNING: GNU Parallel version $parallel_version has a known bug (pidtable format)"
+    echo "         that may cause backup failures. Please upgrade to a version newer than"
+    echo "         20160222. On RHEL/CentOS 7 you can run:"
+    echo "           wget -O /etc/yum.repos.d/tange.repo \\"
+    echo "             http://download.opensuse.org/repositories/home:/tange/CentOS_7/home:tange.repo"
+    echo "           yum install -y parallel"
+    zmlog local7.warn "Zmbackup: GNU Parallel $parallel_version has a known pidtable bug — please upgrade."
   fi
 }
 

--- a/tests/mocks/parallel
+++ b/tests/mocks/parallel
@@ -1,5 +1,10 @@
 #!/bin/bash
 # parallel mock - sequential execution
+if [[ "$1" == "--version" ]]; then
+  echo "GNU parallel ${MOCK_PARALLEL_VERSION:-20200722}"
+  exit 0
+fi
+
 # Skip flags
 while [[ $# -gt 1 ]]; do
   case "$1" in

--- a/tests/unit/installer/test_depDownload.bats
+++ b/tests/unit/installer/test_depDownload.bats
@@ -13,21 +13,21 @@ setup() {
 # ---------------------------------------------------------------------------
 
 @test "install_ubuntu: succeeds when apt succeeds" {
-  MOCK_APT_FAIL=0
+  export MOCK_APT_FAIL=0
   run install_ubuntu
   [ "$status" -eq 0 ]
   [[ "$output" == *"success"* ]]
 }
 
 @test "install_ubuntu: exits ERR_DEPNOTFOUND when apt fails" {
-  MOCK_APT_FAIL=1
+  export MOCK_APT_FAIL=1
   run install_ubuntu
   [ "$status" -eq "$ERR_DEPNOTFOUND" ]
   [[ "$output" == *"wasn't installed"* ]]
 }
 
 @test "install_ubuntu: prints manual command hint on failure" {
-  MOCK_APT_FAIL=1
+  export MOCK_APT_FAIL=1
   run install_ubuntu
   [[ "$output" == *"apt update"* ]]
 }
@@ -36,28 +36,28 @@ setup() {
 # install_redhat
 # ---------------------------------------------------------------------------
 
-@test "install_redhat: succeeds when yum succeeds (CentOS 7)" {
-  MOCK_YUM_FAIL=0
-  # CentOS 7 - grep for "6" fails (not CentOS 6)
+@test "install_redhat: succeeds when yum succeeds (no RHEL version file)" {
+  export MOCK_YUM_FAIL=0
+  # No /etc/redhat-release in test environment — neither CentOS 6 nor 7 branch runs
   run install_redhat
   [ "$status" -eq 0 ]
   [[ "$output" == *"success"* ]]
 }
 
 @test "install_redhat: exits ERR_DEPNOTFOUND when yum fails" {
-  MOCK_YUM_FAIL=1
+  export MOCK_YUM_FAIL=1
   run install_redhat
   [ "$status" -eq "$ERR_DEPNOTFOUND" ]
   [[ "$output" == *"wasn't installed"* ]]
 }
 
 @test "install_redhat: exits ERR_NO_CONNECTION when wget fails on CentOS 6" {
-  MOCK_YUM_FAIL=0
-  MOCK_WGET_FAIL=1
+  export MOCK_YUM_FAIL=0
+  export MOCK_WGET_FAIL=1
   # Simulate CentOS 6 detection: override grep for redhat-release
   grep() {
-    if [[ "$*" == *"redhat-release"* ]]; then
-      return 0  # "6" found
+    if [[ "$*" == *"release 6"* && "$*" == *"redhat-release"* ]]; then
+      return 0  # "release 6" found
     fi
     command grep "$@"
   }
@@ -66,8 +66,42 @@ setup() {
   [[ "$output" == *"Tange"* ]]
 }
 
+@test "install_redhat: exits ERR_NO_CONNECTION when wget fails on CentOS 7" {
+  export MOCK_YUM_FAIL=0
+  export MOCK_WGET_FAIL=1
+  # Simulate CentOS 7 detection: "release 6" not found, "release 7" found
+  grep() {
+    if [[ "$*" == *"release 6"* && "$*" == *"redhat-release"* ]]; then
+      return 1  # Not CentOS 6
+    elif [[ "$*" == *"release 7"* && "$*" == *"redhat-release"* ]]; then
+      return 0  # CentOS 7 detected
+    fi
+    command grep "$@"
+  }
+  run install_redhat
+  [ "$status" -eq "$ERR_NO_CONNECTION" ]
+  [[ "$output" == *"Tange"* ]]
+}
+
+@test "install_redhat: succeeds when yum succeeds on CentOS 7 with tange repo" {
+  export MOCK_YUM_FAIL=0
+  export MOCK_WGET_FAIL=0
+  # Simulate CentOS 7 detection
+  grep() {
+    if [[ "$*" == *"release 6"* && "$*" == *"redhat-release"* ]]; then
+      return 1
+    elif [[ "$*" == *"release 7"* && "$*" == *"redhat-release"* ]]; then
+      return 0
+    fi
+    command grep "$@"
+  }
+  run install_redhat
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"success"* ]]
+}
+
 @test "install_redhat: prints manual command hint on failure" {
-  MOCK_YUM_FAIL=1
+  export MOCK_YUM_FAIL=1
   run install_redhat
   [[ "$output" == *"yum install"* ]]
 }
@@ -77,21 +111,21 @@ setup() {
 # ---------------------------------------------------------------------------
 
 @test "remove_ubuntu: succeeds when apt remove succeeds" {
-  MOCK_APT_FAIL=0
+  export MOCK_APT_FAIL=0
   run remove_ubuntu
   [ "$status" -eq 0 ]
   [[ "$output" == *"success"* ]]
 }
 
 @test "remove_ubuntu: prints warning but does not exit on apt failure" {
-  MOCK_APT_FAIL=1
+  export MOCK_APT_FAIL=1
   run remove_ubuntu
   [ "$status" -eq 0 ]
   [[ "$output" == *"wasn't removed"* ]]
 }
 
 @test "remove_ubuntu: prints manual command hint on failure" {
-  MOCK_APT_FAIL=1
+  export MOCK_APT_FAIL=1
   run remove_ubuntu
   [[ "$output" == *"apt remove"* ]]
 }
@@ -101,21 +135,21 @@ setup() {
 # ---------------------------------------------------------------------------
 
 @test "remove_redhat: succeeds when yum remove succeeds (CentOS 7)" {
-  MOCK_YUM_FAIL=0
+  export MOCK_YUM_FAIL=0
   run remove_redhat
   [ "$status" -eq 0 ]
   [[ "$output" == *"success"* ]]
 }
 
 @test "remove_redhat: prints warning but does not exit on yum failure" {
-  MOCK_YUM_FAIL=1
+  export MOCK_YUM_FAIL=1
   run remove_redhat
   [ "$status" -eq 0 ]
   [[ "$output" == *"wasn't removed"* ]]
 }
 
 @test "remove_redhat: prints manual command hint on failure" {
-  MOCK_YUM_FAIL=1
+  export MOCK_YUM_FAIL=1
   run remove_redhat
   [[ "$output" == *"yum install"* ]]
 }

--- a/tests/unit/test_MiscAction.bats
+++ b/tests/unit/test_MiscAction.bats
@@ -529,6 +529,49 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# check_parallel_version
+# ---------------------------------------------------------------------------
+
+@test "check_parallel_version: warns when parallel version is 20160222" {
+  export MOCK_PARALLEL_VERSION="20160222"
+  run check_parallel_version
+  unset MOCK_PARALLEL_VERSION
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARNING"* ]]
+  [[ "$output" == *"20160222"* ]]
+}
+
+@test "check_parallel_version: warns when parallel version is older than 20160222" {
+  export MOCK_PARALLEL_VERSION="20140722"
+  run check_parallel_version
+  unset MOCK_PARALLEL_VERSION
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARNING"* ]]
+}
+
+@test "check_parallel_version: does not warn when parallel version is newer than 20160222" {
+  export MOCK_PARALLEL_VERSION="20200722"
+  run check_parallel_version
+  unset MOCK_PARALLEL_VERSION
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"WARNING"* ]]
+}
+
+@test "check_parallel_version: does not fail when parallel is not installed" {
+  run bash -c "PATH=/nonexistent_bin_dir check_parallel_version 2>/dev/null; echo ok"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok"* ]]
+}
+
+@test "validate_config: calls check_parallel_version (warn present with old parallel)" {
+  export MOCK_PARALLEL_VERSION="20160222"
+  run validate_config
+  unset MOCK_PARALLEL_VERSION
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARNING"* ]]
+}
+
+# ---------------------------------------------------------------------------
 # checkpid
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Two root causes addressed:

1. installScript/depDownload.sh: RHEL7 systems were only using EPEL, which ships the buggy GNU Parallel 20160222. The installer now adds Ole Tange's CentOS 7 repository (same fix already applied to RHEL6) so a non-buggy version of parallel is installed on RHEL7 as well. The version detection is changed from the fragile `grep 6` pattern to `grep -E "release 6"` / `grep -E "release 7"` for clarity. OLE_TANGE_RHEL7 repo URL is added to vars.sh.

2. project/lib/bash/MiscAction.sh: adds check_parallel_version(), called from validate_config(), which detects parallel <= 20160222 at startup and emits a WARNING with upgrade instructions so existing deployments get actionable guidance even before re-running the installer.

Also fixes pre-existing test issues in test_depDownload.bats where MOCK_* variables were not exported, making mock subprocesses ignore them.

https://claude.ai/code/session_01WPWe2NNNaqax5fSJ9g62kk