### PR TITLE
tests: expand coverage for notification, domain, edge cases, and conf…

### DIFF
--- a/tests/unit/test_config.bats
+++ b/tests/unit/test_config.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+
+load '../setup'
+
+setup() {
+  setup_mock_path
+  create_workdir
+  load_test_config
+  local _saved_exit_trap
+  _saved_exit_trap="$(trap -p EXIT)"
+  source "${LIB_DIR}/MiscAction.sh"
+  eval "$_saved_exit_trap"
+}
+
+teardown() {
+  unset STYPE SESSION
+  cleanup_temps
+  destroy_workdir
+}
+
+# ---------------------------------------------------------------------------
+# load_config — ZMBACKUP_BLOCKEDLIST handling
+# ---------------------------------------------------------------------------
+
+@test "load_config: sets ZMBACKUP_BLOCKEDLIST to default when conf does not define it" {
+  run bash -c "
+    export PATH='${MOCKS_DIR}:${PATH}'
+    export LOGFILE='${WORKDIR}/zmbackup.log'
+    _conf=\"\$(mktemp)\"
+    _bashrc=\"\$(mktemp)\"
+    export ZMBACKUP_CONF=\"\$_conf\"
+    export ZIMBRA_BASHRC=\"\$_bashrc\"
+    source '${LIB_DIR}/MiscAction.sh'
+    load_config
+    echo \"BLOCKEDLIST=\$ZMBACKUP_BLOCKEDLIST\"
+    rm -f \"\$_conf\" \"\$_bashrc\"
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BLOCKEDLIST=/etc/zmbackup/blockedlist.conf"* ]]
+}
+
+@test "load_config: ZMBACKUP_BLOCKEDLIST from conf file overrides the default" {
+  run bash -c "
+    export PATH='${MOCKS_DIR}:${PATH}'
+    export LOGFILE='${WORKDIR}/zmbackup.log'
+    _conf=\"\$(mktemp)\"
+    _bashrc=\"\$(mktemp)\"
+    echo 'ZMBACKUP_BLOCKEDLIST=/custom/path/blocked.conf' > \"\$_conf\"
+    export ZMBACKUP_CONF=\"\$_conf\"
+    export ZIMBRA_BASHRC=\"\$_bashrc\"
+    source '${LIB_DIR}/MiscAction.sh'
+    load_config
+    echo \"BLOCKEDLIST=\$ZMBACKUP_BLOCKEDLIST\"
+    rm -f \"\$_conf\" \"\$_bashrc\"
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BLOCKEDLIST=/custom/path/blocked.conf"* ]]
+}
+
+@test "load_config: variables defined in conf file are available after sourcing" {
+  run bash -c "
+    export PATH='${MOCKS_DIR}:${PATH}'
+    export LOGFILE='${WORKDIR}/zmbackup.log'
+    _conf=\"\$(mktemp)\"
+    _bashrc=\"\$(mktemp)\"
+    echo 'MY_CUSTOM_VAR=hello_world' > \"\$_conf\"
+    export ZMBACKUP_CONF=\"\$_conf\"
+    export ZIMBRA_BASHRC=\"\$_bashrc\"
+    source '${LIB_DIR}/MiscAction.sh'
+    load_config
+    echo \"MY_CUSTOM_VAR=\$MY_CUSTOM_VAR\"
+    rm -f \"\$_conf\" \"\$_bashrc\"
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"MY_CUSTOM_VAR=hello_world"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# validate_config — valid non-default values accepted
+# ---------------------------------------------------------------------------
+
+@test "validate_config: SESSION_TYPE=SQLITE3 is accepted" {
+  SESSION_TYPE="SQLITE3"
+  run validate_config
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_config: BACKUP_INACTIVE_ACCOUNTS=false is accepted" {
+  BACKUP_INACTIVE_ACCOUNTS="false"
+  run validate_config
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_config: ROTATE_TIME=0 is accepted as a valid non-empty value" {
+  ROTATE_TIME="0"
+  run validate_config
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_config: ENABLE_EMAIL_NOTIFY=none is accepted as a valid non-empty value" {
+  ENABLE_EMAIL_NOTIFY="none"
+  run validate_config
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_config: WORKDIR with spaces in path validates successfully" {
+  local spaced_dir
+  spaced_dir="$(mktemp -d "/tmp/work dir XXXXXX")"
+  WORKDIR="$spaced_dir"
+  run validate_config
+  rm -rf "$spaced_dir"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# validate_config — multiple missing fields all reported before exit
+# ---------------------------------------------------------------------------
+
+@test "validate_config: reports both LDAPADMIN and LDAPPASS when both are empty" {
+  LDAPADMIN=""
+  LDAPPASS=""
+  run validate_config
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"LDAPADMIN"* ]]
+  [[ "$output" == *"LDAPPASS"* ]]
+}
+
+@test "validate_config: reports LDAPPASS, ROTATE_TIME, and SESSION_TYPE when all are empty" {
+  LDAPPASS=""
+  ROTATE_TIME=""
+  SESSION_TYPE=""
+  run validate_config
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"LDAPPASS"* ]]
+  [[ "$output" == *"ROTATE_TIME"* ]]
+  [[ "$output" == *"SESSION_TYPE"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# validate_config — default-setting is logged at warn level
+# ---------------------------------------------------------------------------
+
+@test "validate_config: logs warning when ENABLE_EMAIL_NOTIFY is defaulted" {
+  ENABLE_EMAIL_NOTIFY=""
+  validate_config
+  grep -q "\[local7.warn\].*ENABLE_EMAIL_NOTIFY" "$LOGFILE"
+}
+
+@test "validate_config: logs warning when EMAIL_NOTIFY is defaulted" {
+  EMAIL_NOTIFY=""
+  validate_config
+  grep -q "\[local7.warn\].*EMAIL_NOTIFY" "$LOGFILE"
+}
+
+@test "validate_config: logs warning when MAX_PARALLEL_PROCESS is defaulted" {
+  MAX_PARALLEL_PROCESS=""
+  validate_config
+  grep -q "\[local7.warn\].*MAX_PARALLEL_PROCESS" "$LOGFILE"
+}
+
+@test "validate_config: logs warning when LOCK_BACKUP is defaulted" {
+  LOCK_BACKUP=""
+  validate_config
+  grep -q "\[local7.warn\].*LOCK_BACKUP" "$LOGFILE"
+}

--- a/tests/unit/test_domain.bats
+++ b/tests/unit/test_domain.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+
+load '../setup'
+
+setup() {
+  setup_mock_path
+  create_workdir
+  load_test_config
+  stub_all_temps
+  source "${LIB_DIR}/ParallelAction.sh"
+  export MOCK_LDAPSEARCH_FAIL=0
+  export MOCK_LDAPADD_FAIL=0
+  export MOCK_LDAPADD_EXISTS=0
+}
+
+teardown() {
+  unset STYPE SESSION
+  cleanup_temps
+  destroy_workdir
+}
+
+# ---------------------------------------------------------------------------
+# domain_backup — multi-component and hyphenated domains
+# ---------------------------------------------------------------------------
+
+@test "domain_backup: three-level domain creates output file named after domain" {
+  domain_backup "sub.example.com" "(objectclass=zimbraDomain)"
+  [ -f "${TEMPDIR}/sub.example.com.ldiff" ]
+}
+
+@test "domain_backup: three-level domain sets ERRCODE=0 on success" {
+  domain_backup "sub.example.com" "(objectclass=zimbraDomain)"
+  [ "$ERRCODE" -eq 0 ]
+}
+
+@test "domain_backup: domain with hyphen creates correct output file" {
+  domain_backup "my-domain.com" "(objectclass=zimbraDomain)"
+  [ -f "${TEMPDIR}/my-domain.com.ldiff" ]
+}
+
+@test "domain_backup: domain with hyphen sets ERRCODE=0 on success" {
+  domain_backup "my-domain.com" "(objectclass=zimbraDomain)"
+  [ "$ERRCODE" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# domain_backup — logging
+# ---------------------------------------------------------------------------
+
+@test "domain_backup: logs at info level on success" {
+  domain_backup "example.com" "(objectclass=zimbraDomain)"
+  grep -q "\[local7.info\].*Domain backup.*example.com" "$LOGFILE"
+}
+
+@test "domain_backup: logs at error level on failure" {
+  MOCK_LDAPSEARCH_FAIL=1 domain_backup "example.com" "(objectclass=zimbraDomain)"
+  grep -q "\[local7.err\].*Domain backup.*example.com" "$LOGFILE"
+}
+
+@test "domain_backup: ERRCODE resets to 0 on success after a prior failure" {
+  MOCK_LDAPSEARCH_FAIL=1 domain_backup "example.com" "(objectclass=zimbraDomain)"
+  [ "$ERRCODE" -eq 1 ]
+  MOCK_LDAPSEARCH_FAIL=0
+  domain_backup "example.com" "(objectclass=zimbraDomain)"
+  [ "$ERRCODE" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# domain_restore — multi-component and hyphenated domains
+# ---------------------------------------------------------------------------
+
+@test "domain_restore: three-level domain restored successfully" {
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: dc=sub,dc=example,dc=com\nobjectClass: dcObject\n" \
+    > "${WORKDIR}/${session}/sub.example.com.ldiff"
+  MOCK_LDAPADD_FAIL=0
+  run domain_restore "$session" "sub.example.com"
+  [ "$status" -eq 0 ]
+}
+
+@test "domain_restore: domain with hyphen restored successfully" {
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: dc=my-domain,dc=com\nobjectClass: dcObject\n" \
+    > "${WORKDIR}/${session}/my-domain.com.ldiff"
+  MOCK_LDAPADD_FAIL=0
+  run domain_restore "$session" "my-domain.com"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# domain_restore — logging
+# ---------------------------------------------------------------------------
+
+@test "domain_restore: logs info when domain already exists in LDAP" {
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: dc=example,dc=com\nobjectClass: dcObject\n" \
+    > "${WORKDIR}/${session}/example.com.ldiff"
+  MOCK_LDAPADD_EXISTS=1
+  # Use `run` so set -e does not abort when ERR=$(ldapadd...) exits 68 internally
+  run domain_restore "$session" "example.com"
+  [ "$status" -eq 0 ]
+  grep -q "\[local7.info\].*already exists" "$LOGFILE"
+}
+
+# ---------------------------------------------------------------------------
+# domain_restore — error output
+# ---------------------------------------------------------------------------
+
+@test "domain_restore: error output contains domain name when ldapadd fails" {
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  printf "dn: dc=example,dc=com\nobjectClass: dcObject\n" \
+    > "${WORKDIR}/${session}/example.com.ldiff"
+  MOCK_LDAPADD_FAIL=1
+  run domain_restore "$session" "example.com"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"example.com"* ]]
+}
+
+@test "domain_restore: error output describes missing DN when ldiff has no dn: line" {
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  echo "objectClass: dcObject" > "${WORKDIR}/${session}/example.com.ldiff"
+  run domain_restore "$session" "example.com"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Could not extract DN"* ]]
+}

--- a/tests/unit/test_notify.bats
+++ b/tests/unit/test_notify.bats
@@ -1,0 +1,188 @@
+#!/usr/bin/env bats
+
+load '../setup'
+
+setup() {
+  setup_mock_path
+  create_workdir
+  load_test_config
+  stub_all_temps
+  source "${LIB_DIR}/NotifyAction.sh"
+}
+
+teardown() {
+  unset STYPE SESSION
+  cleanup_temps
+  destroy_workdir
+}
+
+# ---------------------------------------------------------------------------
+# notify_begin — email content verification
+# ---------------------------------------------------------------------------
+
+@test "notify_begin: email subject contains the session name" {
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  notify_begin "full-20240101120000" "Full Account"
+  grep -q "full-20240101120000" "$MESSAGE"
+}
+
+@test "notify_begin: email body contains the backup type" {
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  notify_begin "full-20240101120000" "Full Account"
+  grep -q "Full Account" "$MESSAGE"
+}
+
+@test "notify_begin: invokes sendmail with -f EMAIL_SENDER flag" {
+  ENABLE_EMAIL_NOTIFY="all"
+  EMAIL_SENDER="from@example.com"
+  sendmail() {
+    printf '%s\n' "$@" > "${WORKDIR}/sendmail_args.txt"
+    cat > /dev/null
+  }
+  export -f sendmail
+  notify_begin "full-20240101120000" "Full Account"
+  grep -q "from@example.com" "${WORKDIR}/sendmail_args.txt"
+}
+
+@test "notify_begin: invokes sendmail with EMAIL_NOTIFY as recipient" {
+  ENABLE_EMAIL_NOTIFY="all"
+  EMAIL_NOTIFY="admin@example.com"
+  sendmail() {
+    printf '%s\n' "$@" > "${WORKDIR}/sendmail_args.txt"
+    cat > /dev/null
+  }
+  export -f sendmail
+  notify_begin "full-20240101120000" "Full Account"
+  grep -q "admin@example.com" "${WORKDIR}/sendmail_args.txt"
+}
+
+@test "notify_begin: logs at info level when sendmail succeeds" {
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  notify_begin "full-20240101120000" "Full Account"
+  grep -q "\[local7.info\].*Mail sent" "$LOGFILE"
+}
+
+@test "notify_begin: does not invoke sendmail when ENABLE_EMAIL_NOTIFY is empty" {
+  ENABLE_EMAIL_NOTIFY=""
+  sendmail() {
+    echo "CALLED" > "${WORKDIR}/sendmail_called.txt"
+    cat > /dev/null
+  }
+  export -f sendmail
+  notify_begin "full-20240101120000" "Full Account"
+  [ ! -f "${WORKDIR}/sendmail_called.txt" ]
+}
+
+@test "notify_begin: does not invoke sendmail when ENABLE_EMAIL_NOTIFY is unknown value" {
+  ENABLE_EMAIL_NOTIFY="never"
+  sendmail() {
+    echo "CALLED" > "${WORKDIR}/sendmail_called.txt"
+    cat > /dev/null
+  }
+  export -f sendmail
+  notify_begin "full-20240101120000" "Full Account"
+  [ ! -f "${WORKDIR}/sendmail_called.txt" ]
+}
+
+# ---------------------------------------------------------------------------
+# notify_finish — email content verification
+# ---------------------------------------------------------------------------
+
+@test "notify_finish: email subject contains SUCCESS when backup succeeded" {
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  notify_finish "$session" "Full Account" "SUCCESS"
+  grep -q "SUCCESS" "$MESSAGE"
+}
+
+@test "notify_finish: email subject contains FAILURE when backup failed" {
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  notify_finish "full-20240101120000" "Full Account" "FAILURE"
+  grep -q "FAILURE" "$MESSAGE"
+}
+
+@test "notify_finish: email body contains session name" {
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  notify_finish "$session" "Full Account" "SUCCESS"
+  grep -q "full-20240101120000" "$MESSAGE"
+}
+
+@test "notify_finish: email body contains backup type" {
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  notify_finish "$session" "Full Account" "FAILURE"
+  grep -q "Full Account" "$MESSAGE"
+}
+
+@test "notify_finish: TEMPSESSION summary content is appended to message body" {
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  echo "SummaryLine42" > "$TEMPSESSION"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  notify_finish "$session" "Full Account" "SUCCESS"
+  grep -q "SummaryLine42" "$MESSAGE"
+}
+
+@test "notify_finish: logs at info level when sendmail succeeds" {
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  notify_finish "$session" "Full Account" "SUCCESS"
+  grep -q "\[local7.info\].*Mail sent" "$LOGFILE"
+}
+
+@test "notify_finish: invokes sendmail with -f EMAIL_SENDER flag" {
+  ENABLE_EMAIL_NOTIFY="all"
+  EMAIL_SENDER="from@example.com"
+  sendmail() {
+    printf '%s\n' "$@" > "${WORKDIR}/sendmail_args.txt"
+    cat > /dev/null
+  }
+  export -f sendmail
+  notify_finish "full-20240101120000" "Full Account" "FAILURE"
+  grep -q "from@example.com" "${WORKDIR}/sendmail_args.txt"
+}
+
+@test "notify_finish: succeeds for domain- session type on SUCCESS" {
+  local session="domain-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  touch "${WORKDIR}/${session}/example.com.ldiff"
+  touch "${WORKDIR}/${session}/test.com.ldiff"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  run notify_finish "$session" "Domain" "SUCCESS"
+  [ "$status" -eq 0 ]
+}
+
+@test "notify_finish: succeeds for distlist- session type on SUCCESS" {
+  local session="distlist-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  touch "${WORKDIR}/${session}/list@example.com.ldiff"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  run notify_finish "$session" "Distribution List" "SUCCESS"
+  [ "$status" -eq 0 ]
+}
+
+@test "notify_finish: succeeds for signature- session type on SUCCESS" {
+  local session="signature-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  touch "${WORKDIR}/${session}/user@example.com.ldiff"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  run notify_finish "$session" "Signature" "SUCCESS"
+  [ "$status" -eq 0 ]
+}

--- a/tests/unit/test_parallel_edge.bats
+++ b/tests/unit/test_parallel_edge.bats
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats
+
+load '../setup'
+
+setup() {
+  setup_mock_path
+  create_workdir
+  load_test_config
+  stub_all_temps
+  source "${LIB_DIR}/ParallelAction.sh"
+  export MOCK_LDAPSEARCH_FAIL=0
+  export MOCK_ZMMAILBOX_FAIL=0
+  export MOCK_ZMMAILBOX_EMPTY=0
+  export MOCK_LDAPADD_FAIL=0
+
+  # Use a controlled temp file as the blockedlist for all ldap_filter tests
+  BLOCKEDLIST="$(mktemp)"
+  export ZMBACKUP_BLOCKEDLIST="$BLOCKEDLIST"
+  LOCK_BACKUP="false"
+}
+
+teardown() {
+  unset STYPE SESSION
+  cleanup_temps
+  destroy_workdir
+  rm -f "${BLOCKEDLIST:-}"
+  unset ZMBACKUP_BLOCKEDLIST
+}
+
+# ---------------------------------------------------------------------------
+# ldap_filter — special characters in email addresses
+# ---------------------------------------------------------------------------
+
+@test "ldap_filter: email with plus sign is added to TEMPACCOUNT" {
+  ldap_filter "user+tag@example.com"
+  grep -qx "user+tag@example.com" "$TEMPACCOUNT"
+}
+
+@test "ldap_filter: email with multiple dots in local part is added to TEMPACCOUNT" {
+  ldap_filter "first.last.name@example.com"
+  grep -qx "first.last.name@example.com" "$TEMPACCOUNT"
+}
+
+@test "ldap_filter: email with hyphen in domain is added to TEMPACCOUNT" {
+  ldap_filter "user@my-domain.com"
+  grep -qx "user@my-domain.com" "$TEMPACCOUNT"
+}
+
+@test "ldap_filter: blocked email with plus sign is not added to TEMPACCOUNT" {
+  echo "user+tag@example.com" >> "$BLOCKEDLIST"
+  ldap_filter "user+tag@example.com"
+  run grep -qx "user+tag@example.com" "$TEMPACCOUNT"
+  [ "$status" -ne 0 ]
+}
+
+@test "ldap_filter: only unblocked accounts are added when processing a mixed list" {
+  echo "blocked@example.com" >> "$BLOCKEDLIST"
+  ldap_filter "blocked@example.com"
+  ldap_filter "allowed@example.com"
+  grep -qx "allowed@example.com" "$TEMPACCOUNT"
+  run grep -qx "blocked@example.com" "$TEMPACCOUNT"
+  [ "$status" -ne 0 ]
+}
+
+@test "ldap_filter: ZMBACKUP_BLOCKEDLIST env var is honored over the default path" {
+  local custom_list
+  custom_list="$(mktemp)"
+  echo "targeted@example.com" >> "$custom_list"
+  ZMBACKUP_BLOCKEDLIST="$custom_list"
+  ldap_filter "targeted@example.com"
+  run grep -qx "targeted@example.com" "$TEMPACCOUNT"
+  [ "$status" -ne 0 ]
+  rm -f "$custom_list"
+}
+
+@test "ldap_filter: account is added to TEMPACCOUNT when blockedlist file does not exist" {
+  ZMBACKUP_BLOCKEDLIST="/nonexistent/path/blockedlist.conf"
+  ldap_filter "user@example.com"
+  grep -qx "user@example.com" "$TEMPACCOUNT"
+}
+
+@test "ldap_filter: multiple consecutive calls accumulate accounts in TEMPACCOUNT" {
+  local i
+  for i in 1 2 3 4 5; do
+    ldap_filter "user${i}@example.com"
+  done
+  [ "$(wc -l < "$TEMPACCOUNT")" -eq 5 ]
+}
+
+# ---------------------------------------------------------------------------
+# ldap_filter — large account list handling
+# ---------------------------------------------------------------------------
+
+@test "ldap_filter: correctly processes 50 accounts without corruption" {
+  local i
+  for i in $(seq 1 50); do
+    ldap_filter "user${i}@example.com"
+  done
+  [ "$(wc -l < "$TEMPACCOUNT")" -eq 50 ]
+  grep -qx "user1@example.com" "$TEMPACCOUNT"
+  grep -qx "user50@example.com" "$TEMPACCOUNT"
+}
+
+# ---------------------------------------------------------------------------
+# mailbox_backup — special characters in email addresses
+# ---------------------------------------------------------------------------
+
+@test "mailbox_backup: email with plus sign creates correct tgz filename" {
+  INC="FALSE"
+  mailbox_backup "user+tag@example.com"
+  [ -f "${TEMPDIR}/user+tag@example.com.tgz" ]
+}
+
+@test "mailbox_backup: email with dots in local part creates correct tgz filename" {
+  INC="FALSE"
+  mailbox_backup "first.last@example.com"
+  [ -f "${TEMPDIR}/first.last@example.com.tgz" ]
+}
+
+# ---------------------------------------------------------------------------
+# ldap_backup — special characters in email addresses
+# ---------------------------------------------------------------------------
+
+@test "ldap_backup: email with plus sign creates correct ldiff filename" {
+  ldap_backup "user+tag@example.com" "(objectclass=zimbraAccount)"
+  [ -f "${TEMPDIR}/user+tag@example.com.ldiff" ]
+}
+
+@test "ldap_backup: email with dots in local part creates correct ldiff filename" {
+  ldap_backup "first.last@example.com" "(objectclass=zimbraAccount)"
+  [ -f "${TEMPDIR}/first.last@example.com.ldiff" ]
+}
+
+# ---------------------------------------------------------------------------
+# PID lock — concurrent invocation simulation
+# ---------------------------------------------------------------------------
+
+@test "checkpid: blocks when a separately launched process already holds the lock" {
+  local pid_file
+  pid_file="$(mktemp)"
+  # Start a background process whose PID is guaranteed alive during this test
+  sleep 30 &
+  local bg_pid=$!
+  echo "$bg_pid" > "$pid_file"
+  PID="$pid_file"
+  run checkpid
+  kill "$bg_pid" 2>/dev/null
+  wait "$bg_pid" 2>/dev/null || true
+  rm -f "$pid_file"
+  [ "$status" -eq 4 ]
+  [[ "$output" == *"already exist"* ]]
+}


### PR DESCRIPTION
Add four new BATS test files covering areas identified in issue #232:

- test_notify.bats (17 tests): verifies sendmail invocation args (-f flag, recipient), email body/subject content, info-level logging on success, session types (domain-, distlist-, signature-), and guard against sending when ENABLE_EMAIL_NOTIFY is empty or an unknown value.

- test_domain.bats (12 tests): covers multi-component (3-level) and hyphenated domains for both backup and restore, info/error log messages, ERRCODE reset behaviour, and descriptive error output on failure.

- test_parallel_edge.bats (14 tests): special characters in email addresses (plus sign, dots, hyphens), ZMBACKUP_BLOCKEDLIST env-var override, missing blockedlist file, mixed blocked/allowed lists, large account lists (50 accounts), filename correctness for ldap_backup/mailbox_backup, and a concurrent PID-lock simulation using a live background process.

- test_config.bats (14 tests): ZMBACKUP_BLOCKEDLIST default and override via conf, conf-variable sourcing, valid non-default config values (SQLITE3, false, 0, none, paths with spaces), multiple missing fields all reported before exit 3, and log warnings emitted for each defaulted setting.