### PR TITLE
Implement YAML config loading in app module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,4 +2,5 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":zimbra"))
     implementation(project(":local"))
+    implementation("org.yaml:snakeyaml:2.6")
 }

--- a/app/src/main/java/io/zmbackup/app/config/AppConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/AppConfig.java
@@ -1,0 +1,20 @@
+package io.zmbackup.app.config;
+
+import java.util.Objects;
+
+/**
+ * The fully parsed contents of {@code zmbackup.yaml}, mirroring the sections of the bash tool's
+ * {@code zmbackup.conf}.
+ *
+ * @param zimbraLdap    LDAP connection settings used for account discovery and LDAP object export
+ * @param zimbraMailbox Zimbra mailbox export settings
+ * @param backup        local backup behavior (storage, rotation, notifications)
+ */
+public record AppConfig(ZimbraLdapConfig zimbraLdap, ZimbraMailboxConfig zimbraMailbox, BackupConfig backup) {
+
+    public AppConfig {
+        Objects.requireNonNull(zimbraLdap, "zimbraLdap must not be null");
+        Objects.requireNonNull(zimbraMailbox, "zimbraMailbox must not be null");
+        Objects.requireNonNull(backup, "backup must not be null");
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/config/BackupConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/BackupConfig.java
@@ -1,0 +1,40 @@
+package io.zmbackup.app.config;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Local backup behavior, mirroring the {@code WORKDIR}/{@code LOGFILE}/{@code MAX_PARALLEL_PROCESS}/
+ * {@code ROTATE_TIME}/{@code LOCK_BACKUP}/{@code ZMBACKUP_BLOCKEDLIST} fields of the bash tool's
+ * {@code zmbackup.conf}.
+ *
+ * @param workDir            directory backups and session metadata are stored under
+ * @param logFile            path zmbackup writes its logs to
+ * @param blockedListFile    path to the file listing accounts that should never be backed up
+ * @param maxParallelProcesses how many accounts to back up concurrently
+ * @param rotateDays         how many days of backups to keep before housekeeping deletes them
+ * @param lockBackup         whether to allow only one backup session per type per day
+ * @param emailNotify        e-mail notification settings
+ */
+public record BackupConfig(
+        Path workDir,
+        Path logFile,
+        Path blockedListFile,
+        int maxParallelProcesses,
+        int rotateDays,
+        boolean lockBackup,
+        EmailNotifyConfig emailNotify) {
+
+    public BackupConfig {
+        Objects.requireNonNull(workDir, "workDir must not be null");
+        Objects.requireNonNull(logFile, "logFile must not be null");
+        Objects.requireNonNull(blockedListFile, "blockedListFile must not be null");
+        Objects.requireNonNull(emailNotify, "emailNotify must not be null");
+        if (maxParallelProcesses < 1) {
+            throw new IllegalArgumentException("maxParallelProcesses must be at least 1");
+        }
+        if (rotateDays < 0) {
+            throw new IllegalArgumentException("rotateDays must not be negative");
+        }
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/config/ConfigException.java
+++ b/app/src/main/java/io/zmbackup/app/config/ConfigException.java
@@ -1,0 +1,13 @@
+package io.zmbackup.app.config;
+
+/** Thrown when {@code zmbackup.yaml} is missing, malformed, or missing a required field. */
+public class ConfigException extends RuntimeException {
+
+    public ConfigException(String message) {
+        super(message);
+    }
+
+    public ConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/config/EmailNotifyConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/EmailNotifyConfig.java
@@ -1,0 +1,20 @@
+package io.zmbackup.app.config;
+
+import java.util.Objects;
+
+/**
+ * E-mail notification settings, mirroring the {@code ENABLE_EMAIL_NOTIFY}/{@code EMAIL_NOTIFY}/
+ * {@code EMAIL_SENDER} fields of the bash tool's {@code zmbackup.conf}.
+ *
+ * @param level     which lifecycle events to notify on
+ * @param recipient the address a report is sent to after each run
+ * @param sender    the address the report is sent from, e.g. {@code "root@domain"}
+ */
+public record EmailNotifyConfig(EmailNotifyLevel level, String recipient, String sender) {
+
+    public EmailNotifyConfig {
+        Objects.requireNonNull(level, "level must not be null");
+        Objects.requireNonNull(recipient, "recipient must not be null");
+        Objects.requireNonNull(sender, "sender must not be null");
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/config/EmailNotifyLevel.java
+++ b/app/src/main/java/io/zmbackup/app/config/EmailNotifyLevel.java
@@ -1,0 +1,13 @@
+package io.zmbackup.app.config;
+
+/**
+ * Which backup lifecycle events trigger an e-mail notification, mirroring the
+ * {@code ENABLE_EMAIL_NOTIFY} field of the bash tool's {@code zmbackup.conf}.
+ */
+public enum EmailNotifyLevel {
+    ALL,
+    START,
+    FINISH,
+    ERROR,
+    NONE
+}

--- a/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
+++ b/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
@@ -1,0 +1,152 @@
+package io.zmbackup.app.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Map;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Parses {@code zmbackup.yaml} into an {@link AppConfig}, mirroring the fields of the bash tool's
+ * {@code zmbackup.conf}.
+ */
+public final class YamlConfigLoader {
+
+    /** Where the bash tool's installer places {@code zmbackup.conf}; the Java tool's equivalent. */
+    public static final Path DEFAULT_CONFIG_PATH = Path.of("/etc/zmbackup/zmbackup.yaml");
+
+    private YamlConfigLoader() {}
+
+    /** Reads and parses the config file at {@code configFile}. */
+    public static AppConfig load(Path configFile) throws IOException {
+        try (Reader reader = Files.newBufferedReader(configFile)) {
+            return load(reader);
+        } catch (NoSuchFileException e) {
+            throw new ConfigException("Config file not found: " + configFile, e);
+        }
+    }
+
+    /** Parses config content already available as a stream, e.g. a bundled resource. */
+    public static AppConfig load(InputStream in) {
+        return load(new Yaml().<Map<String, Object>>load(in));
+    }
+
+    /** Parses config content already available as a reader. */
+    public static AppConfig load(Reader reader) {
+        return load(new Yaml().<Map<String, Object>>load(reader));
+    }
+
+    private static AppConfig load(Map<String, Object> root) {
+        if (root == null) {
+            throw new ConfigException("Config file is empty");
+        }
+        return new AppConfig(parseZimbraLdap(root), parseZimbraMailbox(root), parseBackup(root));
+    }
+
+    private static ZimbraLdapConfig parseZimbraLdap(Map<String, Object> root) {
+        return new ZimbraLdapConfig(
+                requireString(root, "zimbraLdap.url"),
+                requireString(root, "zimbraLdap.bindDn"),
+                requireString(root, "zimbraLdap.bindPassword"),
+                optionalBoolean(root, "zimbraLdap.sslEnabled", true));
+    }
+
+    private static ZimbraMailboxConfig parseZimbraMailbox(Map<String, Object> root) {
+        return new ZimbraMailboxConfig(
+                requireString(root, "zimbraMailbox.backupUser"),
+                requirePath(root, "zimbraMailbox.zmmailboxPath"),
+                optionalBoolean(root, "zimbraMailbox.backupInactiveAccounts", true));
+    }
+
+    private static BackupConfig parseBackup(Map<String, Object> root) {
+        return new BackupConfig(
+                requirePath(root, "backup.workDir"),
+                requirePath(root, "backup.logFile"),
+                requirePath(root, "backup.blockedListFile"),
+                optionalInt(root, "backup.maxParallelProcesses", 3),
+                optionalInt(root, "backup.rotateDays", 30),
+                optionalBoolean(root, "backup.lockBackup", true),
+                parseEmailNotify(root));
+    }
+
+    private static EmailNotifyConfig parseEmailNotify(Map<String, Object> root) {
+        return new EmailNotifyConfig(
+                optionalEmailNotifyLevel(root, "backup.emailNotify.level", EmailNotifyLevel.ALL),
+                requireString(root, "backup.emailNotify.recipient"),
+                requireString(root, "backup.emailNotify.sender"));
+    }
+
+    /**
+     * Navigates {@code root} following {@code dottedPath} (e.g. {@code "backup.workDir"}),
+     * returning {@code null} if any segment along the way is absent.
+     */
+    private static Object get(Map<String, Object> root, String dottedPath) {
+        Object current = root;
+        StringBuilder soFar = new StringBuilder();
+        for (String segment : dottedPath.split("\\.")) {
+            if (!soFar.isEmpty()) {
+                soFar.append('.');
+            }
+            soFar.append(segment);
+            if (current == null) {
+                return null;
+            }
+            if (!(current instanceof Map)) {
+                throw new ConfigException("Expected a mapping at '" + soFar + "'");
+            }
+            current = ((Map<?, ?>) current).get(segment);
+        }
+        return current;
+    }
+
+    private static String requireString(Map<String, Object> root, String dottedPath) {
+        Object value = get(root, dottedPath);
+        if (value == null) {
+            throw new ConfigException("Missing required config value: " + dottedPath);
+        }
+        return value.toString();
+    }
+
+    private static Path requirePath(Map<String, Object> root, String dottedPath) {
+        return Path.of(requireString(root, dottedPath));
+    }
+
+    private static boolean optionalBoolean(Map<String, Object> root, String dottedPath, boolean defaultValue) {
+        Object value = get(root, dottedPath);
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        throw new ConfigException("Expected a boolean at '" + dottedPath + "', got: " + value);
+    }
+
+    private static int optionalInt(Map<String, Object> root, String dottedPath, int defaultValue) {
+        Object value = get(root, dottedPath);
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof Integer intValue) {
+            return intValue;
+        }
+        throw new ConfigException("Expected an integer at '" + dottedPath + "', got: " + value);
+    }
+
+    private static EmailNotifyLevel optionalEmailNotifyLevel(
+            Map<String, Object> root, String dottedPath, EmailNotifyLevel defaultValue) {
+        Object value = get(root, dottedPath);
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            return EmailNotifyLevel.valueOf(value.toString().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new ConfigException("Invalid value for '" + dottedPath + "': " + value, e);
+        }
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/config/ZimbraLdapConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/ZimbraLdapConfig.java
@@ -1,0 +1,22 @@
+package io.zmbackup.app.config;
+
+import java.util.Objects;
+
+/**
+ * LDAP connection settings, mirroring the {@code LDAPSERVER}/{@code LDAPADMIN}/{@code LDAPPASS}/
+ * {@code SSL_ENABLE} fields of the bash tool's {@code zmbackup.conf}.
+ *
+ * @param url          the LDAP server URL, e.g. {@code "ldap://127.0.0.1:389"}
+ * @param bindDn       the admin distinguished name used to bind, e.g.
+ *                     {@code "uid=zimbra,cn=admins,cn=zimbra"}
+ * @param bindPassword the admin password used to bind
+ * @param sslEnabled   whether to use SSL when talking to the Zimbra server
+ */
+public record ZimbraLdapConfig(String url, String bindDn, String bindPassword, boolean sslEnabled) {
+
+    public ZimbraLdapConfig {
+        Objects.requireNonNull(url, "url must not be null");
+        Objects.requireNonNull(bindDn, "bindDn must not be null");
+        Objects.requireNonNull(bindPassword, "bindPassword must not be null");
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/config/ZimbraMailboxConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/ZimbraMailboxConfig.java
@@ -1,0 +1,21 @@
+package io.zmbackup.app.config;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Zimbra mailbox export settings, mirroring the {@code BACKUPUSER}/{@code ZMMAILBOX}/
+ * {@code BACKUP_INACTIVE_ACCOUNTS} fields of the bash tool's {@code zmbackup.conf}.
+ *
+ * @param backupUser              the Zimbra service account used to start/stop the service and
+ *                                run {@code zmmailbox}, e.g. {@code "zimbra"}
+ * @param zmmailboxPath           location of the {@code zmmailbox} binary
+ * @param backupInactiveAccounts whether to include disabled accounts
+ */
+public record ZimbraMailboxConfig(String backupUser, Path zmmailboxPath, boolean backupInactiveAccounts) {
+
+    public ZimbraMailboxConfig {
+        Objects.requireNonNull(backupUser, "backupUser must not be null");
+        Objects.requireNonNull(zmmailboxPath, "zmmailboxPath must not be null");
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
@@ -1,0 +1,220 @@
+package io.zmbackup.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class YamlConfigLoaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    private static final String FULL_YAML =
+            """
+            zimbraLdap:
+              url: ldap://ldap.example.com:389
+              bindDn: uid=zimbra,cn=admins,cn=zimbra
+              bindPassword: secret
+              sslEnabled: false
+            zimbraMailbox:
+              backupUser: zimbra
+              zmmailboxPath: /opt/zimbra/bin/zmmailbox
+              backupInactiveAccounts: false
+            backup:
+              workDir: /opt/zimbra/backup
+              logFile: /opt/zimbra/log/zmbackup.log
+              blockedListFile: /etc/zmbackup/blockedlist.conf
+              maxParallelProcesses: 5
+              rotateDays: 14
+              lockBackup: false
+              emailNotify:
+                level: ERROR
+                recipient: admin@example.com
+                sender: root@example.com
+            """;
+
+    private static final String MINIMAL_YAML =
+            """
+            zimbraLdap:
+              url: ldap://127.0.0.1:389
+              bindDn: uid=zimbra,cn=admins,cn=zimbra
+              bindPassword: secret
+            zimbraMailbox:
+              backupUser: zimbra
+              zmmailboxPath: /opt/zimbra/bin/zmmailbox
+            backup:
+              workDir: /opt/zimbra/backup
+              logFile: /opt/zimbra/log/zmbackup.log
+              blockedListFile: /etc/zmbackup/blockedlist.conf
+              emailNotify:
+                recipient: admin@example.com
+                sender: root@example.com
+            """;
+
+    @Test
+    void parsesAllFields() {
+        AppConfig config = YamlConfigLoader.load(new StringReader(FULL_YAML));
+
+        assertEquals("ldap://ldap.example.com:389", config.zimbraLdap().url());
+        assertEquals("uid=zimbra,cn=admins,cn=zimbra", config.zimbraLdap().bindDn());
+        assertEquals("secret", config.zimbraLdap().bindPassword());
+        assertFalseSsl(config);
+
+        assertEquals("zimbra", config.zimbraMailbox().backupUser());
+        assertEquals(Path.of("/opt/zimbra/bin/zmmailbox"), config.zimbraMailbox().zmmailboxPath());
+        assertEquals(false, config.zimbraMailbox().backupInactiveAccounts());
+
+        assertEquals(Path.of("/opt/zimbra/backup"), config.backup().workDir());
+        assertEquals(Path.of("/opt/zimbra/log/zmbackup.log"), config.backup().logFile());
+        assertEquals(Path.of("/etc/zmbackup/blockedlist.conf"), config.backup().blockedListFile());
+        assertEquals(5, config.backup().maxParallelProcesses());
+        assertEquals(14, config.backup().rotateDays());
+        assertEquals(false, config.backup().lockBackup());
+        assertEquals(EmailNotifyLevel.ERROR, config.backup().emailNotify().level());
+        assertEquals("admin@example.com", config.backup().emailNotify().recipient());
+        assertEquals("root@example.com", config.backup().emailNotify().sender());
+    }
+
+    private static void assertFalseSsl(AppConfig config) {
+        assertEquals(false, config.zimbraLdap().sslEnabled());
+    }
+
+    @Test
+    void appliesDefaultsForOptionalFields() {
+        AppConfig config = YamlConfigLoader.load(new StringReader(MINIMAL_YAML));
+
+        assertTrue(config.zimbraLdap().sslEnabled());
+        assertTrue(config.zimbraMailbox().backupInactiveAccounts());
+        assertEquals(3, config.backup().maxParallelProcesses());
+        assertEquals(30, config.backup().rotateDays());
+        assertTrue(config.backup().lockBackup());
+        assertEquals(EmailNotifyLevel.ALL, config.backup().emailNotify().level());
+    }
+
+    @Test
+    void loadsFromFile() throws IOException {
+        Path configFile = tempDir.resolve("zmbackup.yaml");
+        Files.writeString(configFile, MINIMAL_YAML);
+
+        AppConfig config = YamlConfigLoader.load(configFile);
+
+        assertEquals("ldap://127.0.0.1:389", config.zimbraLdap().url());
+    }
+
+    @Test
+    void missingFileThrowsConfigException() {
+        Path missing = tempDir.resolve("does-not-exist.yaml");
+
+        ConfigException exception = assertThrows(ConfigException.class, () -> YamlConfigLoader.load(missing));
+        assertTrue(exception.getMessage().contains("does-not-exist.yaml"));
+    }
+
+    @Test
+    void emptyFileThrowsConfigException() {
+        ConfigException exception =
+                assertThrows(ConfigException.class, () -> YamlConfigLoader.load(new StringReader("")));
+        assertEquals("Config file is empty", exception.getMessage());
+    }
+
+    @Test
+    void missingRequiredFieldThrowsConfigException() {
+        String yaml =
+                """
+                zimbraMailbox:
+                  backupUser: zimbra
+                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                backup:
+                  workDir: /opt/zimbra/backup
+                  logFile: /opt/zimbra/log/zmbackup.log
+                  blockedListFile: /etc/zmbackup/blockedlist.conf
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """;
+
+        ConfigException exception =
+                assertThrows(ConfigException.class, () -> YamlConfigLoader.load(new StringReader(yaml)));
+        assertEquals("Missing required config value: zimbraLdap.url", exception.getMessage());
+    }
+
+    @Test
+    void nonMappingSectionThrowsConfigException() {
+        String yaml =
+                """
+                zimbraLdap: not-a-mapping
+                zimbraMailbox:
+                  backupUser: zimbra
+                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                backup:
+                  workDir: /opt/zimbra/backup
+                  logFile: /opt/zimbra/log/zmbackup.log
+                  blockedListFile: /etc/zmbackup/blockedlist.conf
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """;
+
+        ConfigException exception =
+                assertThrows(ConfigException.class, () -> YamlConfigLoader.load(new StringReader(yaml)));
+        assertEquals("Expected a mapping at 'zimbraLdap.url'", exception.getMessage());
+    }
+
+    @Test
+    void wrongTypeThrowsConfigException() {
+        String yaml =
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:389
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                  sslEnabled: not-a-boolean
+                zimbraMailbox:
+                  backupUser: zimbra
+                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                backup:
+                  workDir: /opt/zimbra/backup
+                  logFile: /opt/zimbra/log/zmbackup.log
+                  blockedListFile: /etc/zmbackup/blockedlist.conf
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """;
+
+        ConfigException exception =
+                assertThrows(ConfigException.class, () -> YamlConfigLoader.load(new StringReader(yaml)));
+        assertTrue(exception.getMessage().contains("zimbraLdap.sslEnabled"));
+    }
+
+    @Test
+    void invalidEmailNotifyLevelThrowsConfigException() {
+        String yaml =
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:389
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                zimbraMailbox:
+                  backupUser: zimbra
+                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                backup:
+                  workDir: /opt/zimbra/backup
+                  logFile: /opt/zimbra/log/zmbackup.log
+                  blockedListFile: /etc/zmbackup/blockedlist.conf
+                  emailNotify:
+                    level: LOUD
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """;
+
+        ConfigException exception =
+                assertThrows(ConfigException.class, () -> YamlConfigLoader.load(new StringReader(yaml)));
+        assertTrue(exception.getMessage().contains("backup.emailNotify.level"));
+    }
+}

--- a/project/config/zmbackup.yaml
+++ b/project/config/zmbackup.yaml
@@ -1,0 +1,42 @@
+# zmbackup configuration file (Java tool).
+#
+# Equivalent of zmbackup.conf for the bash tool. Installed at /etc/zmbackup/zmbackup.yaml.
+
+zimbraLdap:
+  # LDAP server URL.
+  url: ldap://127.0.0.1:389
+  # Admin distinguished name used to bind.
+  bindDn: uid=zimbra,cn=admins,cn=zimbra
+  # Admin password used to bind.
+  bindPassword: changeme
+  # Whether to use SSL when talking to the Zimbra server. Optional, defaults to true.
+  sslEnabled: true
+
+zimbraMailbox:
+  # Zimbra service account used to start/stop the service and run zmmailbox.
+  backupUser: zimbra
+  # Location of the zmmailbox binary.
+  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+  # Whether to include disabled accounts. Optional, defaults to true.
+  backupInactiveAccounts: true
+
+backup:
+  # Directory backups and session metadata are stored under.
+  workDir: /opt/zimbra/backup
+  # Path zmbackup writes its logs to.
+  logFile: /opt/zimbra/log/zmbackup.log
+  # Path to the file listing accounts that should never be backed up.
+  blockedListFile: /etc/zmbackup/blockedlist.conf
+  # How many accounts to back up concurrently. Optional, defaults to 3.
+  maxParallelProcesses: 3
+  # How many days of backups to keep before housekeeping deletes them. Optional, defaults to 30.
+  rotateDays: 30
+  # Whether to allow only one backup session per type per day. Optional, defaults to true.
+  lockBackup: true
+  emailNotify:
+    # Which lifecycle events to notify on: ALL, START, FINISH, ERROR, or NONE. Optional, defaults to ALL.
+    level: ALL
+    # Address a report is sent to after each run.
+    recipient: admin@example.com
+    # Address the report is sent from.
+    sender: root@example.com


### PR DESCRIPTION
## Summary
- Adds `AppConfig` and nested records (`ZimbraLdapConfig`, `ZimbraMailboxConfig`, `BackupConfig`, `EmailNotifyConfig`/`EmailNotifyLevel`) representing a parsed `zmbackup.yaml`, mapping the same settings as the bash tool's `zmbackup.conf`.
- Adds `YamlConfigLoader` (SnakeYAML-backed) to parse a config file/reader/stream into `AppConfig`, with clear `ConfigException` messages for missing/malformed fields and sensible defaults for optional settings.
- Adds `project/config/zmbackup.yaml` as a documented reference template, mirroring `project/config/zmbackup.conf`.

Closes #266.

## Test plan
- [x] `./gradlew build` — compiles and all tests pass
- [x] New unit tests in `YamlConfigLoaderTest` cover full/minimal configs, defaults, missing file, empty file, missing required field, wrong type, and invalid enum value

🤖 Generated with [Claude Code](https://claude.com/claude-code)