### PR TITLE
Package app module as a runnable fat jar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("com.gradleup.shadow") version "8.3.6"
+}
+
 dependencies {
     implementation(project(":core"))
     implementation(project(":zimbra"))
@@ -10,4 +14,17 @@ dependencies {
 // keeping it as the single source of truth (it also drives project.version, see root build.gradle.kts).
 tasks.processResources {
     from(rootDir) { include("VERSION") }
+}
+
+// The thin bash launcher runs `java -jar zmbackup.jar`, so the jar must be self-contained
+// (all dependencies bundled) and executable (Main-Class set).
+tasks.shadowJar {
+    archiveFileName.set("zmbackup.jar")
+    manifest {
+        attributes["Main-Class"] = "io.zmbackup.app.cli.Main"
+    }
+}
+
+tasks.build {
+    dependsOn(tasks.shadowJar)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,3 +28,9 @@ tasks.shadowJar {
 tasks.build {
     dependsOn(tasks.shadowJar)
 }
+
+// Packaging smoke tests run the shaded jar as a subprocess, so it must exist first.
+tasks.test {
+    dependsOn(tasks.shadowJar)
+    systemProperty("zmbackup.shadowJar", tasks.shadowJar.get().archiveFile.get().asFile.absolutePath)
+}

--- a/app/src/test/java/io/zmbackup/app/cli/ShadowJarSmokeTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/ShadowJarSmokeTest.java
@@ -1,0 +1,92 @@
+package io.zmbackup.app.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Runs the actual shaded jar as a subprocess, the way the thin bash launcher does
+ * ({@code java -jar zmbackup.jar}). Tests that invoke {@link Main} in-process exercise its logic
+ * but can't catch packaging problems (missing Main-Class, unbundled dependencies), since they run
+ * against compiled classes on the test classpath rather than the built artifact.
+ */
+class ShadowJarSmokeTest {
+
+    private static final int TIMEOUT_SECONDS = 30;
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void versionRunsAgainstPackagedJar() throws IOException, InterruptedException {
+        Process process = runJar("--version");
+
+        assertTrue(process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        String output = outputOf(process);
+        assertEquals(0, process.exitValue(), output);
+        assertTrue(output.contains("zmbackup version:"), output);
+    }
+
+    @Test
+    void listRunsAgainstPackagedJar() throws IOException, InterruptedException {
+        Path configFile = writeConfig();
+
+        Process process = runJar("--config", configFile.toString(), "list");
+
+        assertTrue(process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        String output = outputOf(process);
+        assertEquals(0, process.exitValue(), output);
+        assertTrue(output.contains("Session ID"), output);
+    }
+
+    private static Process runJar(String... args) throws IOException {
+        String jarPath = System.getProperty("zmbackup.shadowJar");
+        String javaBin =
+                Path.of(System.getProperty("java.home"), "bin", "java").toString();
+
+        List<String> command = new ArrayList<>();
+        command.add(javaBin);
+        command.add("-jar");
+        command.add(jarPath);
+        command.addAll(List.of(args));
+
+        return new ProcessBuilder(command).redirectErrorStream(true).start();
+    }
+
+    private static String outputOf(Process process) throws IOException {
+        return new String(process.getInputStream().readAllBytes());
+    }
+
+    private Path writeConfig() throws IOException {
+        Path configFile = tempDir.resolve("zmbackup.yaml");
+        Files.writeString(
+                configFile,
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:389
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                zimbraMailbox:
+                  backupUser: zimbra
+                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                backup:
+                  workDir: %s
+                  logFile: %s
+                  blockedListFile: %s
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """
+                        .formatted(
+                                tempDir, tempDir.resolve("zmbackup.log"), tempDir.resolve("blockedlist.conf")));
+        return configFile;
+    }
+}


### PR DESCRIPTION
## Summary
- All 12 sub-issues of #255 were closed, but the issue's own validation criteria (`zmbackup --version` / `zmbackup list` exiting 0) actually failed: the `app` module's jar had no `Main-Class` manifest attribute and none of its runtime dependencies (picocli, snakeyaml, sqlite-jdbc, `core`/`zimbra`/`local`) bundled, so the thin bash launcher's `java -jar zmbackup.jar` failed with "no main manifest attribute".
- Added the Shadow plugin to `app/build.gradle.kts` to produce a self-contained, executable `zmbackup.jar` with `Main-Class` set, wired into `build`.
- Added `ShadowJarSmokeTest`, which runs the actual shaded jar as a subprocess (`--version`, `list`) the way the launcher does, since in-process tests exercise `Main`'s logic but can't catch packaging regressions against compiled test classes.

Closes #255

## Test plan
- [x] `./gradlew build` — compiles, all unit + smoke tests pass
- [x] `java -jar app/build/libs/zmbackup.jar --version` exits 0
- [x] `java -jar app/build/libs/zmbackup.jar --config <fixture> list` exits 0, prints empty table
- [x] `npx bats --verbose-run tests/unit/` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)