### PR TITLE
Implement listAccountsForDomain(domain, LdapObjectType) (#276)

### DIFF
--- a/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
@@ -22,8 +22,7 @@ import javax.net.ssl.SSLContext;
 
 /**
  * Connects to Zimbra's LDAP directory via the UnboundID LDAP SDK, mirroring the {@code
- * ldapsearch} invocations in the bash tool's {@code MiscAction.sh}. Domain-scoped enumeration is
- * built on top of {@link #connect()} in follow-up work.
+ * ldapsearch} invocations in the bash tool's {@code MiscAction.sh}.
  */
 public class UnboundIdLdapAdapter implements AccountDiscovery {
 
@@ -67,12 +66,24 @@ public class UnboundIdLdapAdapter implements AccountDiscovery {
     /**
      * {@inheritDoc}
      *
-     * @throws UnsupportedOperationException domain-scoped discovery is implemented in a
-     *     follow-up task
+     * <p>Mirrors {@code build_listBKP}'s per-domain search in the bash tool: {@code ldapsearch -b
+     * "dc=<label>,dc=<label>,..." <objectFilter> <attributeName>}, with the base DN built from the
+     * domain's dot-separated labels.
      */
     @Override
     public List<String> discoverForDomain(LdapObjectType type, String domain) throws IOException {
-        throw new UnsupportedOperationException("discoverForDomain is not yet implemented");
+        return search(domainBaseDn(domain), type);
+    }
+
+    private static String domainBaseDn(String domain) {
+        StringBuilder baseDn = new StringBuilder();
+        for (String label : domain.split("\\.")) {
+            if (baseDn.length() > 0) {
+                baseDn.append(',');
+            }
+            baseDn.append("dc=").append(label);
+        }
+        return baseDn.toString();
     }
 
     private List<String> search(String baseDn, LdapObjectType type) throws IOException {

--- a/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
@@ -130,18 +130,49 @@ class UnboundIdLdapAdapterTest {
     }
 
     @Test
-    void discoverForDomainIsNotYetImplemented() throws Exception {
+    void discoverForDomainReturnsOnlyEntriesUnderThatDomain() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        directoryServer.add(
+                "dc=other,dc=com", new Attribute("objectClass", "domain"), new Attribute("dc", "other"));
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"));
+        directoryServer.add(
+                "uid=carol,dc=other,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "carol"),
+                new Attribute("zimbraMailDeliveryAddress", "carol@other.com"));
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        List<String> accounts = adapter.discoverForDomain(LdapObjectType.ACCOUNT, "example.com");
+
+        assertEquals(List.of("alice@example.com"), accounts);
+    }
+
+    @Test
+    void discoverForDomainReturnsEmptyListWhenDomainHasNoMatches() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
                 "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
 
-        assertThrows(
-                UnsupportedOperationException.class,
-                () -> adapter.discoverForDomain(LdapObjectType.ACCOUNT, "example.com"));
+        assertEquals(List.of(), adapter.discoverForDomain(LdapObjectType.ACCOUNT, "example.com"));
+    }
+
+    @Test
+    void discoverForDomainWrapsUnknownBaseDnInIOException() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        assertThrows(IOException.class, () -> adapter.discoverForDomain(LdapObjectType.ACCOUNT, "nowhere.invalid"));
     }
 
     private InMemoryDirectoryServer startDirectoryServer(SSLSocketFactory startTlsSocketFactory) throws Exception {
-        InMemoryDirectoryServerConfig config = new InMemoryDirectoryServerConfig("dc=example,dc=com");
+        InMemoryDirectoryServerConfig config =
+                new InMemoryDirectoryServerConfig("dc=example,dc=com", "dc=other,dc=com");
         config.addAdditionalBindCredentials(BIND_DN, BIND_PASSWORD);
         config.setSchema(null);
         config.setListenerConfigs(


### PR DESCRIPTION
## Summary
- `UnboundIdLdapAdapter.discoverForDomain()` now scopes the LDAP search to the domain's base DN (`dc=<label>,dc=<label>,...`), built from the domain's dot-separated labels, instead of throwing `UnsupportedOperationException`.
- Mirrors `build_listBKP`'s per-domain `ldapsearch -b "dc=..."` invocation in the bash tool.

Closes #276 (sub-task of #256).

## Test plan
- [x] `./gradlew :zimbra:test --tests "io.zmbackup.zimbra.UnboundIdLdapAdapterTest"` — new tests cover: entries scoped correctly to their domain (using an `InMemoryDirectoryServer` configured with two domain base DNs), empty result when a domain has no matches, and an unknown domain wraps the LDAP error in `IOException`.
- [x] `./gradlew build` — full build passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_011x1NCh5j2Q5ZSrNaMQvCj9)_