### PR TITLE
Implement listAccounts(LdapObjectType) (#275)

### DIFF
--- a/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
@@ -1,23 +1,31 @@
 package io.zmbackup.zimbra;
 
+import com.unboundid.ldap.sdk.Entry;
 import com.unboundid.ldap.sdk.ExtendedResult;
 import com.unboundid.ldap.sdk.LDAPConnection;
 import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldap.sdk.LDAPURL;
 import com.unboundid.ldap.sdk.ResultCode;
+import com.unboundid.ldap.sdk.SearchRequest;
+import com.unboundid.ldap.sdk.SearchResult;
+import com.unboundid.ldap.sdk.SearchScope;
 import com.unboundid.ldap.sdk.extensions.StartTLSExtendedRequest;
 import com.unboundid.util.ssl.SSLUtil;
 import com.unboundid.util.ssl.TrustAllTrustManager;
+import io.zmbackup.core.domain.LdapObjectType;
+import io.zmbackup.core.port.AccountDiscovery;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.List;
 import javax.net.ssl.SSLContext;
 
 /**
  * Connects to Zimbra's LDAP directory via the UnboundID LDAP SDK, mirroring the {@code
- * ldapsearch} invocations in the bash tool's {@code MiscAction.sh}. Account and domain
- * enumeration is built on top of {@link #connect()} in follow-up work.
+ * ldapsearch} invocations in the bash tool's {@code MiscAction.sh}. Domain-scoped enumeration is
+ * built on top of {@link #connect()} in follow-up work.
  */
-public class UnboundIdLdapAdapter {
+public class UnboundIdLdapAdapter implements AccountDiscovery {
 
     private final String host;
     private final int port;
@@ -43,6 +51,46 @@ public class UnboundIdLdapAdapter {
         this.bindDn = bindDn;
         this.bindPassword = bindPassword;
         this.startTls = startTls;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Mirrors {@code build_listBKP}'s whole-directory search in the bash tool: {@code
+     * ldapsearch -b '' <objectFilter> <attributeName>}.
+     */
+    @Override
+    public List<String> discover(LdapObjectType type) throws IOException {
+        return search("", type);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws UnsupportedOperationException domain-scoped discovery is implemented in a
+     *     follow-up task
+     */
+    @Override
+    public List<String> discoverForDomain(LdapObjectType type, String domain) throws IOException {
+        throw new UnsupportedOperationException("discoverForDomain is not yet implemented");
+    }
+
+    private List<String> search(String baseDn, LdapObjectType type) throws IOException {
+        try (LDAPConnection connection = connect()) {
+            SearchRequest searchRequest = new SearchRequest(
+                    baseDn, SearchScope.SUB, type.objectFilter(), type.attributeName());
+            SearchResult searchResult = connection.search(searchRequest);
+            List<String> values = new ArrayList<>();
+            for (Entry entry : searchResult.getSearchEntries()) {
+                String value = entry.getAttributeValue(type.attributeName());
+                if (value != null) {
+                    values.add(value);
+                }
+            }
+            return values;
+        } catch (LDAPException e) {
+            throw new IOException("Failed to search Zimbra LDAP at " + host + ":" + port, e);
+        }
     }
 
     /**

--- a/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
@@ -1,11 +1,13 @@
 package io.zmbackup.zimbra;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
 import com.unboundid.ldap.listener.InMemoryListenerConfig;
+import com.unboundid.ldap.sdk.Attribute;
 import com.unboundid.ldap.sdk.DN;
 import com.unboundid.ldap.sdk.LDAPConnection;
 import com.unboundid.util.ObjectPair;
@@ -15,6 +17,7 @@ import com.unboundid.util.ssl.TrustAllTrustManager;
 import com.unboundid.util.ssl.cert.PublicKeyAlgorithmIdentifier;
 import com.unboundid.util.ssl.cert.SignatureAlgorithmIdentifier;
 import com.unboundid.util.ssl.cert.X509Certificate;
+import io.zmbackup.core.domain.LdapObjectType;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -23,6 +26,7 @@ import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.time.Duration;
+import java.util.List;
 import javax.net.ssl.SSLSocketFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -90,13 +94,61 @@ class UnboundIdLdapAdapterTest {
                 () -> new UnboundIdLdapAdapter("not-a-url", BIND_DN, BIND_PASSWORD, false));
     }
 
+    @Test
+    void discoverReturnsIdentifyingAttributeForMatchingEntries() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"));
+        directoryServer.add(
+                "uid=bob,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "bob"),
+                new Attribute("zimbraMailDeliveryAddress", "bob@example.com"));
+        directoryServer.add(
+                "cn=engineering,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraDistributionList"),
+                new Attribute("cn", "engineering"),
+                new Attribute("mail", "engineering@example.com"));
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        List<String> accounts = adapter.discover(LdapObjectType.ACCOUNT);
+
+        assertEquals(List.of("alice@example.com", "bob@example.com"), accounts);
+    }
+
+    @Test
+    void discoverReturnsEmptyListWhenNoEntriesMatch() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        assertEquals(List.of(), adapter.discover(LdapObjectType.ACCOUNT));
+    }
+
+    @Test
+    void discoverForDomainIsNotYetImplemented() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> adapter.discoverForDomain(LdapObjectType.ACCOUNT, "example.com"));
+    }
+
     private InMemoryDirectoryServer startDirectoryServer(SSLSocketFactory startTlsSocketFactory) throws Exception {
         InMemoryDirectoryServerConfig config = new InMemoryDirectoryServerConfig("dc=example,dc=com");
         config.addAdditionalBindCredentials(BIND_DN, BIND_PASSWORD);
+        config.setSchema(null);
         config.setListenerConfigs(
                 InMemoryListenerConfig.createLDAPConfig("default", null, 0, startTlsSocketFactory));
         InMemoryDirectoryServer server = new InMemoryDirectoryServer(config);
         server.startListening();
+        server.add("dc=example,dc=com", new Attribute("objectClass", "domain"), new Attribute("dc", "example"));
         return server;
     }
 


### PR DESCRIPTION
## Summary
- `UnboundIdLdapAdapter` now implements `AccountDiscovery`, adding `discover(LdapObjectType)`: a whole-directory LDAP search for the type's `objectFilter()` that collects each matching entry's `attributeName()`, mirroring `build_listBKP`'s non-domain-scoped `ldapsearch -b '' <filter> <attribute>` call in the bash tool's `MiscAction.sh`/`ListAction.sh`.
- `discoverForDomain(LdapObjectType, String)` is left as an explicit `UnsupportedOperationException` stub — domain-scoped search (`ldapsearch -b "dc=..."`) is sub-task #276.

## Test plan
- [x] Added `UnboundIdLdapAdapterTest` cases using UnboundID's `InMemoryDirectoryServer` (schema checking disabled) seeded with fixture `zimbraAccount`/`zimbraDistributionList` entries, verifying `discover` returns only the matching type's identifying attribute values, in entry order, and an empty list when nothing matches.
- [x] Added a test confirming `discoverForDomain` throws `UnsupportedOperationException` for now.
- [x] `./gradlew :zimbra:test` — all 8 tests pass.
- [x] `./gradlew build -x test` — full multi-module build succeeds.

Closes #275.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVfaQxXq1Jyh2AMZuuQEx9)_