### PR TITLE
Refactor: centralize TXT vs SQLite3 session dispatch into session_que…

### DIFF
--- a/project/lib/bash/BackupAction.sh
+++ b/project/lib/bash/BackupAction.sh
@@ -16,16 +16,13 @@ function __backupFullInc(){
   if [ "$ERRCODE" -eq 0 ]; then
     mailbox_backup "$1"
     if [ "$ERRCODE" -eq 0 ]; then
-      if [[ $SESSION_TYPE == 'TXT' ]]; then
-        echo "$SESSION":"$1":"$(date +%m/%d/%y)" >> "$TEMPSESSION"
-      elif [[ $SESSION_TYPE == "SQLITE3" ]]; then
-        EDATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
-        SIZE=$(du -ch "$TEMPDIR"/"$1"* | grep total | cut -f1)
-        local SAFE_EMAIL
-        SAFE_EMAIL=$(safe_sql_value "$1")
-        echo "insert into backup_account (email,sessionID,account_size, initial_date, \
-              conclusion_date) values ('${SAFE_EMAIL}','$SESSION','$SIZE','$SDATE','$EDATE');"  >> "$TEMPSQL"
-      fi
+      local SAFE_EMAIL EDATE SIZE
+      SAFE_EMAIL=$(safe_sql_value "$1")
+      EDATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
+      SIZE=$(du -ch "$TEMPDIR"/"$1"* | grep total | cut -f1)
+      session_query \
+        "insert into backup_account (email,sessionID,account_size,initial_date,conclusion_date) values ('${SAFE_EMAIL}','$SESSION','$SIZE','$SDATE','$EDATE');" \
+        "echo \"$SESSION:$1:$(date +%m/%d/%y)\" >> \"$TEMPSESSION\""
     fi
   fi
 }
@@ -44,16 +41,13 @@ function __backupLdap(){
   SDATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
   ldap_backup "$1" "$2"
   if [ "$ERRCODE" -eq 0 ]; then
-    if [[ $SESSION_TYPE == 'TXT' ]]; then
-      echo "$SESSION":"$1":"$(date +%m/%d/%y)" >> "$TEMPSESSION"
-    elif [[ $SESSION_TYPE == "SQLITE3" ]]; then
-      EDATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
-      SIZE=$(du -ch "$TEMPDIR"/"$1"* | grep total | cut -f1)
-      local SAFE_EMAIL
-      SAFE_EMAIL=$(safe_sql_value "$1")
-      echo "insert into backup_account (email,sessionID,account_size, initial_date, \
-            conclusion_date) values ('${SAFE_EMAIL}','$SESSION','$SIZE','$SDATE','$EDATE');"  >> "$TEMPSQL"
-    fi
+    local SAFE_EMAIL EDATE SIZE
+    SAFE_EMAIL=$(safe_sql_value "$1")
+    EDATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
+    SIZE=$(du -ch "$TEMPDIR"/"$1"* | grep total | cut -f1)
+    session_query \
+      "insert into backup_account (email,sessionID,account_size,initial_date,conclusion_date) values ('${SAFE_EMAIL}','$SESSION','$SIZE','$SDATE','$EDATE');" \
+      "echo \"$SESSION:$1:$(date +%m/%d/%y)\" >> \"$TEMPSESSION\""
   fi
 }
 
@@ -67,16 +61,13 @@ function __backupDomain(){
   SDATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
   domain_backup "$1" "$2"
   if [ "$ERRCODE" -eq 0 ]; then
-    if [[ $SESSION_TYPE == 'TXT' ]]; then
-      echo "$SESSION":"$1":"$(date +%m/%d/%y)" >> "$TEMPSESSION"
-    elif [[ $SESSION_TYPE == "SQLITE3" ]]; then
-      EDATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
-      SIZE=$(du -ch "$TEMPDIR"/"$1"* | grep total | cut -f1)
-      local SAFE_EMAIL
-      SAFE_EMAIL=$(safe_sql_value "$1")
-      echo "insert into backup_account (email,sessionID,account_size, initial_date, \
-            conclusion_date) values ('${SAFE_EMAIL}','$SESSION','$SIZE','$SDATE','$EDATE');"  >> "$TEMPSQL"
-    fi
+    local SAFE_EMAIL EDATE SIZE
+    SAFE_EMAIL=$(safe_sql_value "$1")
+    EDATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
+    SIZE=$(du -ch "$TEMPDIR"/"$1"* | grep total | cut -f1)
+    session_query \
+      "insert into backup_account (email,sessionID,account_size,initial_date,conclusion_date) values ('${SAFE_EMAIL}','$SESSION','$SIZE','$SDATE','$EDATE');" \
+      "echo \"$SESSION:$1:$(date +%m/%d/%y)\" >> \"$TEMPSESSION\""
   fi
 }
 
@@ -91,16 +82,13 @@ function __backupMailbox(){
   SDATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
   mailbox_backup "$1" "$2"
   if [ "$ERRCODE" -eq 0 ]; then
-    if [[ $SESSION_TYPE == 'TXT' ]]; then
-      echo "$SESSION":"$1":"$(date +%m/%d/%y)" >> "$TEMPSESSION"
-    elif [[ $SESSION_TYPE == "SQLITE3" ]]; then
-      EDATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
-      SIZE=$(du -ch "$TEMPDIR"/"$1"* | grep total | cut -f1)
-      local SAFE_EMAIL
-      SAFE_EMAIL=$(safe_sql_value "$1")
-      echo "insert into backup_account (email,sessionID,account_size, initial_date, \
-            conclusion_date) values ('${SAFE_EMAIL}','$SESSION','$SIZE','$SDATE','$EDATE');"  >> "$TEMPSQL"
-    fi
+    local SAFE_EMAIL EDATE SIZE
+    SAFE_EMAIL=$(safe_sql_value "$1")
+    EDATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
+    SIZE=$(du -ch "$TEMPDIR"/"$1"* | grep total | cut -f1)
+    session_query \
+      "insert into backup_account (email,sessionID,account_size,initial_date,conclusion_date) values ('${SAFE_EMAIL}','$SESSION','$SIZE','$SDATE','$EDATE');" \
+      "echo \"$SESSION:$1:$(date +%m/%d/%y)\" >> \"$TEMPSESSION\""
   fi
 }
 
@@ -140,14 +128,10 @@ function backup_main()
     notify_begin "$SESSION" "$STYPE"
     zmlog local7.info "Zmbackup: Backup session $SESSION started on $(date)"
     echo "Backup session $SESSION started on $(date)"
-    if [[ $SESSION_TYPE == 'TXT' ]]; then
-      echo "SESSION: $SESSION started on $(date)" >> "$TEMPSESSION"
-    elif [[ $SESSION_TYPE == "SQLITE3" ]]; then
-      DATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
-      sqlite3 "$WORKDIR"/sessions.sqlite3 "insert into backup_session(sessionID,\
-                                         initial_date,type,status) values \
-                                         ('$SESSION','$DATE','$STYPE','IN PROGRESS')" > /dev/null 2>&1
-    fi
+    DATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
+    session_query \
+      "insert into backup_session(sessionID,initial_date,type,status) values ('$SESSION','$DATE','$STYPE','IN PROGRESS')" \
+      "echo \"SESSION: $SESSION started on $(date)\" >> \"$TEMPSESSION\""
     if [[ "$SESSION" == "full"* ]] || [[ "$SESSION" == "inc"* ]]; then
       parallel --jobs "$MAX_PARALLEL_PROCESS" "__backupFullInc '{}' '$1'" < "$TEMPACCOUNT"
     elif [[ "$SESSION" == "mbox"* ]]; then
@@ -158,18 +142,12 @@ function backup_main()
       parallel --jobs "$MAX_PARALLEL_PROCESS" "__backupLdap '{}' '$1'" < "$TEMPACCOUNT"
     fi
     mv "$TEMPDIR" "$WORKDIR/$SESSION" && rm -rf "$TEMPDIR"
-    if [[ $SESSION_TYPE == 'TXT' ]]; then
-      echo "SESSION: $SESSION completed in $(date)" >> "$TEMPSESSION"
-      cat "$TEMPSESSION" >> "$WORKDIR"/sessions.txt
-    elif [[ $SESSION_TYPE == "SQLITE3" ]]; then
-      chmod -R 775 "$WORKDIR"/"$SESSION"
-      DATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
-      SIZE=$(du -sh "$WORKDIR"/"$SESSION" | awk '{print $1}')
-      sqlite3 "$WORKDIR"/sessions.sqlite3 < "$TEMPSQL" > /dev/null 2>&1
-      sqlite3 "$WORKDIR"/sessions.sqlite3 "update backup_session set conclusion_date='$DATE',\
-                                         size='$SIZE',status='FINISHED' where \
-                                         sessionID='$SESSION'" > /dev/null 2>&1
-    fi
+    chmod -R 775 "$WORKDIR"/"$SESSION"
+    DATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
+    SIZE=$(du -sh "$WORKDIR"/"$SESSION" | awk '{print $1}')
+    session_query \
+      "update backup_session set conclusion_date='$DATE',size='$SIZE',status='FINISHED' where sessionID='$SESSION'" \
+      "echo \"SESSION: $SESSION completed in $(date)\" >> \"$TEMPSESSION\"; cat \"$TEMPSESSION\" >> \"$WORKDIR\"/sessions.txt"
     zmlog local7.info "Zmbackup: Backup session $SESSION finished on $(date)"
     echo "Backup session $SESSION finished on $(date)"
   else

--- a/project/lib/bash/DeleteAction.sh
+++ b/project/lib/bash/DeleteAction.sh
@@ -10,11 +10,9 @@
 ################################################################################
 function delete_one(){
   local RETCODE=0
-  if [[ $SESSION_TYPE == 'TXT' ]]; then
-    SESSION=$(grep "$1 started" "$WORKDIR"/sessions.txt -m 1 | awk '{print $2}')
-  elif [[ $SESSION_TYPE == 'SQLITE3' ]]; then
-    SESSION=$(sqlite3 "$WORKDIR"/sessions.sqlite3 "select sessionID from backup_session where sessionID='$1'")
-  fi
+  SESSION=$(session_query \
+    "select sessionID from backup_session where sessionID='$1'" \
+    "grep '$1 started' \"$WORKDIR\"/sessions.txt -m 1 | awk '{print \$2}'")
   if [ -n "$SESSION" ]; then
     echo "Removing session $1 - please wait."
     __DELETEBACKUP "$1"
@@ -34,19 +32,14 @@ function delete_one(){
 function delete_old(){
   echo "Removing old backup folders - please wait."
   zmlog local7.info "Zmbhousekeep: Cleaning $WORKDIR from old backup sessions."
-  if [[ $SESSION_TYPE == 'TXT' ]]; then
-    OLDEST=$(date  +%Y%m%d%H%M%S -d "-$ROTATE_TIME days")
-    grep SESS "$WORKDIR"/sessions.txt | awk '{print $2}'| while read -r LINE; do
-      if [ "$(echo "$LINE" | cut -d- -f2)" -lt "$OLDEST" ]; then
-         __DELETEBACKUP "$LINE"
-      fi
-    done
-  elif [[ $SESSION_TYPE == 'SQLITE3' ]]; then
-    sqlite3 "$WORKDIR"/sessions.sqlite3 "select sessionID from backup_session where conclusion_date < datetime('now','-$ROTATE_TIME day')" | while read -r LINE; do
+  OLDEST=$(date +%Y%m%d%H%M%S -d "-$ROTATE_TIME days")
+  session_query \
+    "select sessionID from backup_session where conclusion_date < datetime('now','-$ROTATE_TIME day')" \
+    "grep SESS \"$WORKDIR\"/sessions.txt | awk -v oldest=\"$OLDEST\" '{n=split(\$2,a,\"-\"); if (n>=2 && a[2]+0 < oldest+0) print \$2}'" \
+  | while read -r LINE; do
       __DELETEBACKUP "$LINE"
     done
-    sqlite3 "$WORKDIR"/sessions.sqlite3 "VACUUM"
-  fi
+  [[ $SESSION_TYPE == 'SQLITE3' ]] && sqlite3 "$WORKDIR"/sessions.sqlite3 "VACUUM"
   zmlog local7.info "Zmbhousekeep: Clean old backups activity concluded."
 }
 
@@ -56,16 +49,13 @@ function delete_old(){
 function leeroy_jenkins(){
   echo "LEEROY JENKINS!!!!!"
   zmlog local7.info "Zmbhousekeep: Cleaning $WORKDIR from all the backup sessions."
-  if [[ $SESSION_TYPE == 'TXT' ]]; then
-    grep SESS "$WORKDIR"/sessions.txt | awk '{print $2}'| while read -r LINE; do
+  session_query \
+    "select sessionID from backup_session" \
+    "grep SESS \"$WORKDIR\"/sessions.txt | awk '{print \$2}'" \
+  | while read -r LINE; do
       __DELETEBACKUP "$LINE"
     done
-  elif [[ $SESSION_TYPE == 'SQLITE3' ]]; then
-    sqlite3 "$WORKDIR"/sessions.sqlite3 "select sessionID from backup_session" | while read -r LINE; do
-      __DELETEBACKUP "$LINE"
-    done
-    sqlite3 "$WORKDIR"/sessions.sqlite3 "VACUUM"
-  fi
+  [[ $SESSION_TYPE == 'SQLITE3' ]] && sqlite3 "$WORKDIR"/sessions.sqlite3 "VACUUM"
   zmlog local7.info "Zmbhousekeep: Clean old backups activity concluded."
   echo "All the backups are deleted - Have a nice week :)"
 }
@@ -79,14 +69,10 @@ function __DELETEBACKUP(){
   ERR=$( (rm -rf "${WORKDIR:?}"/"${1:?}") 2>&1)
   BASHERRCODE=$?
   if [[ $BASHERRCODE -eq 0 ]]; then
-    if [[ $SESSION_TYPE == 'TXT' ]]; then
-      # grep -v exits 1 when all lines are filtered out (last session removed); || true prevents set -e from aborting
-      grep -v "$1" "${WORKDIR:?}"/sessions.txt > "${WORKDIR:?}"/.sessions.txt || true
-      mv "${WORKDIR:?}"/.sessions.txt "${WORKDIR:?}"/sessions.txt
-    elif [[ $SESSION_TYPE == 'SQLITE3' ]]; then
-      sqlite3 "${WORKDIR:?}"/sessions.sqlite3 "delete from backup_account where sessionID='$1'"
-      sqlite3 "${WORKDIR:?}"/sessions.sqlite3 "delete from backup_session where sessionID='$1'"
-    fi
+    # grep -v exits 1 when all lines are filtered out (last session removed); || true prevents set -e from aborting
+    session_query \
+      "delete from backup_account where sessionID='$1'; delete from backup_session where sessionID='$1'" \
+      "grep -v \"$1\" \"${WORKDIR:?}\"/sessions.txt > \"${WORKDIR:?}\"/.sessions.txt || true; mv \"${WORKDIR:?}\"/.sessions.txt \"${WORKDIR:?}\"/sessions.txt"
     echo "Backup session $1 removed."
     zmlog local7.info "Zmbhousekeep: Backup session $1 removed."
   else

--- a/project/lib/bash/MiscAction.sh
+++ b/project/lib/bash/MiscAction.sh
@@ -42,6 +42,21 @@ function ldap_escape_filter() {
 }
 
 ################################################################################
+# session_query: Dispatch a session query to TXT or SQLite3 backend.
+# Options:
+#    $1 - SQL statement(s) for the SQLite3 backend
+#    $2 - Shell command string for the TXT backend (passed to eval)
+################################################################################
+function session_query() {
+  local sql="$1" txt_fallback_cmd="$2"
+  if [[ $SESSION_TYPE == "SQLITE3" ]]; then
+    sqlite3 "$WORKDIR/sessions.sqlite3" "$sql"
+  else
+    eval "$txt_fallback_cmd"
+  fi
+}
+
+################################################################################
 # clear_temp: Clear all the temporary files.
 ################################################################################
 function on_exit(){
@@ -54,7 +69,7 @@ function on_exit(){
     fi
   fi
   # shellcheck disable=SC2086
-  rm -rf "$TEMPSESSION" "$TEMPACCOUNT" "$TEMPINACCOUNT" "$TEMPDIR" $MESSAGE $TEMPSQL $FAILURE
+  rm -rf "$TEMPSESSION" "$TEMPACCOUNT" "$TEMPINACCOUNT" "$TEMPDIR" $MESSAGE $FAILURE
   zmlog local7.info "Zmbackup: Excluding the temporary files before close."
 }
 
@@ -71,8 +86,7 @@ function create_temp(){
   MESSAGE=$(mktemp)
   FAILURE=$(mktemp)
   TEMPSESSION=$(mktemp)
-  TEMPSQL=$(mktemp)
-  export TEMPDIR TEMPACCOUNT TEMPINACCOUNT MESSAGE FAILURE TEMPSESSION TEMPSQL
+  export TEMPDIR TEMPACCOUNT TEMPINACCOUNT MESSAGE FAILURE TEMPSESSION
 }
 
 ################################################################################
@@ -326,6 +340,7 @@ function export_function(){
   export -f zmlog
   export -f safe_sql_value
   export -f ldap_escape_filter
+  export -f session_query
   export -f __backupMailbox
   export -f __backupFullInc
   export -f __backupLdap

--- a/project/lib/bash/ParallelAction.sh
+++ b/project/lib/bash/ParallelAction.sh
@@ -41,15 +41,11 @@ function mailbox_backup()
 {
   TEMP_CLI_OUTPUT=$(mktemp)
   if [[ "$INC" == "TRUE" ]]; then
-    if [[ $SESSION_TYPE == 'TXT' ]]; then
-      DATE=$(grep "$1" "$WORKDIR"/sessions.txt | tail -1 | awk -F: '{print $3}' | cut -d'-' -f2)
-    elif [[ $SESSION_TYPE == 'SQLITE3' ]]; then
-      local SAFE_EMAIL
-      SAFE_EMAIL=$(safe_sql_value "$1")
-      DATE=$(sqlite3 "$WORKDIR"/sessions.sqlite3 "select MAX(initial_date) \
-             from backup_account where email='${SAFE_EMAIL}' and \
-             (sessionID like 'full%' or sessionID like 'inc%' or sessionID like 'mbox%')")
-    fi
+    local SAFE_EMAIL
+    SAFE_EMAIL=$(safe_sql_value "$1")
+    DATE=$(session_query \
+      "select MAX(initial_date) from backup_account where email='${SAFE_EMAIL}' and (sessionID like 'full%' or sessionID like 'inc%' or sessionID like 'mbox%')" \
+      "grep \"$1\" \"$WORKDIR\"/sessions.txt | tail -1 | awk -F: '{print \$3}' | cut -d- -f2")
     YESTERDAY=$(date -d "$DATE" --date='-48 hours' +%m/%d/%Y)
     AFTER='&'"query=after:\"$YESTERDAY\""
   fi
@@ -198,15 +194,13 @@ function ldap_filter()
 {
   EXIST=
   if [[ "$LOCK_BACKUP" == "true" ]]; then
-    if [[ "$SESSION_TYPE" == "TXT" ]]; then
-      EXIST=$(grep "$1:$(date +%m/%d/%y)" "$WORKDIR"/sessions.txt 2> /dev/null | tail -1)
-    else
-      TODAY=$(date +%Y-%m-%dT%H:%M:%S.%N)
-      YESTERDAY=$(date +%Y-%m-%dT%H:%M:%S.%N -d "yesterday")
-      local SAFE_EMAIL
-      SAFE_EMAIL=$(safe_sql_value "$1")
-      EXIST=$(sqlite3 "$WORKDIR"/sessions.sqlite3 "select email from backup_account where conclusion_date < '$TODAY' and conclusion_date > '$YESTERDAY' and email='${SAFE_EMAIL}'")
-    fi
+    TODAY=$(date +%Y-%m-%dT%H:%M:%S.%N)
+    YESTERDAY=$(date +%Y-%m-%dT%H:%M:%S.%N -d "yesterday")
+    local SAFE_EMAIL
+    SAFE_EMAIL=$(safe_sql_value "$1")
+    EXIST=$(session_query \
+      "select email from backup_account where conclusion_date < '$TODAY' and conclusion_date > '$YESTERDAY' and email='${SAFE_EMAIL}'" \
+      "grep \"$1:$(date +%m/%d/%y)\" \"$WORKDIR\"/sessions.txt 2>/dev/null | tail -1")
   fi
   local blockedlist="${ZMBACKUP_BLOCKEDLIST:-/etc/zmbackup/blockedlist.conf}"
   if grep -Fxq "$1" "$blockedlist"; then

--- a/project/lib/bash/RestoreAction.sh
+++ b/project/lib/bash/RestoreAction.sh
@@ -12,12 +12,9 @@
 ################################################################################
 function restore_main_mailbox()
 {
-  if [[ $SESSION_TYPE == 'TXT' ]]; then
-    SESSION=$(grep -E ": $1 started" "$WORKDIR"/sessions.txt | grep 'started' | \
-                  awk '{print $2}' | sort | uniq)
-  elif [[ $SESSION_TYPE == "SQLITE3" ]]; then
-    SESSION=$(sqlite3 "$WORKDIR"/sessions.sqlite3 "select * from backup_session where sessionID='$1'")
-  fi
+  SESSION=$(session_query \
+    "select * from backup_session where sessionID='$1'" \
+    "grep -E ': $1 started' \"$WORKDIR\"/sessions.txt | grep 'started' | awk '{print \$2}' | sort | uniq")
   if [ -n "$SESSION" ]; then
     printf "Restore mail process with session %s started at %s" "$1" "$(date)"
     TOTAL_COUNT=0
@@ -80,12 +77,9 @@ function restore_main_mailbox()
 ################################################################################
 function restore_main_domain()
 {
-  if [[ $SESSION_TYPE == 'TXT' ]]; then
-    SESSION=$(grep -E ": $1 started" "$WORKDIR"/sessions.txt | grep 'started' | \
-                  awk '{print $2}' | sort | uniq)
-  elif [[ $SESSION_TYPE == "SQLITE3" ]]; then
-    SESSION=$(sqlite3 "$WORKDIR"/sessions.sqlite3 "select * from backup_session where sessionID='$1'")
-  fi
+  SESSION=$(session_query \
+    "select * from backup_session where sessionID='$1'" \
+    "grep -E ': $1 started' \"$WORKDIR\"/sessions.txt | grep 'started' | awk '{print \$2}' | sort | uniq")
   if [ -n "$SESSION" ]; then
     echo "Restore Domain LDAP process with session $1 started at $(date)"
     if [[ -n "$2" ]]; then
@@ -117,12 +111,9 @@ function restore_main_domain()
 ################################################################################
 function restore_main_ldap()
 {
-  if [[ $SESSION_TYPE == 'TXT' ]]; then
-    SESSION=$(grep -E ": $1 started" "$WORKDIR"/sessions.txt | grep 'started' | \
-                  awk '{print $2}' | sort | uniq)
-  elif [[ $SESSION_TYPE == "SQLITE3" ]]; then
-    SESSION=$(sqlite3 "$WORKDIR"/sessions.sqlite3 "select * from backup_session where sessionID='$1'")
-  fi
+  SESSION=$(session_query \
+    "select * from backup_session where sessionID='$1'" \
+    "grep -E ': $1 started' \"$WORKDIR\"/sessions.txt | grep 'started' | awk '{print \$2}' | sort | uniq")
   if [ -n "$SESSION" ]; then
     echo "Restore LDAP process with session $1 started at $(date)"
     LDAP_FAILFILE=$(mktemp)

--- a/tests/setup.bash
+++ b/tests/setup.bash
@@ -62,13 +62,12 @@ stub_all_temps() {
   MESSAGE="$(mktemp)"
   FAILURE="$(mktemp)"
   TEMPSESSION="$(mktemp)"
-  TEMPSQL="$(mktemp)"
-  export TEMPDIR TEMPACCOUNT TEMPINACCOUNT MESSAGE FAILURE TEMPSESSION TEMPSQL
+  export TEMPDIR TEMPACCOUNT TEMPINACCOUNT MESSAGE FAILURE TEMPSESSION
 }
 
 cleanup_temps() {
   for f in "${TEMPDIR:-}" "${TEMPACCOUNT:-}" "${TEMPINACCOUNT:-}" \
-            "${MESSAGE:-}" "${FAILURE:-}" "${TEMPSESSION:-}" "${TEMPSQL:-}"; do
+            "${MESSAGE:-}" "${FAILURE:-}" "${TEMPSESSION:-}"; do
     [ -n "$f" ] && rm -rf "$f"
   done
 }

--- a/tests/unit/test_BackupAction.bats
+++ b/tests/unit/test_BackupAction.bats
@@ -28,6 +28,7 @@ setup() {
 
   # Export functions required by the parallel mock subprocess
   export -f __backupFullInc __backupLdap __backupMailbox __backupDomain ldap_backup mailbox_backup domain_backup
+  export -f zmlog safe_sql_value ldap_escape_filter session_query
 
   # Suppress blockedlist lookup in ldap_filter
   grep() {
@@ -65,8 +66,12 @@ teardown() {
   MOCK_LDAPSEARCH_FAIL=0
   MOCK_ZMMAILBOX_FAIL=0
   MOCK_ZMMAILBOX_EMPTY=0
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
   __backupFullInc "user@example.com" "$ACOBJECT"
-  grep -q "insert into backup_account" "$TEMPSQL"
+  local count
+  count=$(sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "select count(*) from backup_account where email='user@example.com'")
+  [ "$count" -eq 1 ]
 }
 
 @test "__backupFullInc: does not write record when ldap_backup fails" {
@@ -104,8 +109,12 @@ teardown() {
   SESSION="alias-20240101120000"
   SESSION_TYPE="SQLITE3"
   MOCK_LDAPSEARCH_FAIL=0
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
   __backupLdap "alias@example.com" "(objectclass=zimbraAlias)"
-  grep -q "insert into backup_account" "$TEMPSQL"
+  local count
+  count=$(sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "select count(*) from backup_account where email='alias@example.com'")
+  [ "$count" -eq 1 ]
 }
 
 @test "__backupLdap: does not write record when ldap_backup fails" {
@@ -133,8 +142,12 @@ teardown() {
   SESSION="domain-20240101120000"
   SESSION_TYPE="SQLITE3"
   MOCK_LDAPSEARCH_FAIL=0
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
   __backupDomain "example.com" "(objectclass=zimbraDomain)"
-  grep -q "insert into backup_account" "$TEMPSQL"
+  local count
+  count=$(sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "select count(*) from backup_account where email='example.com'")
+  [ "$count" -eq 1 ]
 }
 
 @test "__backupDomain: does not write record when domain_backup fails" {
@@ -166,8 +179,12 @@ teardown() {
   INC="FALSE"
   MOCK_ZMMAILBOX_FAIL=0
   MOCK_ZMMAILBOX_EMPTY=0
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
   __backupMailbox "user@example.com" "$ACOBJECT"
-  grep -q "insert into backup_account" "$TEMPSQL"
+  local count
+  count=$(sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "select count(*) from backup_account where email='user@example.com'")
+  [ "$count" -eq 1 ]
 }
 
 @test "__backupMailbox: does not write record when mailbox_backup fails" {
@@ -294,18 +311,7 @@ teardown() {
 # SQL injection regression tests
 # ---------------------------------------------------------------------------
 
-@test "__backupFullInc: SQL injection in email is escaped in TEMPSQL" {
-  SESSION="full-20240101120000"
-  SESSION_TYPE="SQLITE3"
-  MOCK_LDAPSEARCH_FAIL=0
-  MOCK_ZMMAILBOX_FAIL=0
-  MOCK_ZMMAILBOX_EMPTY=0
-  __backupFullInc "'; DELETE FROM backup_session; --@evil.com" "$ACOBJECT"
-  # Single quote must be doubled so the DELETE is not a separate statement
-  grep -q "''; DELETE FROM backup_session; --@evil.com'" "$TEMPSQL"
-}
-
-@test "__backupFullInc: SQL injection payload does not corrupt the database" {
+@test "__backupFullInc: SQL injection in email does not corrupt the database" {
   SESSION="full-20240101120000"
   SESSION_TYPE="SQLITE3"
   sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
@@ -316,35 +322,52 @@ teardown() {
   MOCK_ZMMAILBOX_FAIL=0
   MOCK_ZMMAILBOX_EMPTY=0
   __backupFullInc "'; DELETE FROM backup_session; --@evil.com" "$ACOBJECT"
-  sqlite3 "${WORKDIR}/sessions.sqlite3" < "$TEMPSQL" > /dev/null 2>&1
-  # Session row inserted by setup must still exist
+  # Session row must still exist — the injection must not have executed the DELETE
   local count
   count=$(sqlite3 "${WORKDIR}/sessions.sqlite3" "select count(*) from backup_session")
   [ "$count" -eq 1 ]
 }
 
-@test "__backupLdap: SQL injection in email is escaped in TEMPSQL" {
+@test "__backupLdap: SQL injection in email does not corrupt the database" {
   SESSION="alias-20240101120000"
   SESSION_TYPE="SQLITE3"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "insert into backup_session(sessionID,initial_date,type,status) \
+     values('alias-20240101120000','2024-01-01T00:00:00.000','Alias','IN PROGRESS')"
   MOCK_LDAPSEARCH_FAIL=0
   __backupLdap "'; DELETE FROM backup_session; --@evil.com" "(objectclass=zimbraAlias)"
-  grep -q "''; DELETE FROM backup_session; --@evil.com'" "$TEMPSQL"
+  local count
+  count=$(sqlite3 "${WORKDIR}/sessions.sqlite3" "select count(*) from backup_session")
+  [ "$count" -eq 1 ]
 }
 
-@test "__backupDomain: SQL injection in domain name is escaped in TEMPSQL" {
+@test "__backupDomain: SQL injection in domain name does not corrupt the database" {
   SESSION="domain-20240101120000"
   SESSION_TYPE="SQLITE3"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "insert into backup_session(sessionID,initial_date,type,status) \
+     values('domain-20240101120000','2024-01-01T00:00:00.000','Domain','IN PROGRESS')"
   MOCK_LDAPSEARCH_FAIL=0
   __backupDomain "evil'.com" "(objectclass=zimbraDomain)"
-  grep -q "evil''.com" "$TEMPSQL"
+  local count
+  count=$(sqlite3 "${WORKDIR}/sessions.sqlite3" "select count(*) from backup_session")
+  [ "$count" -eq 1 ]
 }
 
-@test "__backupMailbox: SQL injection in email is escaped in TEMPSQL" {
+@test "__backupMailbox: SQL injection in email does not corrupt the database" {
   SESSION="mbox-20240101120000"
   SESSION_TYPE="SQLITE3"
   INC="FALSE"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "insert into backup_session(sessionID,initial_date,type,status) \
+     values('mbox-20240101120000','2024-01-01T00:00:00.000','Mailbox','IN PROGRESS')"
   MOCK_ZMMAILBOX_FAIL=0
   MOCK_ZMMAILBOX_EMPTY=0
   __backupMailbox "'; DELETE FROM backup_session; --@evil.com" "$ACOBJECT"
-  grep -q "''; DELETE FROM backup_session; --@evil.com'" "$TEMPSQL"
+  local count
+  count=$(sqlite3 "${WORKDIR}/sessions.sqlite3" "select count(*) from backup_session")
+  [ "$count" -eq 1 ]
 }

--- a/tests/unit/test_MiscAction.bats
+++ b/tests/unit/test_MiscAction.bats
@@ -101,11 +101,6 @@ teardown() {
   [ -f "$TEMPSESSION" ]
 }
 
-@test "create_temp: creates TEMPSQL file" {
-  create_temp
-  [ -f "$TEMPSQL" ]
-}
-
 @test "create_temp: all temp vars are exported" {
   create_temp
   export -p | grep -q ' TEMPDIR='
@@ -114,7 +109,6 @@ teardown() {
   export -p | grep -q ' MESSAGE='
   export -p | grep -q ' FAILURE='
   export -p | grep -q ' TEMPSESSION='
-  export -p | grep -q ' TEMPSQL='
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…ry helper

Adds session_query() to MiscAction.sh which accepts a SQL statement and a shell fallback command, routing to sqlite3 or eval based on SESSION_TYPE. Replaces all ten inline if/elif dispatch blocks across BackupAction.sh, RestoreAction.sh, DeleteAction.sh, and ParallelAction.sh with calls to this helper, eliminating the need to update two code paths on every session-storage change.

The batch TEMPSQL accumulation pattern in BackupAction.sh is replaced with immediate per-account sqlite3 inserts via session_query, removing the TEMPSQL temp file entirely.

Closes #225
