### PR TITLE
fix: capture parallel exit code and record FAILED status on job failu…

### DIFF
--- a/project/lib/bash/BackupAction.sh
+++ b/project/lib/bash/BackupAction.sh
@@ -25,6 +25,7 @@ function __backupFullInc(){
         "echo \"$SESSION:$1:$(date +%m/%d/%y)\" >> \"$TEMPSESSION\""
     fi
   fi
+  return "$ERRCODE"
 }
 
 ################################################################################
@@ -49,6 +50,7 @@ function __backupLdap(){
       "insert into backup_account (email,sessionID,account_size,initial_date,conclusion_date) values ('${SAFE_EMAIL}','$SESSION','$SIZE','$SDATE','$EDATE');" \
       "echo \"$SESSION:$1:$(date +%m/%d/%y)\" >> \"$TEMPSESSION\""
   fi
+  return "$ERRCODE"
 }
 
 ################################################################################
@@ -69,6 +71,7 @@ function __backupDomain(){
       "insert into backup_account (email,sessionID,account_size,initial_date,conclusion_date) values ('${SAFE_EMAIL}','$SESSION','$SIZE','$SDATE','$EDATE');" \
       "echo \"$SESSION:$1:$(date +%m/%d/%y)\" >> \"$TEMPSESSION\""
   fi
+  return "$ERRCODE"
 }
 
 ################################################################################
@@ -90,6 +93,7 @@ function __backupMailbox(){
       "insert into backup_account (email,sessionID,account_size,initial_date,conclusion_date) values ('${SAFE_EMAIL}','$SESSION','$SIZE','$SDATE','$EDATE');" \
       "echo \"$SESSION:$1:$(date +%m/%d/%y)\" >> \"$TEMPSESSION\""
   fi
+  return "$ERRCODE"
 }
 
 ################################################################################
@@ -141,12 +145,18 @@ function backup_main()
     else
       parallel --jobs "$MAX_PARALLEL_PROCESS" "__backupLdap '{}' '$1'" < "$TEMPACCOUNT"
     fi
+    PARALLEL_EXIT=$?
     mv "$TEMPDIR" "$WORKDIR/$SESSION" && rm -rf "$TEMPDIR"
     chmod -R 775 "$WORKDIR"/"$SESSION"
     DATE=$(date +%Y-%m-%dT%H:%M:%S.%N)
     SIZE=$(du -sh "$WORKDIR"/"$SESSION" | awk '{print $1}')
+    if [[ $PARALLEL_EXIT -eq 0 ]]; then
+      STATUS="FINISHED"
+    else
+      STATUS="FAILED"
+    fi
     session_query \
-      "update backup_session set conclusion_date='$DATE',size='$SIZE',status='FINISHED' where sessionID='$SESSION'" \
+      "update backup_session set conclusion_date='$DATE',size='$SIZE',status='$STATUS' where sessionID='$SESSION'" \
       "echo \"SESSION: $SESSION completed in $(date)\" >> \"$TEMPSESSION\"; cat \"$TEMPSESSION\" >> \"$WORKDIR\"/sessions.txt"
     zmlog local7.info "Zmbackup: Backup session $SESSION finished on $(date)"
     echo "Backup session $SESSION finished on $(date)"

--- a/tests/unit/test_BackupAction.bats
+++ b/tests/unit/test_BackupAction.bats
@@ -78,7 +78,7 @@ teardown() {
   SESSION="full-20240101120000"
   SESSION_TYPE="TXT"
   MOCK_LDAPSEARCH_FAIL=1
-  __backupFullInc "user@example.com" "$ACOBJECT"
+  __backupFullInc "user@example.com" "$ACOBJECT" || true
   run grep -q "user@example.com" "$TEMPSESSION"
   [ "$status" -ne 0 ]
 }
@@ -88,7 +88,7 @@ teardown() {
   SESSION_TYPE="TXT"
   MOCK_LDAPSEARCH_FAIL=0
   MOCK_ZMMAILBOX_FAIL=1
-  __backupFullInc "user@example.com" "$ACOBJECT"
+  __backupFullInc "user@example.com" "$ACOBJECT" || true
   run grep -q "user@example.com" "$TEMPSESSION"
   [ "$status" -ne 0 ]
 }
@@ -121,7 +121,7 @@ teardown() {
   SESSION="alias-20240101120000"
   SESSION_TYPE="TXT"
   MOCK_LDAPSEARCH_FAIL=1
-  __backupLdap "alias@example.com" "(objectclass=zimbraAlias)"
+  __backupLdap "alias@example.com" "(objectclass=zimbraAlias)" || true
   run grep -q "alias@example.com" "$TEMPSESSION"
   [ "$status" -ne 0 ]
 }
@@ -154,7 +154,7 @@ teardown() {
   SESSION="domain-20240101120000"
   SESSION_TYPE="TXT"
   MOCK_LDAPSEARCH_FAIL=1
-  __backupDomain "example.com" "(objectclass=zimbraDomain)"
+  __backupDomain "example.com" "(objectclass=zimbraDomain)" || true
   run grep -q "example.com" "$TEMPSESSION"
   [ "$status" -ne 0 ]
 }
@@ -192,7 +192,7 @@ teardown() {
   SESSION_TYPE="TXT"
   INC="FALSE"
   MOCK_ZMMAILBOX_FAIL=1
-  __backupMailbox "user@example.com" "$ACOBJECT"
+  __backupMailbox "user@example.com" "$ACOBJECT" || true
   run grep -q "user@example.com" "$TEMPSESSION"
   [ "$status" -ne 0 ]
 }
@@ -370,4 +370,76 @@ teardown() {
   local count
   count=$(sqlite3 "${WORKDIR}/sessions.sqlite3" "select count(*) from backup_session")
   [ "$count" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# backup_main: parallel exit code → session status
+# ---------------------------------------------------------------------------
+
+@test "backup_main: records FINISHED in SQLITE3 mode when all parallel jobs succeed" {
+  SESSION="full-20240101120000"
+  STYPE="Full Account"
+  SESSION_TYPE="SQLITE3"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
+  MOCK_LDAPSEARCH_FAIL=0
+  MOCK_ZMMAILBOX_FAIL=0
+  MOCK_ZMMAILBOX_EMPTY=0
+  backup_main "$ACOBJECT" "$ACFILTER" "-a" "user@example.com"
+  local status_val
+  status_val=$(sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "select status from backup_session where sessionID='full-20240101120000'")
+  [ "$status_val" = "FINISHED" ]
+}
+
+@test "backup_main: records FAILED in SQLITE3 mode when parallel jobs fail (full session)" {
+  SESSION="full-20240101120000"
+  STYPE="Full Account"
+  SESSION_TYPE="SQLITE3"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
+  MOCK_LDAPSEARCH_FAIL=1
+  run backup_main "$ACOBJECT" "$ACFILTER" "-a" "user@example.com"
+  local status_val
+  status_val=$(sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "select status from backup_session where sessionID='full-20240101120000'")
+  [ "$status_val" = "FAILED" ]
+}
+
+@test "backup_main: records FAILED in SQLITE3 mode when parallel jobs fail (mbox session)" {
+  SESSION="mbox-20240101120000"
+  STYPE="Mailbox"
+  SESSION_TYPE="SQLITE3"
+  INC="FALSE"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
+  MOCK_ZMMAILBOX_FAIL=1
+  run backup_main "$ACOBJECT" "$ACFILTER" "-a" "user@example.com"
+  local status_val
+  status_val=$(sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "select status from backup_session where sessionID='mbox-20240101120000'")
+  [ "$status_val" = "FAILED" ]
+}
+
+@test "backup_main: records FAILED in SQLITE3 mode when parallel jobs fail (domain session)" {
+  SESSION="domain-20240101120000"
+  STYPE="Domain"
+  SESSION_TYPE="SQLITE3"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
+  MOCK_LDAPSEARCH_FAIL=1
+  run backup_main "$DOMOBJECT" "$DOMFILTER" "-a" "example.com"
+  local status_val
+  status_val=$(sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "select status from backup_session where sessionID='domain-20240101120000'")
+  [ "$status_val" = "FAILED" ]
+}
+
+@test "backup_main: records FAILED in SQLITE3 mode when parallel jobs fail (ldap/alias session)" {
+  SESSION="alias-20240101120000"
+  STYPE="Alias"
+  SESSION_TYPE="SQLITE3"
+  sqlite3 "${WORKDIR}/sessions.sqlite3" < "${PROJECT_ROOT}/project/lib/sqlite3/database.sql"
+  MOCK_LDAPSEARCH_FAIL=1
+  run backup_main "(objectclass=zimbraAlias)" "uid" "-a" "alias@example.com"
+  local status_val
+  status_val=$(sqlite3 "${WORKDIR}/sessions.sqlite3" \
+    "select status from backup_session where sessionID='alias-20240101120000'")
+  [ "$status_val" = "FAILED" ]
 }


### PR DESCRIPTION
…res (issue #239)

`backup_main` previously discarded the exit code from every `parallel` call and unconditionally marked sessions as FINISHED.  If any backup job failed, GNU parallel exits non-zero but the failure was silently ignored.

Fix in two parts:
1. `__backupFullInc`, `__backupLdap`, `__backupDomain`, and `__backupMailbox` now `return "$ERRCODE"` so that individual job failures propagate as a non-zero exit code to `parallel`.
2. `backup_main` captures `PARALLEL_EXIT=$?` after the parallel block and sets the session status to `FAILED` when non-zero, or `FINISHED` when zero.

Five new SQLITE3-mode tests verify the FINISHED/FAILED paths for all four session types (full, mbox, domain, ldap/alias).  Existing "does not write record" tests updated with `|| true` to acknowledge the now-correct non-zero return from backup helper functions.