### PR TITLE
Define core ports: StorageProvider, MetadataStore, AccountDiscovery, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The table below documents what zmbackup covers and what falls outside its scope.
 - **ldap-utils** - a package that includes a number of utilities that can be used to perform queries on the LDAP server;
 - **mktemp** - make a temporary file or directory;
 - **SQLite3** - a relational database management system contained in a C programming library.
+- **Java 21 (JDK)** - required to build and run zmbackup 2.0, the Java rewrite currently under development; the Gradle toolchain will download it automatically if it isn't already installed.
 
 ## Installation
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ subprojects {
     dependencies {
         "testImplementation"(platform("org.junit:junit-bom:5.11.4"))
         "testImplementation"("org.junit.jupiter:junit-jupiter")
+        "testRuntimeOnly"("org.junit.platform:junit-platform-launcher")
     }
 
     tasks.withType<Test> {

--- a/core/src/main/java/io/zmbackup/core/port/AccountDiscovery.java
+++ b/core/src/main/java/io/zmbackup/core/port/AccountDiscovery.java
@@ -1,0 +1,24 @@
+package io.zmbackup.core.port;
+
+import io.zmbackup.core.domain.LdapObjectType;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Enumerates the LDAP objects eligible for backup, mirroring {@code build_listBKP} in the bash
+ * tool's {@code MiscAction.sh}.
+ */
+public interface AccountDiscovery {
+
+    /**
+     * The identifying attribute value ({@link LdapObjectType#attributeName()}) of every object
+     * of {@code type} found across the whole directory.
+     */
+    List<String> discover(LdapObjectType type) throws IOException;
+
+    /**
+     * Same as {@link #discover(LdapObjectType)}, scoped to a single {@code domain} (e.g.
+     * {@code "example.com"}).
+     */
+    List<String> discoverForDomain(LdapObjectType type, String domain) throws IOException;
+}

--- a/core/src/main/java/io/zmbackup/core/port/MetadataStore.java
+++ b/core/src/main/java/io/zmbackup/core/port/MetadataStore.java
@@ -1,0 +1,45 @@
+package io.zmbackup.core.port;
+
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Persists {@link BackupSession} and {@link BackupAccountRecord} data, mirroring the
+ * {@code backup_session} and {@code backup_account} tables in the bash tool's
+ * {@code sessions.sqlite3}.
+ */
+public interface MetadataStore {
+
+    /** Creates or replaces the stored session with the same {@link BackupSession#sessionId()}. */
+    void save(BackupSession session) throws IOException;
+
+    /** The session with the given ID, or empty if none exists. */
+    Optional<BackupSession> findSession(String sessionId) throws IOException;
+
+    /** All stored sessions. */
+    List<BackupSession> listSessions() throws IOException;
+
+    /** Sessions whose {@link BackupSession#completedAt()} is before {@code cutoff}, for housekeeping. */
+    List<BackupSession> findSessionsCompletedBefore(Instant cutoff) throws IOException;
+
+    /** Removes a session and its associated account records. */
+    void deleteSession(String sessionId) throws IOException;
+
+    /** Records that the account in {@code record} was backed up as part of its session. */
+    void recordAccountBackup(BackupAccountRecord record) throws IOException;
+
+    /** All account records backed up as part of {@code sessionId}, for restore. */
+    List<BackupAccountRecord> findAccountsForSession(String sessionId) throws IOException;
+
+    /**
+     * When {@code email} was last successfully backed up — the latest
+     * {@link BackupAccountRecord#completedAt()} across all of its sessions — or empty if it was
+     * never backed up. Used both to compute the "after" cutoff for incremental mailbox backups
+     * and to skip accounts already backed up today.
+     */
+    Optional<Instant> lastSuccessfulBackupTime(String email) throws IOException;
+}

--- a/core/src/main/java/io/zmbackup/core/port/StorageProvider.java
+++ b/core/src/main/java/io/zmbackup/core/port/StorageProvider.java
@@ -1,0 +1,43 @@
+package io.zmbackup.core.port;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Stores and retrieves the raw backup content (LDAP {@code .ldiff} exports and mailbox
+ * {@code .tgz} archives) produced for a session, mirroring the bash tool's
+ * {@code {WORKDIR}/{sessionId}/{account}.{suffix}} file layout without committing callers to a
+ * particular storage backend.
+ */
+public interface StorageProvider {
+
+    /**
+     * Opens a stream to write the content identified by {@code account} and {@code suffix}
+     * (e.g. {@code "ldiff"}, {@code "tgz"}) within {@code sessionId}. Any existing content at
+     * the same location is replaced.
+     */
+    OutputStream openWrite(String sessionId, String account, String suffix) throws IOException;
+
+    /** Opens a stream to read back content previously written with {@link #openWrite}. */
+    InputStream openRead(String sessionId, String account, String suffix) throws IOException;
+
+    /** Whether content was written for {@code account} and {@code suffix} within {@code sessionId}. */
+    boolean exists(String sessionId, String account, String suffix);
+
+    /**
+     * The human-readable total size of the content stored for {@code account} within
+     * {@code sessionId} (e.g. {@code "10M"}), for
+     * {@link io.zmbackup.core.domain.BackupAccountRecord#size()}.
+     */
+    String sizeOfAccount(String sessionId, String account) throws IOException;
+
+    /**
+     * The human-readable total size of all content stored for {@code sessionId} (e.g.
+     * {@code "10M"}), for {@link io.zmbackup.core.domain.BackupSession#size()}.
+     */
+    String sizeOfSession(String sessionId) throws IOException;
+
+    /** Permanently removes all stored content for {@code sessionId}. */
+    void deleteSession(String sessionId) throws IOException;
+}

--- a/core/src/main/java/io/zmbackup/core/port/ZimbraLdapExporter.java
+++ b/core/src/main/java/io/zmbackup/core/port/ZimbraLdapExporter.java
@@ -1,0 +1,26 @@
+package io.zmbackup.core.port;
+
+import io.zmbackup.core.domain.LdapObjectType;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Exports and restores a single LDAP object's raw {@code .ldiff} entry, mirroring
+ * {@code ldap_backup}/{@code ldap_restore}/{@code domain_backup}/{@code domain_restore} in the
+ * bash tool's {@code ParallelAction.sh}.
+ */
+public interface ZimbraLdapExporter {
+
+    /**
+     * Writes the {@code .ldiff} entry for the object identified by {@code identifier} and
+     * {@code type} to {@code destination}.
+     */
+    void export(String identifier, LdapObjectType type, OutputStream destination) throws IOException;
+
+    /**
+     * Restores an object of the given {@code type} from a previously exported {@code .ldiff}
+     * entry, replacing any existing entry with the same distinguished name.
+     */
+    void restore(LdapObjectType type, InputStream source) throws IOException;
+}

--- a/core/src/main/java/io/zmbackup/core/port/ZimbraMailboxExporter.java
+++ b/core/src/main/java/io/zmbackup/core/port/ZimbraMailboxExporter.java
@@ -1,0 +1,28 @@
+package io.zmbackup.core.port;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Instant;
+
+/**
+ * Exports and restores a single account's mailbox content as a {@code .tgz} archive, mirroring
+ * {@code mailbox_backup}/{@code mailbox_restore} in the bash tool's {@code ParallelAction.sh}.
+ */
+public interface ZimbraMailboxExporter {
+
+    /** Exports the full mailbox content of {@code account} to {@code destination}. */
+    default boolean export(String account, OutputStream destination) throws IOException {
+        return export(account, destination, null);
+    }
+
+    /**
+     * Exports {@code account}'s mailbox content to {@code destination}, limited to items after
+     * {@code since} when non-null. Returns {@code false} without writing anything when there is
+     * no content to export (e.g. nothing changed since an incremental cutoff).
+     */
+    boolean export(String account, OutputStream destination, Instant since) throws IOException;
+
+    /** Restores {@code account}'s mailbox content from a previously exported {@code .tgz} archive. */
+    void restore(String account, InputStream source) throws IOException;
+}

--- a/core/src/test/java/io/zmbackup/core/port/ZimbraMailboxExporterTest.java
+++ b/core/src/test/java/io/zmbackup/core/port/ZimbraMailboxExporterTest.java
@@ -1,0 +1,40 @@
+package io.zmbackup.core.port;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class ZimbraMailboxExporterTest {
+
+    @Test
+    void fullExportDelegatesToIncrementalExportWithNullSince() throws IOException {
+        Instant[] capturedSince = new Instant[1];
+        ZimbraMailboxExporter exporter = new ZimbraMailboxExporter() {
+            @Override
+            public boolean export(String account, OutputStream destination, Instant since) throws IOException {
+                capturedSince[0] = since;
+                destination.write("content".getBytes());
+                return true;
+            }
+
+            @Override
+            public void restore(String account, InputStream source) {
+                throw new UnsupportedOperationException();
+            }
+        };
+
+        ByteArrayOutputStream destination = new ByteArrayOutputStream();
+        boolean wroteContent = exporter.export("user@example.com", destination);
+
+        assertTrue(wroteContent);
+        assertEquals("content", destination.toString());
+        assertNull(capturedSince[0]);
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "zmbackup"
 
 include("core", "zimbra", "local", "app")


### PR DESCRIPTION
…ZimbraLdapExporter, ZimbraMailboxExporter (#263)

Each interface mirrors the corresponding bash tool behavior (MiscAction.sh, ParallelAction.sh, BackupAction.sh, RestoreAction.sh) so later modules can adapt to it without changing the contract.

Also upgrades Gradle to 9.7.1 with toolchain auto-provisioning, since the pinned 8.14.3 cannot run under JDK 26, and documents the Java 21 requirement in the README.