### PR TITLE
fix: omit AFTER filter for new accounts with no prior incremental bac…

### DIFF
--- a/project/lib/bash/ParallelAction.sh
+++ b/project/lib/bash/ParallelAction.sh
@@ -46,8 +46,12 @@ function mailbox_backup()
     DATE=$(session_query \
       "select MAX(initial_date) from backup_account where email='${SAFE_EMAIL}' and (sessionID like 'full%' or sessionID like 'inc%' or sessionID like 'mbox%')" \
       "grep \"$1\" \"$WORKDIR\"/sessions.txt | tail -1 | awk -F: '{print \$3}' | cut -d- -f2")
-    YESTERDAY=$(date -d "$DATE" --date='-48 hours' +%m/%d/%Y)
-    AFTER='&'"query=after:\"$YESTERDAY\""
+    if [[ -n "$DATE" ]]; then
+      YESTERDAY=$(date -d "$DATE" --date='-48 hours' +%m/%d/%Y)
+      AFTER='&'"query=after:\"$YESTERDAY\""
+    else
+      AFTER=''
+    fi
   fi
   if $ZMMAILBOX -t0 -z -m "$1" getRestURL --output "$TEMPDIR"/"$1".tgz "/?fmt=tgz&resolve=skip$AFTER" > "$TEMP_CLI_OUTPUT" 2>&1; then
     if [[ -s $TEMPDIR/$1.tgz ]]; then

--- a/tests/unit/test_ParallelAction.bats
+++ b/tests/unit/test_ParallelAction.bats
@@ -102,6 +102,52 @@ teardown() {
   ! grep -q "\[local7.err\]" "${LOGFILE}"
 }
 
+@test "mailbox_backup: incremental with no prior backup performs full pull (TXT mode)" {
+  INC="TRUE"
+  SESSION_TYPE="TXT"
+  # sessions.txt has no entry for new@example.com — DATE will be empty
+  MOCK_ZMMAILBOX_FAIL=0
+  MOCK_ZMMAILBOX_EMPTY=0
+  # Capture the URL argument passed to zmmailbox
+  zmmailbox() {
+    for arg in "$@"; do
+      echo "$arg" >> "${WORKDIR}/zmmailbox_args.txt"
+    done
+    echo "mock tgz content" > "${TEMPDIR}/new@example.com.tgz"
+    return 0
+  }
+  export -f zmmailbox
+  mailbox_backup "new@example.com"
+  [ "$ERRCODE" -eq 0 ]
+  # The URL must NOT contain an 'after:' date filter
+  run grep -q "after:" "${WORKDIR}/zmmailbox_args.txt"
+  [ "$status" -ne 0 ]
+}
+
+@test "mailbox_backup: incremental with no prior backup performs full pull (SQLITE3 mode)" {
+  INC="TRUE"
+  SESSION_TYPE="SQLITE3"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
+  # DB has a session but NO backup_account row for new@example.com — DATE will be empty
+  sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "insert into backup_session values('full-20240101120000','2024-01-01T12:00:00.000',
+     '2024-01-01T12:30:00.000','100M','Full Backup','FINISHED')"
+  MOCK_ZMMAILBOX_FAIL=0
+  MOCK_ZMMAILBOX_EMPTY=0
+  zmmailbox() {
+    for arg in "$@"; do
+      echo "$arg" >> "${WORKDIR}/zmmailbox_args.txt"
+    done
+    echo "mock tgz content" > "${TEMPDIR}/new@example.com.tgz"
+    return 0
+  }
+  export -f zmmailbox
+  mailbox_backup "new@example.com"
+  [ "$ERRCODE" -eq 0 ]
+  run grep -q "after:" "${WORKDIR}/zmmailbox_args.txt"
+  [ "$status" -ne 0 ]
+}
+
 @test "mailbox_backup: incremental with TXT session reads date from sessions.txt" {
   INC="TRUE"
   SESSION_TYPE="TXT"


### PR DESCRIPTION
…kup (issue #241)

When DATE is empty (account never backed up before), skip the -48h AFTER filter so zmmailbox fetches all mail instead of silently discarding anything older than 48 hours. Two new unit tests cover both TXT and SQLITE3 session modes.