### PR TITLE
Implement Picocli entry point with stubbed subcommands

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,4 +3,5 @@ dependencies {
     implementation(project(":zimbra"))
     implementation(project(":local"))
     implementation("org.yaml:snakeyaml:2.6")
+    implementation("info.picocli:picocli:4.7.6")
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupCommand.java
@@ -1,0 +1,20 @@
+package io.zmbackup.app.cli;
+
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+/** Stub for the backup subcommand; real backup logic lands once the zimbra module is implemented. */
+@Command(name = "backup", description = "Run a backup (not yet implemented).")
+public final class BackupCommand implements Callable<Integer> {
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() {
+        spec.commandLine().getErr().println("backup: not yet implemented");
+        return 1;
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/DeleteCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/DeleteCommand.java
@@ -1,0 +1,20 @@
+package io.zmbackup.app.cli;
+
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+/** Stub for the delete subcommand; real deletion logic lands once the zimbra module is implemented. */
+@Command(name = "delete", description = "Delete a stored backup session (not yet implemented).")
+public final class DeleteCommand implements Callable<Integer> {
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() {
+        spec.commandLine().getErr().println("delete: not yet implemented");
+        return 1;
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/HousekeepCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/HousekeepCommand.java
@@ -1,0 +1,20 @@
+package io.zmbackup.app.cli;
+
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+/** Stub for the housekeep subcommand; real cleanup logic lands once the zimbra module is implemented. */
+@Command(name = "housekeep", description = "Prune old backup sessions (not yet implemented).")
+public final class HousekeepCommand implements Callable<Integer> {
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() {
+        spec.commandLine().getErr().println("housekeep: not yet implemented");
+        return 1;
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/ListCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/ListCommand.java
@@ -1,0 +1,46 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.BackupSession;
+import java.io.PrintWriter;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/** Lists all stored backup sessions, mirroring the bash tool's {@code --list}. */
+@Command(name = "list", description = "List stored backup sessions.")
+public final class ListCommand implements Callable<Integer> {
+
+    private static final String BORDER =
+            "+-----------------------------+----------------------+----------------------+----------+--------------------+";
+    private static final String ROW_FORMAT = "| %-27s | %-20s | %-20s | %-8s | %-18s |%n";
+
+    @ParentCommand
+    private Main parent;
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.configFile());
+        PrintWriter out = spec.commandLine().getOut();
+
+        out.println(BORDER);
+        out.printf(ROW_FORMAT, "Session ID", "Started", "Completed", "Size", "Type");
+        out.println(BORDER);
+        for (BackupSession session : context.metadataStore().listSessions()) {
+            out.printf(
+                    ROW_FORMAT,
+                    session.sessionId(),
+                    session.startedAt(),
+                    session.completedAt() == null ? "-" : session.completedAt(),
+                    session.size() == null ? "-" : session.size(),
+                    session.type());
+        }
+        out.println(BORDER);
+        return 0;
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/Main.java
+++ b/app/src/main/java/io/zmbackup/app/cli/Main.java
@@ -1,0 +1,51 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.config.YamlConfigLoader;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+
+/**
+ * Picocli entry point. Dispatches to one of the subcommands, each of which turns the
+ * {@code --config} option into a wired {@link io.zmbackup.app.AppContext}.
+ */
+@Command(
+        name = "zmbackup",
+        subcommands = {
+            BackupCommand.class,
+            RestoreCommand.class,
+            ListCommand.class,
+            DeleteCommand.class,
+            HousekeepCommand.class
+        })
+public final class Main implements Callable<Integer> {
+
+    @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message and exit.")
+    boolean helpRequested;
+
+    @Option(names = "--config", description = "Path to zmbackup.yaml (default: ${DEFAULT-VALUE})")
+    private Path configFile = YamlConfigLoader.DEFAULT_CONFIG_PATH;
+
+    @Spec
+    private CommandSpec spec;
+
+    public static void main(String[] args) {
+        System.exit(new CommandLine(new Main()).execute(args));
+    }
+
+    /** The config file passed via {@code --config}, or {@link YamlConfigLoader#DEFAULT_CONFIG_PATH}. */
+    public Path configFile() {
+        return configFile;
+    }
+
+    /** No subcommand given: show usage instead of doing nothing silently. */
+    @Override
+    public Integer call() {
+        spec.commandLine().usage(spec.commandLine().getOut());
+        return CommandLine.ExitCode.USAGE;
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
@@ -1,0 +1,20 @@
+package io.zmbackup.app.cli;
+
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+/** Stub for the restore subcommand; real restore logic lands once the zimbra module is implemented. */
+@Command(name = "restore", description = "Restore a backup session (not yet implemented).")
+public final class RestoreCommand implements Callable<Integer> {
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() {
+        spec.commandLine().getErr().println("restore: not yet implemented");
+        return 1;
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cli/MainTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MainTest.java
@@ -1,0 +1,132 @@
+package io.zmbackup.app.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import io.zmbackup.local.SqliteMetadataStore;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+class MainTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void noSubcommandPrintsUsage() {
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute();
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(out.toString().contains("Usage: zmbackup"));
+    }
+
+    @Test
+    void listPrintsEmptyTableWhenNoSessionsStored() throws IOException {
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "list");
+
+        assertEquals(0, exitCode);
+        String output = out.toString();
+        assertTrue(output.contains("Session ID"));
+        assertTrue(output.contains("Type"));
+    }
+
+    @Test
+    void listPrintsStoredSessions() throws IOException {
+        Path configFile = writeConfig();
+        new SqliteMetadataStore(tempDir.resolve("sessions.sqlite3"))
+                .save(
+                        new BackupSession(
+                                "full-20260101120000",
+                                BackupType.FULL,
+                                SessionStatus.FINISHED,
+                                Instant.parse("2026-01-01T12:00:00Z"),
+                                Instant.parse("2026-01-01T12:05:00Z"),
+                                "10M"));
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "list");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("full-20260101120000"));
+    }
+
+    @Test
+    void backupIsStubbed() {
+        assertStubbed("backup");
+    }
+
+    @Test
+    void restoreIsStubbed() {
+        assertStubbed("restore");
+    }
+
+    @Test
+    void deleteIsStubbed() {
+        assertStubbed("delete");
+    }
+
+    @Test
+    void housekeepIsStubbed() {
+        assertStubbed("housekeep");
+    }
+
+    private void assertStubbed(String subcommand) {
+        StringWriter err = new StringWriter();
+        CommandLine cmd = commandLine(new StringWriter(), err);
+
+        int exitCode = cmd.execute(subcommand);
+
+        assertEquals(1, exitCode);
+        assertTrue(err.toString().contains("not yet implemented"));
+    }
+
+    private Path writeConfig() throws IOException {
+        Path configFile = tempDir.resolve("zmbackup.yaml");
+        Files.writeString(
+                configFile,
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:389
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                zimbraMailbox:
+                  backupUser: zimbra
+                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                backup:
+                  workDir: %s
+                  logFile: %s
+                  blockedListFile: %s
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """
+                        .formatted(
+                                tempDir, tempDir.resolve("zmbackup.log"), tempDir.resolve("blockedlist.conf")));
+        return configFile;
+    }
+
+    private static CommandLine commandLine(StringWriter out, StringWriter err) {
+        CommandLine cmd = new CommandLine(new Main());
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(err));
+        return cmd;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `io.zmbackup.app.cli.Main`, a Picocli entry point with a `--config` option (defaulting to `YamlConfigLoader.DEFAULT_CONFIG_PATH`) and five subcommands: `backup`, `restore`, `list`, `delete`, `housekeep`.
- `list` is fully wired to `AppContext`/`MetadataStore` and prints a session table (empty when no sessions are stored, matching #255's acceptance criteria).
- `backup`, `restore`, `delete`, `housekeep` are stubs — they print `<name>: not yet implemented` to stderr and exit 1, since real implementations depend on the (still scaffolded) `zimbra` module.
- Adds the `picocli` dependency to `app/build.gradle.kts`.

Closes #268.

## Test plan
- [x] `./gradlew build` — compiles and all tests pass
- [x] Manually ran the built classes: `zmbackup list` exits 0 and prints an empty table; `zmbackup backup` exits 1 with the stub message; `zmbackup` with no subcommand prints usage and exits 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)