### PR TITLE
Refactor: extract parse_session_name helper to eliminate duplicate of…

### DIFF
--- a/project/lib/bash/MigrationAction.sh
+++ b/project/lib/bash/MigrationAction.sh
@@ -25,49 +25,15 @@ function importsessionSQL(){
   for i in $(grep -E 'SESSION:' "$WORKDIR"/sessions.txt | grep 'started' |  awk '{print $2}' | sort | uniq); do
     SESSIONID=$i
     OPT=$(echo "$i" | cut -d"-" -f1 )
+    parse_session_name "$i"
     case $OPT in
-      "full")
-          OPT="Full Backup"
-          YEAR=$(echo "$i" | cut -c6-9)
-          MONTH=$(echo "$i" | cut -c10-11)
-          DAY=$(echo "$i" | cut -c12-13)
-      ;;
-      "inc")
-          OPT="Incremental Backup"
-          YEAR=$(echo "$i" | cut -c5-8)
-          MONTH=$(echo "$i" | cut -c9-10)
-          DAY=$(echo "$i" | cut -c11-12)
-      ;;
-      "distlist")
-          OPT="Distribution List Backup"
-          YEAR=$(echo "$i" | cut -c10-13)
-          MONTH=$(echo "$i" | cut -c14-15)
-          DAY=$(echo "$i" | cut -c16-17)
-      ;;
-      "alias")
-          OPT="Alias Backup"
-          YEAR=$(echo "$i" | cut -c7-10)
-          MONTH=$(echo "$i" | cut -c11-12)
-          DAY=$(echo "$i" | cut -c13-14)
-      ;;
-      "ldap")
-          OPT="Account Backup - Only LDAP"
-          YEAR=$(echo "$i" | cut -c6-9)
-          MONTH=$(echo "$i" | cut -c10-11)
-          DAY=$(echo "$i" | cut -c12-13)
-      ;;
-      "mbox")
-          OPT="Mailbox Backup"
-          YEAR=$(echo "$i" | cut -c6-9)
-          MONTH=$(echo "$i" | cut -c10-11)
-          DAY=$(echo "$i" | cut -c12-13)
-      ;;
-      "signature")
-          OPT="Signature Backup"
-          YEAR=$(echo "$i" | cut -c11-14)
-          MONTH=$(echo "$i" | cut -c15-16)
-          DAY=$(echo "$i" | cut -c17-18)
-      ;;
+      "full")      OPT="Full Backup" ;;
+      "inc")       OPT="Incremental Backup" ;;
+      "distlist")  OPT="Distribution List Backup" ;;
+      "alias")     OPT="Alias Backup" ;;
+      "ldap")      OPT="Account Backup - Only LDAP" ;;
+      "mbox")      OPT="Mailbox Backup" ;;
+      "signature") OPT="Signature Backup" ;;
     esac
     INITIAL=$YEAR'-'$MONTH'-'$DAY"T00:00:00.000"
     CONCLUSION=$YEAR'-'$MONTH'-'$DAY"T00:00:00.000"

--- a/project/lib/bash/MiscAction.sh
+++ b/project/lib/bash/MiscAction.sh
@@ -4,6 +4,19 @@
 ################################################################################
 
 ################################################################################
+# parse_session_name: Extract YEAR, MONTH, DAY from a session name.
+# The session name format is {prefix}-YYYYMMDDHHMMSS regardless of prefix length.
+# Sets YEAR, MONTH, DAY in the caller's scope; returns 1 if the name is invalid.
+################################################################################
+function parse_session_name() {
+  local name="$1"
+  [[ "$name" =~ -([0-9]{4})([0-9]{2})([0-9]{2}) ]] || return 1
+  YEAR="${BASH_REMATCH[1]}"
+  MONTH="${BASH_REMATCH[2]}"
+  DAY="${BASH_REMATCH[3]}"
+}
+
+################################################################################
 # zmlog: Write a log entry to both syslog and $LOGFILE.
 # Options:
 #    $1 - syslog priority (e.g. local7.info, local7.err, local7.warn)
@@ -323,6 +336,7 @@ function checkpid(){
 # export_function: Export all the functions used by ParallelAction
 ################################################################################
 function export_function(){
+  export -f parse_session_name
   export -f zmlog
   export -f safe_sql_value
   export -f ldap_escape_filter

--- a/project/lib/bash/SessionAction.sh
+++ b/project/lib/bash/SessionAction.sh
@@ -30,49 +30,15 @@ function list_sessions_txt ()
     # Load variables
     SIZE=$(du -h "$WORKDIR"/"$i" | awk '{print $1}')
     OPT=$(echo "$i" | cut -d"-" -f1 )
+    parse_session_name "$i"
     case $OPT in
-      "full")
-          OPT="Full Backup"
-          YEAR=$(echo "$i" | cut -c6-9)
-          MONTH=$(echo "$i" | cut -c10-11)
-          DAY=$(echo "$i" | cut -c12-13)
-      ;;
-      "inc")
-          OPT="Incremental Backup"
-          YEAR=$(echo "$i" | cut -c5-8)
-          MONTH=$(echo "$i" | cut -c9-10)
-          DAY=$(echo "$i" | cut -c11-12)
-      ;;
-      "distlist")
-          OPT="Distribution List Backup"
-          YEAR=$(echo "$i" | cut -c10-13)
-          MONTH=$(echo "$i" | cut -c14-15)
-          DAY=$(echo "$i" | cut -c16-17)
-      ;;
-      "alias")
-          OPT="Alias Backup"
-          YEAR=$(echo "$i" | cut -c7-10)
-          MONTH=$(echo "$i" | cut -c11-12)
-          DAY=$(echo "$i" | cut -c13-14)
-      ;;
-      "ldap")
-          OPT="Account Backup - Only LDAP"
-          YEAR=$(echo "$i" | cut -c6-9)
-          MONTH=$(echo "$i" | cut -c10-11)
-          DAY=$(echo "$i" | cut -c12-13)
-      ;;
-      "mbox")
-          OPT="Mailbox Backup"
-          YEAR=$(echo "$i" | cut -c6-9)
-          MONTH=$(echo "$i" | cut -c10-11)
-          DAY=$(echo "$i" | cut -c12-13)
-      ;;
-      "signature")
-          OPT="Signature Backup"
-          YEAR=$(echo "$i" | cut -c11-14)
-          MONTH=$(echo "$i" | cut -c15-16)
-          DAY=$(echo "$i" | cut -c17-18)
-      ;;
+      "full")      OPT="Full Backup" ;;
+      "inc")       OPT="Incremental Backup" ;;
+      "distlist")  OPT="Distribution List Backup" ;;
+      "alias")     OPT="Alias Backup" ;;
+      "ldap")      OPT="Account Backup - Only LDAP" ;;
+      "mbox")      OPT="Mailbox Backup" ;;
+      "signature") OPT="Signature Backup" ;;
     esac
 
     # Printing the information as a table


### PR DESCRIPTION
…fset tables

Adds a single parse_session_name() function in MiscAction.sh that uses a regex to extract YEAR/MONTH/DAY from any session name regardless of prefix length, replacing the identical hardcoded cut-offset case blocks that existed in both SessionAction.sh and MigrationAction.sh (closes #223).
