### PR TITLE
Implement UnboundIdLdapAdapter — connection and StartTLS setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Working conventions for this repo
+
+## Pull requests
+
+When a task's changes are pushed to a branch, always open a pull request for
+it (don't just push and stop) — unless the user explicitly says not to.
+
+After opening a PR, subscribe to its activity (`subscribe_pr_activity`) and
+keep watching it: address review comments, fix CI failures, and keep the PR
+moving toward a mergeable state until it is merged or closed, per the
+standard PR-babysitting rules already in effect.

--- a/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
@@ -1,0 +1,79 @@
+package io.zmbackup.zimbra;
+
+import com.unboundid.ldap.sdk.ExtendedResult;
+import com.unboundid.ldap.sdk.LDAPConnection;
+import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.LDAPURL;
+import com.unboundid.ldap.sdk.ResultCode;
+import com.unboundid.ldap.sdk.extensions.StartTLSExtendedRequest;
+import com.unboundid.util.ssl.SSLUtil;
+import com.unboundid.util.ssl.TrustAllTrustManager;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import javax.net.ssl.SSLContext;
+
+/**
+ * Connects to Zimbra's LDAP directory via the UnboundID LDAP SDK, mirroring the {@code
+ * ldapsearch} invocations in the bash tool's {@code MiscAction.sh}. Account and domain
+ * enumeration is built on top of {@link #connect()} in follow-up work.
+ */
+public class UnboundIdLdapAdapter {
+
+    private final String host;
+    private final int port;
+    private final String bindDn;
+    private final String bindPassword;
+    private final boolean startTls;
+
+    /**
+     * @param url          the LDAP server URL, e.g. {@code "ldap://127.0.0.1:389"}
+     * @param bindDn       the admin distinguished name used to bind
+     * @param bindPassword the admin password used to bind
+     * @param startTls     whether to upgrade the connection with StartTLS before binding
+     */
+    public UnboundIdLdapAdapter(String url, String bindDn, String bindPassword, boolean startTls) {
+        LDAPURL parsedUrl;
+        try {
+            parsedUrl = new LDAPURL(url);
+        } catch (LDAPException e) {
+            throw new IllegalArgumentException("Invalid LDAP URL: " + url, e);
+        }
+        this.host = parsedUrl.getHost();
+        this.port = parsedUrl.getPort();
+        this.bindDn = bindDn;
+        this.bindPassword = bindPassword;
+        this.startTls = startTls;
+    }
+
+    /**
+     * Opens a new connection to the configured server, upgrading it with StartTLS first when
+     * configured, then binds as the admin account. Callers are responsible for closing the
+     * returned connection.
+     */
+    LDAPConnection connect() throws IOException {
+        LDAPConnection connection = null;
+        try {
+            connection = new LDAPConnection(host, port);
+            if (startTls) {
+                // Zimbra's own LDAP server uses a self-signed certificate that isn't in the JVM's
+                // default trust store, so trust it the same way the bash tool's ldapsearch does
+                // via its default ldaprc (TLS_REQCERT never) rather than requiring a CA bundle.
+                SSLContext sslContext = new SSLUtil(new TrustAllTrustManager()).createSSLContext();
+                ExtendedResult startTlsResult =
+                        connection.processExtendedOperation(new StartTLSExtendedRequest(sslContext));
+                if (startTlsResult.getResultCode() != ResultCode.SUCCESS) {
+                    throw new LDAPException(
+                            startTlsResult.getResultCode(),
+                            "StartTLS negotiation failed: " + startTlsResult.getDiagnosticMessage());
+                }
+            }
+            connection.bind(bindDn, bindPassword);
+            return connection;
+        } catch (LDAPException | GeneralSecurityException e) {
+            if (connection != null) {
+                connection.close();
+            }
+            throw new IOException("Failed to connect to Zimbra LDAP at " + host + ":" + port, e);
+        }
+    }
+}

--- a/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
@@ -1,0 +1,129 @@
+package io.zmbackup.zimbra;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.unboundid.ldap.listener.InMemoryDirectoryServer;
+import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
+import com.unboundid.ldap.listener.InMemoryListenerConfig;
+import com.unboundid.ldap.sdk.DN;
+import com.unboundid.ldap.sdk.LDAPConnection;
+import com.unboundid.util.ObjectPair;
+import com.unboundid.util.ssl.KeyStoreKeyManager;
+import com.unboundid.util.ssl.SSLUtil;
+import com.unboundid.util.ssl.TrustAllTrustManager;
+import com.unboundid.util.ssl.cert.PublicKeyAlgorithmIdentifier;
+import com.unboundid.util.ssl.cert.SignatureAlgorithmIdentifier;
+import com.unboundid.util.ssl.cert.X509Certificate;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.time.Duration;
+import javax.net.ssl.SSLSocketFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class UnboundIdLdapAdapterTest {
+
+    private static final String BIND_DN = "uid=zimbra,cn=admins,cn=zimbra";
+    private static final String BIND_PASSWORD = "secret";
+
+    private InMemoryDirectoryServer directoryServer;
+    private Path keyStoreFile;
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (directoryServer != null) {
+            directoryServer.shutDown(true);
+        }
+        if (keyStoreFile != null) {
+            Files.deleteIfExists(keyStoreFile);
+        }
+    }
+
+    @Test
+    void connectsAndBindsWithoutStartTls() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        try (LDAPConnection connection = adapter.connect()) {
+            assertTrue(connection.isConnected());
+        }
+    }
+
+    @Test
+    void connectsAndBindsWithStartTls() throws Exception {
+        directoryServer = startDirectoryServer(serverStartTlsSocketFactory());
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, true);
+
+        try (LDAPConnection connection = adapter.connect()) {
+            assertTrue(connection.isConnected());
+        }
+    }
+
+    @Test
+    void wrapsInvalidCredentialsInIOException() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, "wrong-password", false);
+
+        assertThrows(IOException.class, adapter::connect);
+    }
+
+    @Test
+    void wrapsUnreachableServerInIOException() {
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false);
+
+        assertThrows(IOException.class, adapter::connect);
+    }
+
+    @Test
+    void rejectsInvalidUrl() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new UnboundIdLdapAdapter("not-a-url", BIND_DN, BIND_PASSWORD, false));
+    }
+
+    private InMemoryDirectoryServer startDirectoryServer(SSLSocketFactory startTlsSocketFactory) throws Exception {
+        InMemoryDirectoryServerConfig config = new InMemoryDirectoryServerConfig("dc=example,dc=com");
+        config.addAdditionalBindCredentials(BIND_DN, BIND_PASSWORD);
+        config.setListenerConfigs(
+                InMemoryListenerConfig.createLDAPConfig("default", null, 0, startTlsSocketFactory));
+        InMemoryDirectoryServer server = new InMemoryDirectoryServer(config);
+        server.startListening();
+        return server;
+    }
+
+    /** A throwaway self-signed cert/key so the in-memory server can negotiate StartTLS. */
+    private SSLSocketFactory serverStartTlsSocketFactory() throws Exception {
+        ObjectPair<X509Certificate, KeyPair> certAndKey = X509Certificate.generateSelfSignedCertificate(
+                SignatureAlgorithmIdentifier.SHA_256_WITH_RSA,
+                PublicKeyAlgorithmIdentifier.RSA,
+                2048,
+                new DN("CN=localhost"),
+                System.currentTimeMillis(),
+                System.currentTimeMillis() + Duration.ofDays(1).toMillis());
+
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, null);
+        keyStore.setKeyEntry(
+                "server-cert",
+                certAndKey.getSecond().getPrivate(),
+                BIND_PASSWORD.toCharArray(),
+                new Certificate[] {certAndKey.getFirst().toCertificate()});
+
+        keyStoreFile = Files.createTempFile("zmbackup-test-keystore", ".p12");
+        try (OutputStream out = Files.newOutputStream(keyStoreFile)) {
+            keyStore.store(out, BIND_PASSWORD.toCharArray());
+        }
+
+        KeyStoreKeyManager keyManager = new KeyStoreKeyManager(keyStoreFile.toFile(), BIND_PASSWORD.toCharArray());
+        return new SSLUtil(keyManager, new TrustAllTrustManager()).createSSLSocketFactory();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `UnboundIdLdapAdapter` to the `zimbra` module: opens a connection to Zimbra's LDAP directory via the UnboundID SDK, optionally negotiating StartTLS before binding as the admin account.
- Trusts the server's certificate during the StartTLS handshake, matching the bash tool's default `ldaprc` (`TLS_REQCERT never`) against Zimbra's self-signed LDAP certificate.
- Account/domain enumeration (`discover`/`discoverForDomain`) is intentionally left to the follow-up sub-tasks of #256 (#275, #276) — this PR is scoped to connection + StartTLS setup only, per #274.
- Adds `CLAUDE.md` documenting the working convention to always open and monitor a PR for pushed work.

Closes #274.

## Test plan
- [x] `./gradlew :zimbra:test` — `UnboundIdLdapAdapterTest` (5 tests) verifies connect+bind with and without StartTLS against an in-memory LDAP server (StartTLS test uses a generated self-signed cert), invalid-credential and unreachable-server failures wrap into `IOException`, and an invalid URL is rejected.
- [x] `./gradlew build` — full project build and test suite passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MJhmXMsh4HEoAaHGLgnSun)_