### PR TITLE
Implement LocalStorageProvider in local module

### DIFF
--- a/local/src/main/java/io/zmbackup/local/HumanReadableSize.java
+++ b/local/src/main/java/io/zmbackup/local/HumanReadableSize.java
@@ -1,0 +1,33 @@
+package io.zmbackup.local;
+
+/**
+ * Formats byte counts the way {@link LocalStorageProvider} reports
+ * {@link io.zmbackup.core.domain.BackupSession#size()} and
+ * {@link io.zmbackup.core.domain.BackupAccountRecord#size()}: binary units ({@code K}, {@code M},
+ * {@code G}, {@code T}, {@code P}), one decimal place when not a whole number, and a plain
+ * {@code B} suffix below 1024 bytes (e.g. {@code "512B"}, {@code "1.5K"}, {@code "10M"}).
+ */
+final class HumanReadableSize {
+
+    private static final String[] UNITS = {"K", "M", "G", "T", "P"};
+
+    private HumanReadableSize() {
+    }
+
+    static String format(long bytes) {
+        if (bytes < 1024) {
+            return bytes + "B";
+        }
+        double value = bytes;
+        int unitIndex = -1;
+        while (value >= 1024 && unitIndex < UNITS.length - 1) {
+            value /= 1024;
+            unitIndex++;
+        }
+        double rounded = Math.round(value * 10) / 10.0;
+        if (rounded == Math.floor(rounded)) {
+            return (long) rounded + UNITS[unitIndex];
+        }
+        return rounded + UNITS[unitIndex];
+    }
+}

--- a/local/src/main/java/io/zmbackup/local/LocalStorageProvider.java
+++ b/local/src/main/java/io/zmbackup/local/LocalStorageProvider.java
@@ -1,0 +1,109 @@
+package io.zmbackup.local;
+
+import io.zmbackup.core.port.StorageProvider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.FileVisitResult;
+
+/**
+ * Filesystem-backed {@link StorageProvider} storing content under
+ * {@code {workDir}/{sessionId}/{account}.{suffix}}, the same layout the bash tool uses under its
+ * {@code WORKDIR}.
+ */
+public class LocalStorageProvider implements StorageProvider {
+
+    private final Path workDir;
+
+    public LocalStorageProvider(Path workDir) {
+        this.workDir = workDir;
+    }
+
+    @Override
+    public OutputStream openWrite(String sessionId, String account, String suffix) throws IOException {
+        Path file = accountFile(sessionId, account, suffix);
+        Files.createDirectories(file.getParent());
+        return Files.newOutputStream(
+                file, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+    }
+
+    @Override
+    public InputStream openRead(String sessionId, String account, String suffix) throws IOException {
+        return Files.newInputStream(accountFile(sessionId, account, suffix));
+    }
+
+    @Override
+    public boolean exists(String sessionId, String account, String suffix) {
+        return Files.exists(accountFile(sessionId, account, suffix));
+    }
+
+    @Override
+    public String sizeOfAccount(String sessionId, String account) throws IOException {
+        Path sessionDir = sessionDir(sessionId);
+        long totalBytes = 0;
+        if (Files.isDirectory(sessionDir)) {
+            String prefix = account + ".";
+            try (DirectoryStream<Path> entries =
+                    Files.newDirectoryStream(sessionDir, path -> path.getFileName().toString().startsWith(prefix))) {
+                for (Path entry : entries) {
+                    totalBytes += Files.size(entry);
+                }
+            }
+        }
+        return HumanReadableSize.format(totalBytes);
+    }
+
+    @Override
+    public String sizeOfSession(String sessionId) throws IOException {
+        Path sessionDir = sessionDir(sessionId);
+        long[] totalBytes = {0};
+        if (Files.isDirectory(sessionDir)) {
+            Files.walkFileTree(sessionDir, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    totalBytes[0] += attrs.size();
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        return HumanReadableSize.format(totalBytes[0]);
+    }
+
+    @Override
+    public void deleteSession(String sessionId) throws IOException {
+        Path sessionDir = sessionDir(sessionId);
+        if (!Files.exists(sessionDir)) {
+            return;
+        }
+        Files.walkFileTree(sessionDir, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                if (exc != null) {
+                    throw exc;
+                }
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private Path sessionDir(String sessionId) {
+        return workDir.resolve(sessionId);
+    }
+
+    private Path accountFile(String sessionId, String account, String suffix) {
+        return sessionDir(sessionId).resolve(account + "." + suffix);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `LocalStorageProvider`, a filesystem-backed `StorageProvider` storing content under `{workDir}/{sessionId}/{account}.{suffix}`, mirroring the bash tool's `WORKDIR` layout
- Adds `HumanReadableSize`, a small formatter producing binary-unit sizes (e.g. `10M`, `1.5K`) for `sizeOfAccount`/`sizeOfSession`

## Test plan
- [x] `./gradlew build` passes
- Unit tests are tracked separately in #271 per the existing task breakdown

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)