### PR TITLE
Add core domain records and enums

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,17 @@ jobs:
           name: Run unit tests
           command: npx bats --verbose-run tests/unit/
 
+  test-java:
+    docker:
+      - image: cimg/openjdk:21.0
+    steps:
+      - checkout
+      - run:
+          name: Run Java tests
+          command: ./gradlew test
+
 workflows:
   test-workflow:
     jobs:
       - test
+      - test-java

--- a/core/src/main/java/io/zmbackup/core/domain/BackupAccountRecord.java
+++ b/core/src/main/java/io/zmbackup/core/domain/BackupAccountRecord.java
@@ -1,0 +1,31 @@
+package io.zmbackup.core.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A single account's backup within a session, mirroring the {@code backup_account} table in
+ * {@code sessions.sqlite3}.
+ *
+ * @param id           row ID, or {@code null} before the record has been persisted
+ * @param sessionId    the {@link BackupSession#sessionId()} this account backup belongs to
+ * @param email        the account's email address
+ * @param size         human-readable size of the backed-up data (e.g. {@code "10M"})
+ * @param startedAt    when this account's backup started
+ * @param completedAt  when this account's backup finished, or {@code null} while still in progress
+ */
+public record BackupAccountRecord(
+        Long id,
+        String sessionId,
+        String email,
+        String size,
+        Instant startedAt,
+        Instant completedAt) {
+
+    public BackupAccountRecord {
+        Objects.requireNonNull(sessionId, "sessionId must not be null");
+        Objects.requireNonNull(email, "email must not be null");
+        Objects.requireNonNull(size, "size must not be null");
+        Objects.requireNonNull(startedAt, "startedAt must not be null");
+    }
+}

--- a/core/src/main/java/io/zmbackup/core/domain/BackupSession.java
+++ b/core/src/main/java/io/zmbackup/core/domain/BackupSession.java
@@ -1,0 +1,30 @@
+package io.zmbackup.core.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A single backup run, mirroring the {@code backup_session} table in {@code sessions.sqlite3}.
+ *
+ * @param sessionId    unique session identifier, e.g. {@code "full-20260101120000"}
+ * @param type         the kind of backup that was run
+ * @param status       the session's current lifecycle state
+ * @param startedAt    when the session started
+ * @param completedAt  when the session finished, or {@code null} while still in progress
+ * @param size         human-readable total size (e.g. {@code "10M"}), or {@code null} until complete
+ */
+public record BackupSession(
+        String sessionId,
+        BackupType type,
+        SessionStatus status,
+        Instant startedAt,
+        Instant completedAt,
+        String size) {
+
+    public BackupSession {
+        Objects.requireNonNull(sessionId, "sessionId must not be null");
+        Objects.requireNonNull(type, "type must not be null");
+        Objects.requireNonNull(status, "status must not be null");
+        Objects.requireNonNull(startedAt, "startedAt must not be null");
+    }
+}

--- a/core/src/main/java/io/zmbackup/core/domain/BackupType.java
+++ b/core/src/main/java/io/zmbackup/core/domain/BackupType.java
@@ -1,0 +1,41 @@
+package io.zmbackup.core.domain;
+
+/**
+ * The kind of backup a session performs, mirroring the bash tool's session-name prefixes
+ * (e.g. {@code full-20260101120000}) so existing session IDs stay parseable.
+ */
+public enum BackupType {
+    FULL("full", true, true),
+    INCREMENTAL("inc", true, true),
+    MAILBOX("mbox", false, true),
+    LDAP("ldap", true, false),
+    ALIAS("alias", true, false),
+    DISTRIBUTION_LIST("distlist", true, false),
+    SIGNATURE("signature", true, false),
+    DOMAIN("domain", true, false);
+
+    private final String sessionPrefix;
+    private final boolean includesLdap;
+    private final boolean includesMailbox;
+
+    BackupType(String sessionPrefix, boolean includesLdap, boolean includesMailbox) {
+        this.sessionPrefix = sessionPrefix;
+        this.includesLdap = includesLdap;
+        this.includesMailbox = includesMailbox;
+    }
+
+    /** The prefix used to build session IDs for this backup type, e.g. {@code "full"}. */
+    public String sessionPrefix() {
+        return sessionPrefix;
+    }
+
+    /** Whether this backup type exports LDAP objects (accounts, aliases, lists, signatures, domains). */
+    public boolean includesLdap() {
+        return includesLdap;
+    }
+
+    /** Whether this backup type exports mailbox content. */
+    public boolean includesMailbox() {
+        return includesMailbox;
+    }
+}

--- a/core/src/main/java/io/zmbackup/core/domain/LdapObjectType.java
+++ b/core/src/main/java/io/zmbackup/core/domain/LdapObjectType.java
@@ -1,0 +1,34 @@
+package io.zmbackup.core.domain;
+
+/**
+ * A class of Zimbra LDAP object that can be backed up, carrying the search filter and the
+ * identifying attribute the bash tool used for each (the {@code *OBJECT}/{@code *FILTER}
+ * constants in {@code MiscAction.sh}).
+ */
+public enum LdapObjectType {
+    // The bash tool narrows this to active-only accounts when BACKUP_INACTIVE_ACCOUNTS is
+    // false; that toggle is an app-level query concern, not part of the base object filter.
+    ACCOUNT("(objectclass=zimbraAccount)", "zimbraMailDeliveryAddress"),
+    DISTRIBUTION_LIST("(objectclass=zimbraDistributionList)", "mail"),
+    ALIAS("(objectclass=zimbraAlias)", "uid"),
+    SIGNATURE("(objectclass=zimbraSignature)", "zimbraSignatureName"),
+    DOMAIN("(objectclass=zimbraDomain)", "zimbraDomainName");
+
+    private final String objectFilter;
+    private final String attributeName;
+
+    LdapObjectType(String objectFilter, String attributeName) {
+        this.objectFilter = objectFilter;
+        this.attributeName = attributeName;
+    }
+
+    /** The LDAP search filter used to enumerate objects of this type. */
+    public String objectFilter() {
+        return objectFilter;
+    }
+
+    /** The LDAP attribute used to identify each object of this type. */
+    public String attributeName() {
+        return attributeName;
+    }
+}

--- a/core/src/main/java/io/zmbackup/core/domain/SessionStatus.java
+++ b/core/src/main/java/io/zmbackup/core/domain/SessionStatus.java
@@ -1,0 +1,29 @@
+package io.zmbackup.core.domain;
+
+/** The lifecycle state of a {@link BackupSession}. */
+public enum SessionStatus {
+    IN_PROGRESS("IN PROGRESS"),
+    FINISHED("FINISHED"),
+    FAILED("FAILED");
+
+    private final String dbValue;
+
+    SessionStatus(String dbValue) {
+        this.dbValue = dbValue;
+    }
+
+    /** The value stored in the {@code backup_session.status} column by the bash tool. */
+    public String dbValue() {
+        return dbValue;
+    }
+
+    /** Resolves the status matching a value previously produced by {@link #dbValue()}. */
+    public static SessionStatus fromDbValue(String dbValue) {
+        for (SessionStatus status : values()) {
+            if (status.dbValue.equals(dbValue)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown session status: " + dbValue);
+    }
+}

--- a/core/src/test/java/io/zmbackup/core/domain/BackupAccountRecordTest.java
+++ b/core/src/test/java/io/zmbackup/core/domain/BackupAccountRecordTest.java
@@ -1,0 +1,58 @@
+package io.zmbackup.core.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class BackupAccountRecordTest {
+
+    @Test
+    void unpersistedRecordHasNoId() {
+        Instant startedAt = Instant.parse("2026-01-01T12:00:00Z");
+        Instant completedAt = Instant.parse("2026-01-01T12:01:00Z");
+        BackupAccountRecord record = new BackupAccountRecord(
+                null, "full-20260101120000", "user@example.com", "1M", startedAt, completedAt);
+
+        assertNull(record.id());
+        assertEquals("full-20260101120000", record.sessionId());
+        assertEquals("user@example.com", record.email());
+        assertEquals("1M", record.size());
+        assertEquals(startedAt, record.startedAt());
+        assertEquals(completedAt, record.completedAt());
+    }
+
+    @Test
+    void persistedRecordCarriesId() {
+        BackupAccountRecord record = new BackupAccountRecord(
+                42L, "full-1", "user@example.com", "1M", Instant.now(), null);
+
+        assertEquals(42L, record.id());
+    }
+
+    @Test
+    void requiresSessionId() {
+        assertThrows(NullPointerException.class, () ->
+                new BackupAccountRecord(null, null, "user@example.com", "1M", Instant.now(), null));
+    }
+
+    @Test
+    void requiresEmail() {
+        assertThrows(NullPointerException.class, () ->
+                new BackupAccountRecord(null, "full-1", null, "1M", Instant.now(), null));
+    }
+
+    @Test
+    void requiresSize() {
+        assertThrows(NullPointerException.class, () ->
+                new BackupAccountRecord(null, "full-1", "user@example.com", null, Instant.now(), null));
+    }
+
+    @Test
+    void requiresStartedAt() {
+        assertThrows(NullPointerException.class, () ->
+                new BackupAccountRecord(null, "full-1", "user@example.com", "1M", null, null));
+    }
+}

--- a/core/src/test/java/io/zmbackup/core/domain/BackupSessionTest.java
+++ b/core/src/test/java/io/zmbackup/core/domain/BackupSessionTest.java
@@ -1,0 +1,60 @@
+package io.zmbackup.core.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class BackupSessionTest {
+
+    @Test
+    void inProgressSessionHasNoCompletionOrSize() {
+        Instant startedAt = Instant.parse("2026-01-01T12:00:00Z");
+        BackupSession session = new BackupSession(
+                "full-20260101120000", BackupType.FULL, SessionStatus.IN_PROGRESS, startedAt, null, null);
+
+        assertEquals("full-20260101120000", session.sessionId());
+        assertEquals(BackupType.FULL, session.type());
+        assertEquals(SessionStatus.IN_PROGRESS, session.status());
+        assertEquals(startedAt, session.startedAt());
+        assertNull(session.completedAt());
+        assertNull(session.size());
+    }
+
+    @Test
+    void finishedSessionCarriesCompletionAndSize() {
+        Instant startedAt = Instant.parse("2026-01-01T12:00:00Z");
+        Instant completedAt = Instant.parse("2026-01-01T12:05:00Z");
+        BackupSession session = new BackupSession(
+                "full-20260101120000", BackupType.FULL, SessionStatus.FINISHED, startedAt, completedAt, "10M");
+
+        assertEquals(completedAt, session.completedAt());
+        assertEquals("10M", session.size());
+    }
+
+    @Test
+    void requiresSessionId() {
+        assertThrows(NullPointerException.class, () ->
+                new BackupSession(null, BackupType.FULL, SessionStatus.IN_PROGRESS, Instant.now(), null, null));
+    }
+
+    @Test
+    void requiresType() {
+        assertThrows(NullPointerException.class, () ->
+                new BackupSession("full-1", null, SessionStatus.IN_PROGRESS, Instant.now(), null, null));
+    }
+
+    @Test
+    void requiresStatus() {
+        assertThrows(NullPointerException.class, () ->
+                new BackupSession("full-1", BackupType.FULL, null, Instant.now(), null, null));
+    }
+
+    @Test
+    void requiresStartedAt() {
+        assertThrows(NullPointerException.class, () ->
+                new BackupSession("full-1", BackupType.FULL, SessionStatus.IN_PROGRESS, null, null, null));
+    }
+}

--- a/core/src/test/java/io/zmbackup/core/domain/BackupTypeTest.java
+++ b/core/src/test/java/io/zmbackup/core/domain/BackupTypeTest.java
@@ -1,0 +1,50 @@
+package io.zmbackup.core.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class BackupTypeTest {
+
+    @Test
+    void fullIncludesLdapAndMailbox() {
+        assertTrue(BackupType.FULL.includesLdap());
+        assertTrue(BackupType.FULL.includesMailbox());
+        assertEquals("full", BackupType.FULL.sessionPrefix());
+    }
+
+    @Test
+    void incrementalIncludesLdapAndMailbox() {
+        assertTrue(BackupType.INCREMENTAL.includesLdap());
+        assertTrue(BackupType.INCREMENTAL.includesMailbox());
+        assertEquals("inc", BackupType.INCREMENTAL.sessionPrefix());
+    }
+
+    @Test
+    void mailboxIncludesMailboxOnly() {
+        assertFalse(BackupType.MAILBOX.includesLdap());
+        assertTrue(BackupType.MAILBOX.includesMailbox());
+        assertEquals("mbox", BackupType.MAILBOX.sessionPrefix());
+    }
+
+    @Test
+    void ldapOnlyTypesIncludeLdapButNotMailbox() {
+        for (BackupType type : new BackupType[] {
+                BackupType.LDAP, BackupType.ALIAS, BackupType.DISTRIBUTION_LIST,
+                BackupType.SIGNATURE, BackupType.DOMAIN}) {
+            assertTrue(type.includesLdap(), type + " should include LDAP");
+            assertFalse(type.includesMailbox(), type + " should not include mailbox");
+        }
+    }
+
+    @Test
+    void sessionPrefixesMatchBashToolConventions() {
+        assertEquals("ldap", BackupType.LDAP.sessionPrefix());
+        assertEquals("alias", BackupType.ALIAS.sessionPrefix());
+        assertEquals("distlist", BackupType.DISTRIBUTION_LIST.sessionPrefix());
+        assertEquals("signature", BackupType.SIGNATURE.sessionPrefix());
+        assertEquals("domain", BackupType.DOMAIN.sessionPrefix());
+    }
+}

--- a/core/src/test/java/io/zmbackup/core/domain/LdapObjectTypeTest.java
+++ b/core/src/test/java/io/zmbackup/core/domain/LdapObjectTypeTest.java
@@ -1,0 +1,38 @@
+package io.zmbackup.core.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class LdapObjectTypeTest {
+
+    @Test
+    void accountFilterAndAttribute() {
+        assertEquals("(objectclass=zimbraAccount)", LdapObjectType.ACCOUNT.objectFilter());
+        assertEquals("zimbraMailDeliveryAddress", LdapObjectType.ACCOUNT.attributeName());
+    }
+
+    @Test
+    void distributionListFilterAndAttribute() {
+        assertEquals("(objectclass=zimbraDistributionList)", LdapObjectType.DISTRIBUTION_LIST.objectFilter());
+        assertEquals("mail", LdapObjectType.DISTRIBUTION_LIST.attributeName());
+    }
+
+    @Test
+    void aliasFilterAndAttribute() {
+        assertEquals("(objectclass=zimbraAlias)", LdapObjectType.ALIAS.objectFilter());
+        assertEquals("uid", LdapObjectType.ALIAS.attributeName());
+    }
+
+    @Test
+    void signatureFilterAndAttribute() {
+        assertEquals("(objectclass=zimbraSignature)", LdapObjectType.SIGNATURE.objectFilter());
+        assertEquals("zimbraSignatureName", LdapObjectType.SIGNATURE.attributeName());
+    }
+
+    @Test
+    void domainFilterAndAttribute() {
+        assertEquals("(objectclass=zimbraDomain)", LdapObjectType.DOMAIN.objectFilter());
+        assertEquals("zimbraDomainName", LdapObjectType.DOMAIN.attributeName());
+    }
+}

--- a/core/src/test/java/io/zmbackup/core/domain/SessionStatusTest.java
+++ b/core/src/test/java/io/zmbackup/core/domain/SessionStatusTest.java
@@ -1,0 +1,28 @@
+package io.zmbackup.core.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class SessionStatusTest {
+
+    @Test
+    void dbValuesMatchBashToolConventions() {
+        assertEquals("IN PROGRESS", SessionStatus.IN_PROGRESS.dbValue());
+        assertEquals("FINISHED", SessionStatus.FINISHED.dbValue());
+        assertEquals("FAILED", SessionStatus.FAILED.dbValue());
+    }
+
+    @Test
+    void fromDbValueRoundTrips() {
+        for (SessionStatus status : SessionStatus.values()) {
+            assertEquals(status, SessionStatus.fromDbValue(status.dbValue()));
+        }
+    }
+
+    @Test
+    void fromDbValueRejectsUnknownValue() {
+        assertThrows(IllegalArgumentException.class, () -> SessionStatus.fromDbValue("BOGUS"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `BackupType`, `LdapObjectType`, and `SessionStatus` enums, and `BackupSession`/`BackupAccountRecord` records to the `core` module, per #262.
- Values mirror the bash tool's conventions: `BackupType.sessionPrefix()` matches the session-ID prefixes in `MiscAction.sh` (`full-`, `inc-`, `mbox-`, etc.), `LdapObjectType` mirrors the `*OBJECT`/`*FILTER` LDAP constants, `SessionStatus.dbValue()` round-trips the `backup_session.status` strings (including the `"IN PROGRESS"` space), and the two records mirror the `backup_session`/`backup_account` tables in `sessions.sqlite3`.
- Adds a `test-java` CircleCI job (`cimg/openjdk:21.0`, `./gradlew test`) so the new Java module gets CI coverage alongside the existing bats job.

## Test plan
- [x] `javac` compiles all new sources cleanly
- [x] All 25 new unit tests pass via the JUnit Platform console launcher (`./gradlew test` could not be run locally — the Gradle 8.14.3 daemon fails to start under the JDK 26 installed in this sandbox; CI uses JDK 21 via `cimg/openjdk:21.0`, which is unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)