### PR TITLE
security: escape session ID with safe_sql_value in restore/delete fun…

### DIFF
--- a/project/lib/bash/DeleteAction.sh
+++ b/project/lib/bash/DeleteAction.sh
@@ -10,8 +10,10 @@
 ################################################################################
 function delete_one(){
   local RETCODE=0
+  local SAFE_SESSION
+  SAFE_SESSION=$(safe_sql_value "$1")
   SESSION=$(session_query \
-    "select sessionID from backup_session where sessionID='$1'" \
+    "select sessionID from backup_session where sessionID='${SAFE_SESSION}'" \
     "grep '$1 started' \"$WORKDIR\"/sessions.txt -m 1 | awk '{print \$2}'")
   if [ -n "$SESSION" ]; then
     echo "Removing session $1 - please wait."

--- a/project/lib/bash/RestoreAction.sh
+++ b/project/lib/bash/RestoreAction.sh
@@ -12,8 +12,10 @@
 ################################################################################
 function restore_main_mailbox()
 {
+  local SAFE_SESSION
+  SAFE_SESSION=$(safe_sql_value "$1")
   SESSION=$(session_query \
-    "select * from backup_session where sessionID='$1'" \
+    "select * from backup_session where sessionID='${SAFE_SESSION}'" \
     "grep -E ': $1 started' \"$WORKDIR\"/sessions.txt | grep 'started' | awk '{print \$2}' | sort | uniq")
   if [ -n "$SESSION" ]; then
     printf "Restore mail process with session %s started at %s" "$1" "$(date)"
@@ -77,8 +79,10 @@ function restore_main_mailbox()
 ################################################################################
 function restore_main_domain()
 {
+  local SAFE_SESSION
+  SAFE_SESSION=$(safe_sql_value "$1")
   SESSION=$(session_query \
-    "select * from backup_session where sessionID='$1'" \
+    "select * from backup_session where sessionID='${SAFE_SESSION}'" \
     "grep -E ': $1 started' \"$WORKDIR\"/sessions.txt | grep 'started' | awk '{print \$2}' | sort | uniq")
   if [ -n "$SESSION" ]; then
     echo "Restore Domain LDAP process with session $1 started at $(date)"
@@ -111,8 +115,10 @@ function restore_main_domain()
 ################################################################################
 function restore_main_ldap()
 {
+  local SAFE_SESSION
+  SAFE_SESSION=$(safe_sql_value "$1")
   SESSION=$(session_query \
-    "select * from backup_session where sessionID='$1'" \
+    "select * from backup_session where sessionID='${SAFE_SESSION}'" \
     "grep -E ': $1 started' \"$WORKDIR\"/sessions.txt | grep 'started' | awk '{print \$2}' | sort | uniq")
   if [ -n "$SESSION" ]; then
     echo "Restore LDAP process with session $1 started at $(date)"


### PR DESCRIPTION
…ctions

restore_main_mailbox, restore_main_domain, restore_main_ldap, and delete_one embedded $1 directly into SQL strings, relying on the zmbackup dispatcher's validate_session_id for protection. Any caller that invokes these library functions directly (tests, wrapper scripts) had no guard against SQL injection.

Fixes #247