### PR TITLE
Add domain backup and restore to fix clean-installation restore (issu…

### DIFF
--- a/project/lib/bash/BackupAction.sh
+++ b/project/lib/bash/BackupAction.sh
@@ -54,6 +54,27 @@ function __backupLdap(){
 }
 
 ################################################################################
+# __backupDomain: Backup a Zimbra domain LDAP entry
+# Options:
+#    $1 - The domain name (e.g., example.com)
+#    $2 - The LDAP object filter (DOMOBJECT)
+################################################################################
+function __backupDomain(){
+  SDATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
+  domain_backup "$1" "$2"
+  if [ "$ERRCODE" -eq 0 ]; then
+    if [[ $SESSION_TYPE == 'TXT' ]]; then
+      echo "$SESSION":"$1":"$(date +%m/%d/%y)" >> "$TEMPSESSION"
+    elif [[ $SESSION_TYPE == "SQLITE3" ]]; then
+      EDATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
+      SIZE=$(du -ch "$TEMPDIR"/"$1"* | grep total | cut -f1)
+      echo "insert into backup_account (email,sessionID,account_size, initial_date, \
+            conclusion_date) values ('$1','$SESSION','$SIZE','$SDATE','$EDATE');"  >> "$TEMPSQL"
+    fi
+  fi
+}
+
+################################################################################
 # __backupMailbox: All the functions used by mailbox backup
 # Options:
 #    $1 - The list of accounts to be backed up
@@ -123,6 +144,8 @@ function backup_main()
       parallel --jobs "$MAX_PARALLEL_PROCESS" "__backupFullInc '{}' '$1'" < "$TEMPACCOUNT"
     elif [[ "$SESSION" == "mbox"* ]]; then
       parallel --jobs "$MAX_PARALLEL_PROCESS" "__backupMailbox '{}' '$1'" < "$TEMPACCOUNT"
+    elif [[ "$SESSION" == "domain"* ]]; then
+      parallel --jobs "$MAX_PARALLEL_PROCESS" "__backupDomain '{}' '$1'" < "$TEMPACCOUNT"
     else
       parallel --jobs "$MAX_PARALLEL_PROCESS" "__backupLdap '{}' '$1'" < "$TEMPACCOUNT"
     fi

--- a/project/lib/bash/HelpAction.sh
+++ b/project/lib/bash/HelpAction.sh
@@ -7,9 +7,9 @@
 # show_help: It will show a quick help about each command from zmbackup
 ################################################################################
 function show_help (){
-  printf "usage: zmbackup -f [-m,-dl,-al,-ldp] [-d,-a] <mail/domain>"
+  printf "usage: zmbackup -f [-m,-dl,-al,-ldp,-dom] [-d,-a] <mail/domain>"
   printf "\n       zmbackup -i <mail>"
-  printf "\n       zmbackup -r [-m,-dl,-al,-ldp] [-d,-a] <session> <mail>"
+  printf "\n       zmbackup -r [-m,-dl,-al,-ldp,-dom] [-d,-a] <session> <mail>"
   printf "\n       zmbackup -r [-ro] <session> <mail_origin> <mail_destination>"
   printf "\n       zmbackup -d <session>"
   printf "\n       zmbackup -mg"
@@ -36,6 +36,7 @@ function show_help (){
   printf "\n -al,  --alias                    : Execute a backup of an alias instead of an account."
   printf "\n -ldp, --ldap                     : Execute a backup of an account, but only the ldap entry."
   printf "\n -sig, --signature                : Execute a backup of a signature."
+  printf "\n -dom, --domain-backup            : Execute a backup of all Zimbra domain configurations."
   printf "\n -d,   --domain                   : Execute a backup of only a set of domains, comma separated"
   printf "\n -a,   --account                  : Execute a backup of only a set of accounts, comma separated"
 
@@ -49,8 +50,9 @@ function show_help (){
   printf "\n -ldp, --ldap                     : Execute a restore of an account, but only the ldap entry."
   printf "\n -ro,  --restoreOnAccount         : Execute a restore of an account inside another account."
   printf "\n -sig, --signature                : Execute a restore of a signature."
-  printf "\n -d,   --domain                   : Execute a backup of only a set of domains, comma separated"
-  printf "\n -a,   --account                  : Execute a backup of only a set of accounts, comma separated"
+  printf "\n -dom, --domain-backup            : Execute a restore of domain configurations. Run before restoring accounts on a clean installation."
+  printf "\n -d,   --domain                   : Execute a restore of only a set of domains, comma separated"
+  printf "\n -a,   --account                  : Execute a restore of only a set of accounts, comma separated"
 
   printf "\n\n\n"
 }

--- a/project/lib/bash/MiscAction.sh
+++ b/project/lib/bash/MiscAction.sh
@@ -102,12 +102,14 @@ function constant(){
   declare -gxr DLOBJECT="(objectclass=zimbraDistributionList)"
   declare -gxr ALOBJECT="(objectclass=zimbraAlias)"
   declare -gxr SIOBJECT="(objectclass=zimbraSignature)"
+  declare -gxr DOMOBJECT="(objectclass=zimbraDomain)"
 
   # LDAP FILTER
   declare -gxr DLFILTER="mail"
   declare -gxr ACFILTER="zimbraMailDeliveryAddress"
   declare -gxr ALFILTER="uid"
   declare -gxr SIFILTER="zimbraSignatureName"
+  declare -gxr DOMFILTER="zimbraDomainName"
 
   # PID FILE
   declare -gxr PID='/opt/zimbra/log/zmbackup.pid'
@@ -145,6 +147,9 @@ function sessionvars(){
   elif [[ $1 == '--signature' || $1 == '-sig' ]]; then
     STYPE="Signature"
     SESSION="signature-"$(date  +%Y%m%d%H%M%S)
+  elif [[ $1 == '-dom' || $1 == '--domain-backup' ]]; then
+    STYPE="Domain"
+    SESSION="domain-"$(date  +%Y%m%d%H%M%S)
   fi
   export SESSION STYPE INC
 }
@@ -300,11 +305,14 @@ function export_function(){
   export -f __backupMailbox
   export -f __backupFullInc
   export -f __backupLdap
+  export -f __backupDomain
   export -f ldap_backup
   export -f ldap_restore
   export -f mailbox_backup
   export -f ldap_filter
   export -f mailbox_restore
+  export -f domain_backup
+  export -f domain_restore
 }
 
 ################################################################################

--- a/project/lib/bash/ParallelAction.sh
+++ b/project/lib/bash/ParallelAction.sh
@@ -128,6 +128,60 @@ function mailbox_restore()
 
 
 ###############################################################################
+# domain_backup: Backup a Zimbra domain LDAP entry.
+# Options:
+# $1 - The domain name (e.g., example.com);
+# $2 - The LDAP object filter for domains (DOMOBJECT).
+###############################################################################
+function domain_backup()
+{
+  DC=",dc="
+  DOMAIN_DN="dc=${1//./$DC}"
+  TEMP_CLI_OUTPUT=$(mktemp)
+  if ldapsearch -Z -x -H "$LDAPSERVER" -D "$LDAPADMIN" -w "$LDAPPASS" \
+             -b "$DOMAIN_DN" -s base -LLL "$2" > "$TEMPDIR"/"$1".ldiff 2> "$TEMP_CLI_OUTPUT"; then
+    zmlog local7.info "Zmbackup: LDAP - Domain backup for $1 finished."
+    export ERRCODE=0
+  else
+    zmlog local7.err "Zmbackup: LDAP - Domain backup for $1 failed. Error message below:"
+    zmlog local7.err < "$TEMP_CLI_OUTPUT"
+    export ERRCODE=1
+  fi
+  rm -rf "${TEMP_CLI_OUTPUT:?}"
+}
+
+
+###############################################################################
+# domain_restore: Restore a Zimbra domain LDAP entry.
+# Options:
+# $1 - The session name to be restored;
+# $2 - The domain name (e.g., example.com).
+###############################################################################
+function domain_restore()
+{
+  local LDAP_DN
+  LDAP_DN=$(grep -m 1 "^dn:" "$WORKDIR"/"$1"/"$2".ldiff | awk '{print $2}')
+  if [[ -z "$LDAP_DN" ]]; then
+    printf "\nError: Could not extract DN from %s/%s/%s.ldiff - skipping domain restore for %s" \
+      "$WORKDIR" "$1" "$2" "$2"
+    return 1
+  fi
+  ERR=$( (ldapadd -Z -x -H "$LDAPSERVER" -D "$LDAPADMIN" \
+           -c -w "$LDAPPASS" -f "$WORKDIR"/"$1"/"$2".ldiff) 2>&1)
+  BASHERRCODE=$?
+  if ! [[ $BASHERRCODE -eq 0 ]]; then
+    if echo "$ERR" | grep -q "Already exists"; then
+      zmlog local7.info "Zmbackup: Domain $2 already exists - skipping."
+      return 0
+    fi
+    printf "\nError during the restore process for domain %s. Error message below:" "$2"
+    printf "\n%s: %s" "$2" "$ERR"
+  fi
+  return $BASHERRCODE
+}
+
+
+###############################################################################
 # ldap_filter: Filter the account to see if you should do backup or not for that
 #              account.
 # Options:

--- a/project/lib/bash/RestoreAction.sh
+++ b/project/lib/bash/RestoreAction.sh
@@ -53,6 +53,46 @@ function restore_main_mailbox()
 }
 
 ################################################################################
+# restore_main_domain: Manage the restore action for Zimbra domain LDAP entries.
+# Run this before restore_main_ldap when restoring to a clean installation so
+# that the domain parent DN exists before account entries are added.
+# Options:
+#    $1 - The session to be restored
+#    $2 - Comma-separated list of domains to restore, or empty for all domains
+#         in the session
+################################################################################
+function restore_main_domain()
+{
+  if [[ $SESSION_TYPE == 'TXT' ]]; then
+    SESSION=$(grep -E ": $1 started" "$WORKDIR"/sessions.txt | grep 'started' | \
+                  awk '{print $2}' | sort | uniq)
+  elif [[ $SESSION_TYPE == "SQLITE3" ]]; then
+    SESSION=$(sqlite3 "$WORKDIR"/sessions.sqlite3 "select * from backup_session where sessionID='$1'")
+  fi
+  if [ -n "$SESSION" ]; then
+    echo "Restore Domain LDAP process with session $1 started at $(date)"
+    if [[ -n "$2" ]]; then
+      for i in $(echo "$2" | tr ',' ' '); do
+        echo "$i" >> "$TEMPACCOUNT"
+      done
+    else
+      build_listRST "$1" ""
+    fi
+    parallel --jobs "$MAX_PARALLEL_PROCESS" "domain_restore '$1' '{}'" < "$TEMPACCOUNT"
+    BASHERRCODE=$?
+    if [[ $BASHERRCODE -eq 0 ]]; then
+      echo "Restore Domain LDAP process with session $1 completed at $(date)"
+    else
+      echo "Restore Domain LDAP process with session $1 completed with errors at $(date)"
+    fi
+    return $BASHERRCODE
+  else
+    echo "Nothing to do. Closing..."
+    return 0
+  fi
+}
+
+################################################################################
 # restore_main_ldap: Manage the restore action for one or all ldap accounts
 # Options:
 #    $1 - The session to be restored

--- a/project/zmbackup
+++ b/project/zmbackup
@@ -100,6 +100,12 @@ case "$1" in
         backup_main "$SIOBJECT" "$SIFILTER" "$3" "$4"
         rm -rf "$PID"
       ;;
+      "-dom"|"--domain-backup" )
+        sessionvars "$2"
+        create_temp
+        backup_main "$DOMOBJECT" "$DOMFILTER"
+        rm -rf "$PID"
+      ;;
       * )
         sessionvars "$1"
         create_temp
@@ -133,6 +139,11 @@ case "$1" in
             ERRCODE=$?
           ;;
         esac
+        rm -rf "$PID"
+      ;;
+      "-dom"|"--domain-backup" )
+        restore_main_domain "$3" "$4"
+        ERRCODE=$?
         rm -rf "$PID"
       ;;
       "-m"|"--mail" )

--- a/tests/mocks/ldapadd
+++ b/tests/mocks/ldapadd
@@ -1,5 +1,9 @@
 #!/bin/bash
 # ldapadd mock
+if [ "${MOCK_LDAPADD_EXISTS:-0}" = "1" ]; then
+  echo "ldap_add: Already exists (68)" >&2
+  exit 68
+fi
 if [ "${MOCK_LDAPADD_FAIL:-0}" = "1" ]; then
   echo "ldap_error: invalid syntax" >&2
   exit 1

--- a/tests/unit/test_BackupAction.bats
+++ b/tests/unit/test_BackupAction.bats
@@ -14,8 +14,10 @@ setup() {
 
   ACOBJECT="(objectclass=zimbraAccount)"
   ACFILTER="zimbraMailDeliveryAddress"
+  DOMOBJECT="(objectclass=zimbraDomain)"
+  DOMFILTER="zimbraDomainName"
   PID="$(mktemp)"
-  export ACOBJECT ACFILTER PID
+  export ACOBJECT ACFILTER DOMOBJECT DOMFILTER PID
 
   # Pre-declare SESSION and INC for export so parallel workers inherit them when tests set them
   export SESSION INC
@@ -25,7 +27,7 @@ setup() {
   export MOCK_ZMMAILBOX_EMPTY=0
 
   # Export functions required by the parallel mock subprocess
-  export -f __backupFullInc __backupLdap __backupMailbox ldap_backup mailbox_backup
+  export -f __backupFullInc __backupLdap __backupMailbox __backupDomain ldap_backup mailbox_backup domain_backup
 
   # Suppress blockedlist lookup in ldap_filter
   grep() {
@@ -112,6 +114,35 @@ teardown() {
   MOCK_LDAPSEARCH_FAIL=1
   __backupLdap "alias@example.com" "(objectclass=zimbraAlias)"
   run grep -q "alias@example.com" "$TEMPSESSION"
+  [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# __backupDomain
+# ---------------------------------------------------------------------------
+
+@test "__backupDomain: writes TXT record on success" {
+  SESSION="domain-20240101120000"
+  SESSION_TYPE="TXT"
+  MOCK_LDAPSEARCH_FAIL=0
+  __backupDomain "example.com" "(objectclass=zimbraDomain)"
+  grep -q "example.com" "$TEMPSESSION"
+}
+
+@test "__backupDomain: writes SQLITE3 record on success" {
+  SESSION="domain-20240101120000"
+  SESSION_TYPE="SQLITE3"
+  MOCK_LDAPSEARCH_FAIL=0
+  __backupDomain "example.com" "(objectclass=zimbraDomain)"
+  grep -q "insert into backup_account" "$TEMPSQL"
+}
+
+@test "__backupDomain: does not write record when domain_backup fails" {
+  SESSION="domain-20240101120000"
+  SESSION_TYPE="TXT"
+  MOCK_LDAPSEARCH_FAIL=1
+  __backupDomain "example.com" "(objectclass=zimbraDomain)"
+  run grep -q "example.com" "$TEMPSESSION"
   [ "$status" -ne 0 ]
 }
 
@@ -236,6 +267,15 @@ teardown() {
   MOCK_ZMMAILBOX_FAIL=0
   MOCK_ZMMAILBOX_EMPTY=0
   backup_main "$ACOBJECT" "$ACFILTER" "-a" "user@example.com"
+  grep -q "SESSION" "$TEMPSESSION"
+}
+
+@test "backup_main: uses __backupDomain for domain sessions" {
+  SESSION="domain-20240101120000"
+  STYPE="Domain"
+  SESSION_TYPE="TXT"
+  MOCK_LDAPSEARCH_FAIL=0
+  backup_main "$DOMOBJECT" "$DOMFILTER" "-a" "example.com"
   grep -q "SESSION" "$TEMPSESSION"
 }
 

--- a/tests/unit/test_HelpAction.bats
+++ b/tests/unit/test_HelpAction.bats
@@ -97,6 +97,12 @@ setup() {
   [[ "$output" == *"--account"* ]]
 }
 
+@test "show_help: lists -dom / --domain-backup option" {
+  run show_help
+  [[ "$output" == *"-dom"* ]]
+  [[ "$output" == *"--domain-backup"* ]]
+}
+
 @test "show_help: lists Full Backup Options section" {
   run show_help
   [[ "$output" == *"Full Backup Options"* ]]

--- a/tests/unit/test_MiscAction.bats
+++ b/tests/unit/test_MiscAction.bats
@@ -238,6 +238,13 @@ teardown() {
   [ "$ACFILTER" = "zimbraMailDeliveryAddress" ]
   [ "$ALFILTER" = "uid" ]
   [ "$SIFILTER" = "zimbraSignatureName" ]
+  [ "$DOMFILTER" = "zimbraDomainName" ]
+}
+
+@test "constant: sets DOMOBJECT for domain entries" {
+  BACKUP_INACTIVE_ACCOUNTS="true"; SSL_ENABLE="false"
+  constant
+  [[ "$DOMOBJECT" == *"zimbraDomain"* ]]
 }
 
 @test "constant: sets PID path" {
@@ -252,10 +259,12 @@ teardown() {
   [[ "$(declare -p DLOBJECT)"  == *"-r"* ]]
   [[ "$(declare -p ALOBJECT)"  == *"-r"* ]]
   [[ "$(declare -p SIOBJECT)"  == *"-r"* ]]
+  [[ "$(declare -p DOMOBJECT)" == *"-r"* ]]
   [[ "$(declare -p DLFILTER)"  == *"-r"* ]]
   [[ "$(declare -p ACFILTER)"  == *"-r"* ]]
   [[ "$(declare -p ALFILTER)"  == *"-r"* ]]
   [[ "$(declare -p SIFILTER)"  == *"-r"* ]]
+  [[ "$(declare -p DOMFILTER)" == *"-r"* ]]
   [[ "$(declare -p PID)"       == *"-r"* ]]
   [[ "$(declare -p ACOBJECT)"  == *"-r"* ]]
   [[ "$(declare -p WEBPROTO)"  == *"-r"* ]]
@@ -372,6 +381,19 @@ teardown() {
   mkdir -p "${WORKDIR}/full-20240101120000"
   sessionvars "-sig"
   [[ "$SESSION" == "signature-"* ]]
+}
+
+@test "sessionvars: --domain-backup creates domain- session" {
+  mkdir -p "${WORKDIR}/full-20240101120000"
+  sessionvars "--domain-backup"
+  [[ "$SESSION" == "domain-"* ]]
+  [ "$STYPE" = "Domain" ]
+}
+
+@test "sessionvars: -dom creates domain- session" {
+  mkdir -p "${WORKDIR}/full-20240101120000"
+  sessionvars "-dom"
+  [[ "$SESSION" == "domain-"* ]]
 }
 
 @test "sessionvars: SESSION STYPE INC are exported" {
@@ -647,6 +669,30 @@ teardown() {
   source "${LIB_DIR}/ParallelAction.sh"
   export_function
   run bash -c 'declare -F ldap_backup'
+  [ "$status" -eq 0 ]
+}
+
+@test "export_function: exports domain_backup" {
+  source "${LIB_DIR}/BackupAction.sh"
+  source "${LIB_DIR}/ParallelAction.sh"
+  export_function
+  run bash -c 'declare -F domain_backup'
+  [ "$status" -eq 0 ]
+}
+
+@test "export_function: exports domain_restore" {
+  source "${LIB_DIR}/BackupAction.sh"
+  source "${LIB_DIR}/ParallelAction.sh"
+  export_function
+  run bash -c 'declare -F domain_restore'
+  [ "$status" -eq 0 ]
+}
+
+@test "export_function: exports __backupDomain" {
+  source "${LIB_DIR}/BackupAction.sh"
+  source "${LIB_DIR}/ParallelAction.sh"
+  export_function
+  run bash -c 'declare -F __backupDomain'
   [ "$status" -eq 0 ]
 }
 

--- a/tests/unit/test_ParallelAction.bats
+++ b/tests/unit/test_ParallelAction.bats
@@ -15,6 +15,7 @@ setup() {
   export MOCK_ZMMAILBOX_EMPTY=0
   export MOCK_ZMMAILBOX_204=0
   export MOCK_LDAPADD_FAIL=0
+  export MOCK_LDAPADD_EXISTS=0
   export MOCK_LDAPDELETE_FAIL=0
 
   # Create a blockedlist in a place ldap_filter can find it
@@ -192,6 +193,70 @@ teardown() {
   run mailbox_restore "$session" "user@example.com"
   [ "$status" -eq 0 ]
   [[ "$output" == *"skipping"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# domain_backup
+# ---------------------------------------------------------------------------
+
+@test "domain_backup: success sets ERRCODE=0" {
+  MOCK_LDAPSEARCH_FAIL=0
+  domain_backup "example.com" "(objectclass=zimbraDomain)"
+  [ "$ERRCODE" -eq 0 ]
+}
+
+@test "domain_backup: success creates ldiff file named after domain" {
+  MOCK_LDAPSEARCH_FAIL=0
+  domain_backup "example.com" "(objectclass=zimbraDomain)"
+  [ -f "${TEMPDIR}/example.com.ldiff" ]
+}
+
+@test "domain_backup: failure sets ERRCODE=1" {
+  MOCK_LDAPSEARCH_FAIL=1 domain_backup "example.com" "(objectclass=zimbraDomain)"
+  [ "$ERRCODE" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# domain_restore
+# ---------------------------------------------------------------------------
+
+@test "domain_restore: success returns 0" {
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: dc=example,dc=com\nobjectClass: dcObject\nobjectClass: zimbraDomain\n" \
+    > "${WORKDIR}/${session}/example.com.ldiff"
+  MOCK_LDAPADD_FAIL=0
+  run domain_restore "$session" "example.com"
+  [ "$status" -eq 0 ]
+}
+
+@test "domain_restore: returns 1 when ldiff has no DN line" {
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  echo "objectClass: dcObject" > "${WORKDIR}/${session}/example.com.ldiff"
+  run domain_restore "$session" "example.com"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Could not extract DN"* ]]
+}
+
+@test "domain_restore: returns 0 when domain already exists in LDAP" {
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: dc=example,dc=com\nobjectClass: dcObject\nobjectClass: zimbraDomain\n" \
+    > "${WORKDIR}/${session}/example.com.ldiff"
+  MOCK_LDAPADD_EXISTS=1
+  run domain_restore "$session" "example.com"
+  [ "$status" -eq 0 ]
+}
+
+@test "domain_restore: returns non-zero when ldapadd fails with unexpected error" {
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: dc=example,dc=com\nobjectClass: dcObject\nobjectClass: zimbraDomain\n" \
+    > "${WORKDIR}/${session}/example.com.ldiff"
+  MOCK_LDAPADD_FAIL=1
+  run domain_restore "$session" "example.com"
+  [ "$status" -ne 0 ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_RestoreAction.bats
+++ b/tests/unit/test_RestoreAction.bats
@@ -21,7 +21,8 @@ setup() {
   export MOCK_LDAPDELETE_FAIL=0
 
   # Export functions required by the parallel mock subprocess
-  export -f mailbox_restore ldap_restore
+  export -f mailbox_restore ldap_restore domain_restore
+  export MOCK_LDAPADD_EXISTS=0
 }
 
 teardown() {
@@ -147,6 +148,83 @@ EOF
   sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
   run restore_main_ldap "nonexistent-session" ""
   [[ "$output" == *"Nothing to do"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# restore_main_domain
+# ---------------------------------------------------------------------------
+
+@test "restore_main_domain: prints nothing-to-do when session not in TXT" {
+  SESSION_TYPE="TXT"
+  run restore_main_domain "nonexistent-session" ""
+  [[ "$output" == *"Nothing to do"* ]]
+}
+
+@test "restore_main_domain: restores all domains when session exists in TXT" {
+  SESSION_TYPE="TXT"
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: dc=example,dc=com\nobjectClass: dcObject\nobjectClass: zimbraDomain\n" \
+    > "${WORKDIR}/${session}/example.com.ldiff"
+  cat >> "${WORKDIR}/sessions.txt" << EOF
+SESSION: ${session} started on Mon Jan 01
+${session}:example.com:01/01/24
+EOF
+  MOCK_LDAPADD_FAIL=0
+  run restore_main_domain "$session" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"started"* ]]
+}
+
+@test "restore_main_domain: restores specific domain when provided" {
+  SESSION_TYPE="TXT"
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: dc=example,dc=com\nobjectClass: dcObject\nobjectClass: zimbraDomain\n" \
+    > "${WORKDIR}/${session}/example.com.ldiff"
+  cat >> "${WORKDIR}/sessions.txt" << EOF
+SESSION: ${session} started on Mon Jan 01
+${session}:example.com:01/01/24
+EOF
+  MOCK_LDAPADD_FAIL=0
+  run restore_main_domain "$session" "example.com"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"started"* ]]
+}
+
+@test "restore_main_domain: restores when session exists in SQLITE3" {
+  SESSION_TYPE="SQLITE3"
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: dc=example,dc=com\nobjectClass: dcObject\nobjectClass: zimbraDomain\n" \
+    > "${WORKDIR}/${session}/example.com.ldiff"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "insert into backup_session values('${session}','2024-01-01T12:00:00.000',
+     '2024-01-01T12:30:00.000','1M','Domain','FINISHED')"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "insert into backup_account(email,sessionID,account_size,initial_date,conclusion_date)
+     values('example.com','${session}','1M','2024-01-01T12:00:00.000','2024-01-01T12:30:00.000')"
+  MOCK_LDAPADD_FAIL=0
+  run restore_main_domain "$session" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"started"* ]]
+}
+
+@test "restore_main_domain: returns non-zero when ldapadd fails" {
+  SESSION_TYPE="TXT"
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: dc=example,dc=com\nobjectClass: dcObject\nobjectClass: zimbraDomain\n" \
+    > "${WORKDIR}/${session}/example.com.ldiff"
+  cat >> "${WORKDIR}/sessions.txt" << EOF
+SESSION: ${session} started on Mon Jan 01
+${session}:example.com:01/01/24
+EOF
+  MOCK_LDAPADD_FAIL=1
+  run restore_main_domain "$session" ""
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"errors"* ]]
 }
 
 @test "restore_main_ldap: runs restore for found SQLITE3 session" {


### PR DESCRIPTION
…e #181)

When restoring to a new Zimbra installation, account LDAP entries fail with 'No such object (32)' because the domain parent DN does not exist. This adds domain-level backup and restore so the domain can be created first, unblocking account restore on a clean server.

New commands:
  zmbackup -f -dom              backup all Zimbra domain configs
  zmbackup -r -dom <session>    restore domain configs from session

New internals:
  domain_backup()      ldapsearch with -s base against the domain DN
  domain_restore()     ldapadd that gracefully skips 'Already exists'
  __backupDomain()     parallel-safe wrapper recording session metadata
  restore_main_domain() orchestrates domain restore with TXT/SQLITE3 support

DOMOBJECT / DOMFILTER constants added to constant(); sessionvars() recognises -dom / --domain-backup; export_function() exports all new functions for GNU Parallel subprocesses.

https://claude.ai/code/session_013TTQHxRcF3megCXoxUianY