### PR TITLE
fix: treat any non-zero exit code as FAILURE in on_exit trap

### DIFF
--- a/project/lib/bash/MiscAction.sh
+++ b/project/lib/bash/MiscAction.sh
@@ -122,9 +122,9 @@ function session_query() {
 function on_exit(){
   BASHERRCODE=$?
   if [[ -n $STYPE ]]; then
-    if [[ $BASHERRCODE -eq 1 ]]; then
+    if [[ $BASHERRCODE -ne 0 ]]; then
       notify_finish "$SESSION" "$STYPE" "FAILURE"
-    elif [[ $BASHERRCODE -eq 0 && -n $SESSION ]]; then
+    elif [[ -n $SESSION ]]; then
       notify_finish "$SESSION" "$STYPE" "SUCCESS"
     fi
   fi


### PR DESCRIPTION
Previously only exit code 1 triggered a FAILURE notification; codes 2-5 and 255 (from GNU Parallel signal kills) fell through to the SUCCESS branch. Now any non-zero exit sends FAILURE, matching the intent of the trap.
