### PR TITLE
Write thin bash launcher (#270)

### DIFF
--- a/app/src/main/scripts/zmbackup
+++ b/app/src/main/scripts/zmbackup
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Thin launcher installed at /usr/local/bin/zmbackup. All behaviour lives in
+# the jar; this script only hands off to it.
+exec java -jar /usr/local/lib/zmbackup/zmbackup.jar "$@"

--- a/tests/mocks/java
+++ b/tests/mocks/java
@@ -1,0 +1,4 @@
+#!/bin/bash
+# java mock
+echo "$@"
+exit "${MOCK_JAVA_EXIT:-0}"

--- a/tests/unit/test_launcher.bats
+++ b/tests/unit/test_launcher.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+# Unit tests for the thin bash launcher installed at /usr/local/bin/zmbackup.
+
+load '../setup'
+
+LAUNCHER="${PROJECT_ROOT}/app/src/main/scripts/zmbackup"
+
+setup() {
+  setup_mock_path
+}
+
+@test "launcher: runs java against the installed jar path" {
+  run "$LAUNCHER" --version
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-jar /usr/local/lib/zmbackup/zmbackup.jar"* ]]
+}
+
+@test "launcher: forwards all arguments to java" {
+  run "$LAUNCHER" backup full user@example.com
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"backup full user@example.com"* ]]
+}
+
+@test "launcher: exits with java's exit code" {
+  export MOCK_JAVA_EXIT=3
+  run "$LAUNCHER"
+  [ "$status" -eq 3 ]
+}


### PR DESCRIPTION
## Summary
- Adds `app/src/main/scripts/zmbackup`, the thin launcher installed at `/usr/local/bin/zmbackup`: it execs `java -jar /usr/local/lib/zmbackup/zmbackup.jar "$@"`, forwarding all arguments and exit codes to the jar.
- Sub-task of #255.

Closes #270

## Test plan
- [x] `npx bats --verbose-run tests/unit/test_launcher.bats` — new tests pass (java mocked via `tests/mocks/java`)
- [x] `npx bats --verbose-run tests/unit/` — full unit suite passes (418 tests)
- [x] `./gradlew test` — Java build unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)