### PR TITLE
Wire AppContext in app module (#267)

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -1,0 +1,47 @@
+package io.zmbackup.app;
+
+import io.zmbackup.app.config.AppConfig;
+import io.zmbackup.app.config.YamlConfigLoader;
+import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.StorageProvider;
+import io.zmbackup.local.LocalStorageProvider;
+import io.zmbackup.local.SqliteMetadataStore;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Wires the application's components from a parsed {@link AppConfig} with plain {@code new},
+ * standing in for a dependency injection framework.
+ */
+public final class AppContext {
+
+    /** Filename of the SQLite database within {@link io.zmbackup.app.config.BackupConfig#workDir()}. */
+    private static final String METADATA_STORE_FILENAME = "sessions.sqlite3";
+
+    private final AppConfig config;
+    private final StorageProvider storageProvider;
+    private final MetadataStore metadataStore;
+
+    public AppContext(AppConfig config) throws IOException {
+        this.config = config;
+        this.storageProvider = new LocalStorageProvider(config.backup().workDir());
+        this.metadataStore = new SqliteMetadataStore(config.backup().workDir().resolve(METADATA_STORE_FILENAME));
+    }
+
+    /** Reads {@code configFile} and wires the components it describes. */
+    public static AppContext fromConfigFile(Path configFile) throws IOException {
+        return new AppContext(YamlConfigLoader.load(configFile));
+    }
+
+    public AppConfig config() {
+        return config;
+    }
+
+    public StorageProvider storageProvider() {
+        return storageProvider;
+    }
+
+    public MetadataStore metadataStore() {
+        return metadataStore;
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/AppContextTest.java
+++ b/app/src/test/java/io/zmbackup/app/AppContextTest.java
@@ -1,0 +1,81 @@
+package io.zmbackup.app;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.zmbackup.app.config.AppConfig;
+import io.zmbackup.app.config.BackupConfig;
+import io.zmbackup.app.config.EmailNotifyConfig;
+import io.zmbackup.app.config.EmailNotifyLevel;
+import io.zmbackup.app.config.ZimbraLdapConfig;
+import io.zmbackup.app.config.ZimbraMailboxConfig;
+import io.zmbackup.local.LocalStorageProvider;
+import io.zmbackup.local.SqliteMetadataStore;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AppContextTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void wiresComponentsFromConfig() throws IOException {
+        AppConfig config = configWithWorkDir(tempDir);
+
+        AppContext context = new AppContext(config);
+
+        assertEquals(config, context.config());
+        assertInstanceOf(LocalStorageProvider.class, context.storageProvider());
+        assertInstanceOf(SqliteMetadataStore.class, context.metadataStore());
+        assertTrue(Files.exists(tempDir.resolve("sessions.sqlite3")));
+    }
+
+    @Test
+    void fromConfigFileLoadsAndWiresComponents() throws IOException {
+        Path configFile = tempDir.resolve("zmbackup.yaml");
+        Files.writeString(
+                configFile,
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:389
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                zimbraMailbox:
+                  backupUser: zimbra
+                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                backup:
+                  workDir: %s
+                  logFile: %s
+                  blockedListFile: %s
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """
+                        .formatted(
+                                tempDir, tempDir.resolve("zmbackup.log"), tempDir.resolve("blockedlist.conf")));
+
+        AppContext context = AppContext.fromConfigFile(configFile);
+
+        assertEquals("ldap://127.0.0.1:389", context.config().zimbraLdap().url());
+        assertTrue(Files.exists(tempDir.resolve("sessions.sqlite3")));
+    }
+
+    private static AppConfig configWithWorkDir(Path workDir) {
+        return new AppConfig(
+                new ZimbraLdapConfig("ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true),
+                new ZimbraMailboxConfig("zimbra", Path.of("/opt/zimbra/bin/zmmailbox"), true),
+                new BackupConfig(
+                        workDir,
+                        workDir.resolve("zmbackup.log"),
+                        workDir.resolve("blockedlist.conf"),
+                        3,
+                        30,
+                        true,
+                        new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com")));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `AppContext`, wiring `LocalStorageProvider` and `SqliteMetadataStore` from a parsed `AppConfig` with plain `new` (no DI framework), plus a `fromConfigFile` convenience factory
- The `zimbra` module is still empty in this delivery, so LDAP/mailbox ports aren't wired yet — that follows in a later task

Closes #267.

## Test plan
- [x] `./gradlew build` — compiles and all tests pass