### PR TITLE
Add UnboundID LDAP SDK dependency to zimbra module (#273)

### DIFF
--- a/zimbra/build.gradle.kts
+++ b/zimbra/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
     implementation(project(":core"))
+    implementation("com.unboundid:unboundid-ldapsdk:7.0.5")
 }


### PR DESCRIPTION
## Summary
- Add `com.unboundid:unboundid-ldapsdk:7.0.5` as an `implementation` dependency of the `zimbra` module

Sub-task of #256, closes #273.

## Test plan
- [x] `./gradlew :zimbra:dependencies --configuration compileClasspath` resolves the new dependency
- [x] `./gradlew build -x test` succeeds across all modules

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWqtTvdByfv2zrNWB7LTTN)_