### PR TITLE
Fix error handling: track restore failures and report counts (issue #192)

### DIFF
--- a/project/lib/bash/ParallelAction.sh
+++ b/project/lib/bash/ParallelAction.sh
@@ -88,6 +88,7 @@ function ldap_restore()
   if [[ -z "$LDAP_DN" ]]; then
     printf "\nError: Could not extract DN from %s/%s/%s.ldiff - skipping LDAP restore for account %s" \
       "$WORKDIR" "$1" "$2" "$2"
+    [[ -n "${LDAP_FAILFILE:-}" ]] && echo "$2" >> "$LDAP_FAILFILE"
     return 1
   fi
   ldapdelete -Z -r -x -H "$LDAPSERVER" -D "$LDAPADMIN" -c -w "$LDAPPASS" \
@@ -98,6 +99,7 @@ function ldap_restore()
   if ! [[ $BASHERRCODE -eq 0 ]]; then
     printf "\nError during the restore process for account %s. Error message below:" "$2"
     printf "\n%s: %s" "$2" "$ERR"
+    [[ -n "${LDAP_FAILFILE:-}" ]] && echo "$2" >> "$LDAP_FAILFILE"
   fi
   return $BASHERRCODE
 }
@@ -121,6 +123,7 @@ function mailbox_restore()
     printf "Error during the restore process for account %s. Error message below:" "$2"
     printf "\n%s: " "$2"
     cat "$TEMP_CLI_OUTPUT"
+    [[ -n "${MAIL_FAILFILE:-}" ]] && echo "$2" >> "$MAIL_FAILFILE"
   fi
   rm -rf "${TEMP_CLI_OUTPUT:?}"
   return $BASHERRCODE

--- a/project/lib/bash/RestoreAction.sh
+++ b/project/lib/bash/RestoreAction.sh
@@ -20,29 +20,46 @@ function restore_main_mailbox()
   fi
   if [ -n "$SESSION" ]; then
     printf "Restore mail process with session %s started at %s" "$1" "$(date)"
+    TOTAL_COUNT=0
+    FAIL_COUNT=0
+    SUCCESS_COUNT=0
+    BASHERRCODE=0
     if [[ -n $3 && $2 == *"@"* ]]; then
+      TOTAL_COUNT=1
       TEMP_CLI_OUTPUT=$(mktemp)
       if $ZMMAILBOX -t0 -z -m "$3" postRestURL '//?fmt=tgz&resolve=skip' "$WORKDIR"/"$1"/"$2".tgz > "$TEMP_CLI_OUTPUT" 2>&1; then
         BASHERRCODE=0
+        SUCCESS_COUNT=1
         if grep -q "No such file or directory" "$TEMP_CLI_OUTPUT"; then
           printf "Account %s has nothing to restore - skipping..." "$2"
         fi
       else
         BASHERRCODE=$?
+        FAIL_COUNT=1
         printf "Error during the restore process for account %s. Error message below:" "$2"
         printf "\n%s: " "$2"
         cat "$TEMP_CLI_OUTPUT"
       fi
       rm -rf "${TEMP_CLI_OUTPUT:?}"
     else
+      MAIL_FAILFILE=$(mktemp)
+      export MAIL_FAILFILE
       build_listRST "$1" "$2"
+      TOTAL_COUNT=$(wc -l < "$TEMPACCOUNT")
       parallel --jobs "$MAX_PARALLEL_PROCESS" "mailbox_restore '$1' '{}'" < "$TEMPACCOUNT"
       BASHERRCODE=$?
+      FAIL_COUNT=$(wc -l < "$MAIL_FAILFILE")
+      [[ $FAIL_COUNT -gt 0 ]] && BASHERRCODE=1
+      SUCCESS_COUNT=$((TOTAL_COUNT - FAIL_COUNT))
+      rm -f "$MAIL_FAILFILE"
+      unset MAIL_FAILFILE
     fi
     if [[ $BASHERRCODE -eq 0 ]]; then
-      printf "\nRestore mail process with session %s completed at %s\n" "$1" "$(date)"
+      printf "\nRestore mail process with session %s completed at %s (%d/%d accounts restored)\n" \
+        "$1" "$(date)" "$SUCCESS_COUNT" "$TOTAL_COUNT"
     else
-      printf "\nRestore mail process with session %s completed with errors at %s\n" "$1" "$(date)"
+      printf "\nRestore mail process with session %s completed with errors at %s (%d/%d accounts restored, %d failed)\n" \
+        "$1" "$(date)" "$SUCCESS_COUNT" "$TOTAL_COUNT" "$FAIL_COUNT"
     fi
     return $BASHERRCODE
   else
@@ -68,13 +85,21 @@ function restore_main_ldap()
   fi
   if [ -n "$SESSION" ]; then
     echo "Restore LDAP process with session $1 started at $(date)"
+    LDAP_FAILFILE=$(mktemp)
+    export LDAP_FAILFILE
     build_listRST "$1" "$2"
+    TOTAL_COUNT=$(wc -l < "$TEMPACCOUNT")
     parallel --jobs "$MAX_PARALLEL_PROCESS" "ldap_restore '$1' '{}'" < "$TEMPACCOUNT"
     BASHERRCODE=$?
+    FAIL_COUNT=$(wc -l < "$LDAP_FAILFILE")
+    [[ $FAIL_COUNT -gt 0 ]] && BASHERRCODE=1
+    SUCCESS_COUNT=$((TOTAL_COUNT - FAIL_COUNT))
+    rm -f "$LDAP_FAILFILE"
+    unset LDAP_FAILFILE
     if [[ $BASHERRCODE -eq 0 ]]; then
-      echo "Restore LDAP process with session $1 completed at $(date)"
+      echo "Restore LDAP process with session $1 completed at $(date) ($SUCCESS_COUNT/$TOTAL_COUNT accounts restored)"
     else
-      echo "Restore LDAP process with session $1 completed with errors at $(date)"
+      echo "Restore LDAP process with session $1 completed with errors at $(date) ($SUCCESS_COUNT/$TOTAL_COUNT accounts restored, $FAIL_COUNT failed)"
     fi
     return $BASHERRCODE
   else

--- a/tests/unit/test_ParallelAction.bats
+++ b/tests/unit/test_ParallelAction.bats
@@ -194,6 +194,68 @@ teardown() {
   [[ "$output" == *"skipping"* ]]
 }
 
+@test "mailbox_restore: writes account to MAIL_FAILFILE on failure" {
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  touch "${WORKDIR}/${session}/user@example.com.tgz"
+  MAIL_FAILFILE=$(mktemp)
+  export MAIL_FAILFILE
+  MOCK_ZMMAILBOX_FAIL=1
+  run mailbox_restore "$session" "user@example.com"
+  grep -qx "user@example.com" "$MAIL_FAILFILE"
+  rm -f "$MAIL_FAILFILE"
+}
+
+@test "mailbox_restore: does not write to MAIL_FAILFILE on success" {
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  touch "${WORKDIR}/${session}/user@example.com.tgz"
+  MAIL_FAILFILE=$(mktemp)
+  export MAIL_FAILFILE
+  MOCK_ZMMAILBOX_FAIL=0
+  mailbox_restore "$session" "user@example.com"
+  [ ! -s "$MAIL_FAILFILE" ]
+  rm -f "$MAIL_FAILFILE"
+}
+
+@test "ldap_restore: writes account to LDAP_FAILFILE when ldapadd fails" {
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: uid=user@example.com,ou=people,dc=example,dc=com\nobjectClass: top\n" \
+    > "${WORKDIR}/${session}/user@example.com.ldiff"
+  LDAP_FAILFILE=$(mktemp)
+  export LDAP_FAILFILE
+  MOCK_LDAPADD_FAIL=1
+  run ldap_restore "$session" "user@example.com"
+  grep -qx "user@example.com" "$LDAP_FAILFILE"
+  rm -f "$LDAP_FAILFILE"
+}
+
+@test "ldap_restore: writes account to LDAP_FAILFILE when ldiff has no DN" {
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  echo "objectClass: top" > "${WORKDIR}/${session}/user@example.com.ldiff"
+  LDAP_FAILFILE=$(mktemp)
+  export LDAP_FAILFILE
+  run ldap_restore "$session" "user@example.com"
+  grep -qx "user@example.com" "$LDAP_FAILFILE"
+  rm -f "$LDAP_FAILFILE"
+}
+
+@test "ldap_restore: does not write to LDAP_FAILFILE on success" {
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: uid=user@example.com,ou=people,dc=example,dc=com\nobjectClass: top\n" \
+    > "${WORKDIR}/${session}/user@example.com.ldiff"
+  LDAP_FAILFILE=$(mktemp)
+  export LDAP_FAILFILE
+  MOCK_LDAPDELETE_FAIL=0
+  MOCK_LDAPADD_FAIL=0
+  ldap_restore "$session" "user@example.com"
+  [ ! -s "$LDAP_FAILFILE" ]
+  rm -f "$LDAP_FAILFILE"
+}
+
 # ---------------------------------------------------------------------------
 # ldap_filter
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_RestoreAction.bats
+++ b/tests/unit/test_RestoreAction.bats
@@ -54,6 +54,48 @@ EOF
   [[ "$output" == *"started"* ]]
 }
 
+@test "restore_main_mailbox: shows account count in completion message on success" {
+  SESSION_TYPE="TXT"
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  cat >> "${WORKDIR}/sessions.txt" << EOF
+SESSION: ${session} started on Mon Jan 01
+${session}:user@example.com:01/01/24
+EOF
+  MOCK_ZMMAILBOX_FAIL=0
+  run restore_main_mailbox "$session" "" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"1/1 accounts restored"* ]]
+}
+
+@test "restore_main_mailbox: returns non-zero when all accounts fail" {
+  SESSION_TYPE="TXT"
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  cat >> "${WORKDIR}/sessions.txt" << EOF
+SESSION: ${session} started on Mon Jan 01
+${session}:user@example.com:01/01/24
+EOF
+  MOCK_ZMMAILBOX_FAIL=1
+  run restore_main_mailbox "$session" "" ""
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"completed with errors"* ]]
+}
+
+@test "restore_main_mailbox: shows failure count in output when accounts fail" {
+  SESSION_TYPE="TXT"
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  cat >> "${WORKDIR}/sessions.txt" << EOF
+SESSION: ${session} started on Mon Jan 01
+${session}:user@example.com:01/01/24
+EOF
+  MOCK_ZMMAILBOX_FAIL=1
+  run restore_main_mailbox "$session" "" ""
+  [[ "$output" == *"0/1 accounts restored"* ]]
+  [[ "$output" == *"1 failed"* ]]
+}
+
 @test "restore_main_mailbox: restores when session exists in SQLITE3" {
   SESSION_TYPE="SQLITE3"
   local session="full-20240101120000"
@@ -134,6 +176,55 @@ EOF
   MOCK_LDAPADD_FAIL=0
   run restore_main_ldap "$session" ""
   [[ "$output" == *"started"* ]]
+}
+
+@test "restore_main_ldap: shows account count in completion message on success" {
+  SESSION_TYPE="TXT"
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: uid=user@example.com,ou=people,dc=example,dc=com\nobjectClass: top\n" \
+    > "${WORKDIR}/${session}/user@example.com.ldiff"
+  cat >> "${WORKDIR}/sessions.txt" << EOF
+SESSION: ${session} started on Mon Jan 01
+${session}:user@example.com:01/01/24
+EOF
+  MOCK_LDAPDELETE_FAIL=0
+  MOCK_LDAPADD_FAIL=0
+  run restore_main_ldap "$session" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"1/1 accounts restored"* ]]
+}
+
+@test "restore_main_ldap: returns non-zero when all ldap accounts fail" {
+  SESSION_TYPE="TXT"
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: uid=user@example.com,ou=people,dc=example,dc=com\nobjectClass: top\n" \
+    > "${WORKDIR}/${session}/user@example.com.ldiff"
+  cat >> "${WORKDIR}/sessions.txt" << EOF
+SESSION: ${session} started on Mon Jan 01
+${session}:user@example.com:01/01/24
+EOF
+  MOCK_LDAPADD_FAIL=1
+  run restore_main_ldap "$session" ""
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"completed with errors"* ]]
+}
+
+@test "restore_main_ldap: shows failure count in output when ldap accounts fail" {
+  SESSION_TYPE="TXT"
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: uid=user@example.com,ou=people,dc=example,dc=com\nobjectClass: top\n" \
+    > "${WORKDIR}/${session}/user@example.com.ldiff"
+  cat >> "${WORKDIR}/sessions.txt" << EOF
+SESSION: ${session} started on Mon Jan 01
+${session}:user@example.com:01/01/24
+EOF
+  MOCK_LDAPADD_FAIL=1
+  run restore_main_ldap "$session" ""
+  [[ "$output" == *"0/1 accounts restored"* ]]
+  [[ "$output" == *"1 failed"* ]]
 }
 
 @test "restore_main_ldap: prints nothing-to-do when session not found in TXT" {


### PR DESCRIPTION
## Summary

- The restore process previously reported "completed" and exited 0 even when all accounts failed, because it relied solely on GNU Parallel's exit code aggregation (which varies by version)
- Workers now append the failed account name to `MAIL_FAILFILE` / `LDAP_FAILFILE` (one line per failure) independently of parallel's exit code
- After parallel finishes, the orchestrator counts failures with `wc -l`, forces a non-zero exit when any account failed, and includes counts in the completion message: `"N/M accounts restored, F failed"`

Closes #192

## Test plan

- [x] Run `zmbackup -r <session>` against a session where all LDAP restores fail — confirm exit code is non-zero and output shows `"0/N accounts restored, N failed"`
- [x] Run `zmbackup -r <session>` against a healthy session — confirm exit code is 0 and output shows `"N/N accounts restored"`
- [x] Run unit tests: `npm test` (or `bats tests/unit/`) — all non-sqlite3 tests pass

https://claude.ai/code/session_01AaDq8hk9SWcLqhQbtYG8QQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaDq8hk9SWcLqhQbtYG8QQ)_