### PR TITLE
Implement SqliteMetadataStore in local module

### DIFF
--- a/core/src/main/java/io/zmbackup/core/domain/BackupType.java
+++ b/core/src/main/java/io/zmbackup/core/domain/BackupType.java
@@ -38,4 +38,14 @@ public enum BackupType {
     public boolean includesMailbox() {
         return includesMailbox;
     }
+
+    /** Resolves the type matching a value previously produced by {@link #sessionPrefix()}. */
+    public static BackupType fromSessionPrefix(String sessionPrefix) {
+        for (BackupType type : values()) {
+            if (type.sessionPrefix.equals(sessionPrefix)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown backup type session prefix: " + sessionPrefix);
+    }
 }

--- a/local/build.gradle.kts
+++ b/local/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
     implementation(project(":core"))
+    implementation("org.xerial:sqlite-jdbc:3.49.1.0")
 }

--- a/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
+++ b/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
@@ -1,0 +1,230 @@
+package io.zmbackup.local;
+
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import io.zmbackup.core.port.MetadataStore;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * JDBC-backed {@link MetadataStore} using SQLite, with DDL identical to the bash tool's
+ * {@code sessions.sqlite3} schema so existing backup databases remain readable.
+ */
+public class SqliteMetadataStore implements MetadataStore {
+
+    private static final String CREATE_BACKUP_SESSION =
+            """
+            create table if not exists backup_session(
+              sessionID varchar primary key,
+              initial_date timestamp not null,
+              conclusion_date timestamp,
+              size varchar,
+              type varchar not null,
+              status varchar not null
+            )
+            """;
+
+    private static final String CREATE_BACKUP_ACCOUNT =
+            """
+            create table if not exists backup_account(
+              id integer primary key autoincrement,
+              sessionID varchar not null,
+              account_size varchar not null,
+              email varchar not null,
+              initial_date timestamp not null,
+              conclusion_date timestamp,
+              foreign key (sessionID) references backup_session(sessionID)
+            )
+            """;
+
+    private final String jdbcUrl;
+
+    public SqliteMetadataStore(Path databaseFile) throws IOException {
+        this.jdbcUrl = "jdbc:sqlite:" + databaseFile;
+        try (Connection connection = connect();
+                Statement statement = connection.createStatement()) {
+            statement.execute(CREATE_BACKUP_SESSION);
+            statement.execute(CREATE_BACKUP_ACCOUNT);
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void save(BackupSession session) throws IOException {
+        String sql =
+                """
+                insert or replace into backup_session(sessionID, initial_date, conclusion_date, size, type, status)
+                values (?, ?, ?, ?, ?, ?)
+                """;
+        try (Connection connection = connect();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, session.sessionId());
+            statement.setString(2, toDb(session.startedAt()));
+            statement.setString(3, toDb(session.completedAt()));
+            statement.setString(4, session.size());
+            statement.setString(5, session.type().sessionPrefix());
+            statement.setString(6, session.status().dbValue());
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public Optional<BackupSession> findSession(String sessionId) throws IOException {
+        String sql =
+                "select sessionID, initial_date, conclusion_date, size, type, status "
+                        + "from backup_session where sessionID = ?";
+        try (Connection connection = connect();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, sessionId);
+            try (ResultSet rs = statement.executeQuery()) {
+                return rs.next() ? Optional.of(mapSession(rs)) : Optional.empty();
+            }
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public List<BackupSession> listSessions() throws IOException {
+        String sql = "select sessionID, initial_date, conclusion_date, size, type, status from backup_session";
+        try (Connection connection = connect();
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery(sql)) {
+            List<BackupSession> sessions = new ArrayList<>();
+            while (rs.next()) {
+                sessions.add(mapSession(rs));
+            }
+            return sessions;
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public List<BackupSession> findSessionsCompletedBefore(Instant cutoff) throws IOException {
+        String sql =
+                "select sessionID, initial_date, conclusion_date, size, type, status from backup_session "
+                        + "where conclusion_date is not null and conclusion_date < ?";
+        try (Connection connection = connect();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, toDb(cutoff));
+            try (ResultSet rs = statement.executeQuery()) {
+                List<BackupSession> sessions = new ArrayList<>();
+                while (rs.next()) {
+                    sessions.add(mapSession(rs));
+                }
+                return sessions;
+            }
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void deleteSession(String sessionId) throws IOException {
+        try (Connection connection = connect()) {
+            try (PreparedStatement deleteAccounts =
+                    connection.prepareStatement("delete from backup_account where sessionID = ?")) {
+                deleteAccounts.setString(1, sessionId);
+                deleteAccounts.executeUpdate();
+            }
+            try (PreparedStatement deleteSession =
+                    connection.prepareStatement("delete from backup_session where sessionID = ?")) {
+                deleteSession.setString(1, sessionId);
+                deleteSession.executeUpdate();
+            }
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void recordAccountBackup(BackupAccountRecord record) throws IOException {
+        String sql =
+                "insert into backup_account (sessionID, account_size, email, initial_date, conclusion_date) "
+                        + "values (?, ?, ?, ?, ?)";
+        try (Connection connection = connect();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, record.sessionId());
+            statement.setString(2, record.size());
+            statement.setString(3, record.email());
+            statement.setString(4, toDb(record.startedAt()));
+            statement.setString(5, toDb(record.completedAt()));
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public List<BackupAccountRecord> findAccountsForSession(String sessionId) throws IOException {
+        String sql =
+                "select id, sessionID, email, account_size, initial_date, conclusion_date "
+                        + "from backup_account where sessionID = ?";
+        try (Connection connection = connect();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, sessionId);
+            try (ResultSet rs = statement.executeQuery()) {
+                List<BackupAccountRecord> records = new ArrayList<>();
+                while (rs.next()) {
+                    records.add(mapAccount(rs));
+                }
+                return records;
+            }
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public Optional<Instant> lastSuccessfulBackupTime(String email) throws IOException {
+        throw new UnsupportedOperationException("lastSuccessfulBackupTime is implemented in a later delivery (#259)");
+    }
+
+    private Connection connect() throws SQLException {
+        return DriverManager.getConnection(jdbcUrl);
+    }
+
+    private static BackupSession mapSession(ResultSet rs) throws SQLException {
+        return new BackupSession(
+                rs.getString("sessionID"),
+                BackupType.fromSessionPrefix(rs.getString("type")),
+                SessionStatus.fromDbValue(rs.getString("status")),
+                fromDb(rs.getString("initial_date")),
+                fromDb(rs.getString("conclusion_date")),
+                rs.getString("size"));
+    }
+
+    private static BackupAccountRecord mapAccount(ResultSet rs) throws SQLException {
+        return new BackupAccountRecord(
+                rs.getLong("id"),
+                rs.getString("sessionID"),
+                rs.getString("email"),
+                rs.getString("account_size"),
+                fromDb(rs.getString("initial_date")),
+                fromDb(rs.getString("conclusion_date")));
+    }
+
+    private static String toDb(Instant instant) {
+        return instant == null ? null : instant.toString();
+    }
+
+    private static Instant fromDb(String value) {
+        return value == null ? null : Instant.parse(value);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SqliteMetadataStore`, a JDBC-backed `MetadataStore` using SQLite, with DDL identical to the bash tool's `sessions.sqlite3` schema (`backup_session`, `backup_account` created with `IF NOT EXISTS`) so existing backup databases stay readable
- Adds `BackupType.fromSessionPrefix()` so the `type` column round-trips the same way `SessionStatus.fromDbValue()` already does for `status`
- `lastSuccessfulBackupTime(email)` is left as a stub throwing `UnsupportedOperationException` — its query logic is implemented in #259 per that issue's own task list
- Adds the `org.xerial:sqlite-jdbc` dependency to the `local` module

## Test plan
- [x] `./gradlew build` passes
- [x] Manual smoke test: opened a database pre-created with the legacy bash DDL, exercised save/find/list/delete/findSessionsCompletedBefore round-trips against it successfully
- Unit tests are tracked separately in #272 per the existing task breakdown

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)