### PR TITLE
fix: use find -name to avoid glob expansion bug in notify_finish

### DIFF
--- a/project/lib/bash/NotifyAction.sh
+++ b/project/lib/bash/NotifyAction.sh
@@ -49,9 +49,9 @@ function notify_finish()
       BASHERRCODE=$?
       if [[ $BASHERRCODE -eq 0 ]]; then
         if [[ "$1" == "mbox"* ]]; then
-          QTDE=$(find "$WORKDIR"/"$1"/*.tgz | wc -l)
+          QTDE=$(find "$WORKDIR/$1" -name "*.tgz" | wc -l)
         else
-          QTDE=$(find "$WORKDIR"/"$1"/*.ldiff | wc -l)
+          QTDE=$(find "$WORKDIR/$1" -name "*.ldiff" | wc -l)
         fi
       else
         SIZE=0

--- a/tests/unit/test_NotifyAction.bats
+++ b/tests/unit/test_NotifyAction.bats
@@ -152,6 +152,67 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "notify_finish: reports zero count and no error when mbox session dir has no .tgz files" {
+  local session="mbox-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  run notify_finish "$session" "Mailbox" "SUCCESS"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "notify_finish: reports zero count and no error when non-mbox session dir has no .ldiff files" {
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  run notify_finish "$session" "Full Account" "SUCCESS"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "notify_finish: email reports Accounts: 0 when mbox session dir has no .tgz files" {
+  local session="mbox-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  notify_finish "$session" "Mailbox" "SUCCESS"
+  grep -q "Accounts: 0" "$MESSAGE"
+}
+
+@test "notify_finish: email reports Accounts: 0 when non-mbox session dir has no .ldiff files" {
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  notify_finish "$session" "Full Account" "SUCCESS"
+  grep -q "Accounts: 0" "$MESSAGE"
+}
+
+@test "notify_finish: email reports correct count for multiple .tgz files in mbox session" {
+  local session="mbox-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  touch "${WORKDIR}/${session}/user1@example.com.tgz"
+  touch "${WORKDIR}/${session}/user2@example.com.tgz"
+  touch "${WORKDIR}/${session}/user3@example.com.tgz"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  notify_finish "$session" "Mailbox" "SUCCESS"
+  grep -q "Accounts: 3" "$MESSAGE"
+}
+
+@test "notify_finish: email reports correct count for multiple .ldiff files in non-mbox session" {
+  local session="full-20240101120000"
+  mkdir -p "${WORKDIR}/${session}"
+  touch "${WORKDIR}/${session}/user1@example.com.ldiff"
+  touch "${WORKDIR}/${session}/user2@example.com.ldiff"
+  ENABLE_EMAIL_NOTIFY="all"
+  MOCK_SENDMAIL_FAIL=0
+  notify_finish "$session" "Full Account" "SUCCESS"
+  grep -q "Accounts: 2" "$MESSAGE"
+}
+
 @test "notify_finish: succeeds even when sendmail fails" {
   local session="full-20240101120000"
   mkdir -p "${WORKDIR}/${session}"


### PR DESCRIPTION
When the session directory exists but contains zero matching files, bash expands globs before find runs. With no matches and nullglob unset, the literal glob string is passed to find as a path, causing find to print an error to stderr and produce no stdout — silently yielding a wrong count.

Switch both find calls in notify_finish to use -name so find handles the pattern internally, correctly returning 0 when no files match.

Closes #243
