### PR TITLE
Write --version command

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,3 +5,9 @@ dependencies {
     implementation("org.yaml:snakeyaml:2.6")
     implementation("info.picocli:picocli:4.7.6")
 }
+
+// Bundle the repo-root VERSION file into the jar so VersionProvider can read it at runtime,
+// keeping it as the single source of truth (it also drives project.version, see root build.gradle.kts).
+tasks.processResources {
+    from(rootDir) { include("VERSION") }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/Main.java
+++ b/app/src/main/java/io/zmbackup/app/cli/Main.java
@@ -15,6 +15,7 @@ import picocli.CommandLine.Spec;
  */
 @Command(
         name = "zmbackup",
+        versionProvider = VersionProvider.class,
         subcommands = {
             BackupCommand.class,
             RestoreCommand.class,
@@ -26,6 +27,9 @@ public final class Main implements Callable<Integer> {
 
     @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message and exit.")
     boolean helpRequested;
+
+    @Option(names = {"-v", "--version"}, versionHelp = true, description = "Show the zmbackup version.")
+    boolean versionRequested;
 
     @Option(names = "--config", description = "Path to zmbackup.yaml (default: ${DEFAULT-VALUE})")
     private Path configFile = YamlConfigLoader.DEFAULT_CONFIG_PATH;

--- a/app/src/main/java/io/zmbackup/app/cli/VersionProvider.java
+++ b/app/src/main/java/io/zmbackup/app/cli/VersionProvider.java
@@ -1,0 +1,18 @@
+package io.zmbackup.app.cli;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import picocli.CommandLine.IVersionProvider;
+
+/** Reads the version string from the {@code VERSION} file bundled into the jar's resources. */
+public final class VersionProvider implements IVersionProvider {
+
+    @Override
+    public String[] getVersion() throws IOException {
+        try (InputStream in = VersionProvider.class.getResourceAsStream("/VERSION")) {
+            String version = new String(in.readAllBytes(), StandardCharsets.UTF_8).trim();
+            return new String[] {"zmbackup version: " + version};
+        }
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cli/MainTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MainTest.java
@@ -34,6 +34,20 @@ class MainTest {
     }
 
     @Test
+    void versionPrintsVersionFromBundledFile() throws IOException {
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--version");
+
+        assertEquals(0, exitCode);
+        try (var in = Main.class.getResourceAsStream("/VERSION")) {
+            String version = new String(in.readAllBytes()).trim();
+            assertTrue(out.toString().contains("zmbackup version: " + version));
+        }
+    }
+
+    @Test
     void listPrintsEmptyTableWhenNoSessionsStored() throws IOException {
         Path configFile = writeConfig();
         StringWriter out = new StringWriter();


### PR DESCRIPTION
## Summary
- Bundle the repo-root `VERSION` file into the `app` module's jar as a classpath resource, keeping it as the single source of truth (it already drives `project.version` in the root build).
- Add `VersionProvider` (Picocli `IVersionProvider`) that reads it at runtime and formats it as `zmbackup version: X`, matching the bash tool's existing `--version` output.
- Wire `-v/--version` into `Main` via `versionHelp = true`.

Closes #269.

## Test plan
- [x] `./gradlew build`
- [x] New `MainTest.versionPrintsVersionFromBundledFile` asserts `--version` exits 0 and prints the bundled version.