### PR TITLE
fix: make blockedlist path configurable via ZMBACKUP_BLOCKEDLIST

### DIFF
--- a/project/config/zmbackup.conf
+++ b/project/config/zmbackup.conf
@@ -107,3 +107,10 @@ SSL_ENABLE=true
 #              DEFAULT: /opt/zimbra/bin/zmmailbox
 
 ZMMAILBOX=/opt/zimbra/bin/zmmailbox
+
+# ZMBACKUP_BLOCKEDLIST - Path to the file containing accounts that should never
+#                        be backed up. Override this if zmbackup is installed to
+#                        a non-standard prefix or you want a custom location.
+#                        DEFAULT: /etc/zmbackup/blockedlist.conf
+
+ZMBACKUP_BLOCKEDLIST=/etc/zmbackup/blockedlist.conf

--- a/project/lib/bash/MiscAction.sh
+++ b/project/lib/bash/MiscAction.sh
@@ -84,6 +84,8 @@ function load_config(){
   local ldaprc="${ZIMBRA_LDAPRC:-/opt/zimbra/.ldaprc}"
   if [ -f "$conf" ]; then
     source "$conf" 2> /dev/null
+    ZMBACKUP_BLOCKEDLIST="${ZMBACKUP_BLOCKEDLIST:-/etc/zmbackup/blockedlist.conf}"
+    export ZMBACKUP_BLOCKEDLIST
   else
     zmlog local7.err "Zmbackup: zmbackup.conf not found."
     echo "ERROR - zmbackup.conf not found. Can't proceed without the file."

--- a/project/lib/bash/ParallelAction.sh
+++ b/project/lib/bash/ParallelAction.sh
@@ -208,7 +208,8 @@ function ldap_filter()
       EXIST=$(sqlite3 "$WORKDIR"/sessions.sqlite3 "select email from backup_account where conclusion_date < '$TODAY' and conclusion_date > '$YESTERDAY' and email='${SAFE_EMAIL}'")
     fi
   fi
-  if grep -Fxq "$1" /etc/zmbackup/blockedlist.conf; then
+  local blockedlist="${ZMBACKUP_BLOCKEDLIST:-/etc/zmbackup/blockedlist.conf}"
+  if grep -Fxq "$1" "$blockedlist"; then
     echo "WARN: $1 found inside blocked list - Nothing to do."
   elif [[ $EXIST ]]; then
     echo "WARN: $1 already has backup today. Nothing to do."


### PR DESCRIPTION
The blockedlist path in ldap_filter was hardcoded to /etc/zmbackup/blockedlist.conf, making it impossible to use a custom location for non-standard installs. Introduce the ZMBACKUP_BLOCKEDLIST variable (defaulting to the original path) that can be set in zmbackup.conf or the environment, and document it in the config template.

Fixes #227 