### PR TITLE
Implement listDomains() (#277)

### DIFF
--- a/core/src/main/java/io/zmbackup/core/port/AccountDiscovery.java
+++ b/core/src/main/java/io/zmbackup/core/port/AccountDiscovery.java
@@ -21,4 +21,12 @@ public interface AccountDiscovery {
      * {@code "example.com"}).
      */
     List<String> discoverForDomain(LdapObjectType type, String domain) throws IOException;
+
+    /**
+     * The name of every Zimbra domain in the directory, i.e. {@link #discover(LdapObjectType)}
+     * for {@link LdapObjectType#DOMAIN}.
+     */
+    default List<String> listDomains() throws IOException {
+        return discover(LdapObjectType.DOMAIN);
+    }
 }

--- a/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
@@ -170,6 +170,36 @@ class UnboundIdLdapAdapterTest {
         assertThrows(IOException.class, () -> adapter.discoverForDomain(LdapObjectType.ACCOUNT, "nowhere.invalid"));
     }
 
+    @Test
+    void listDomainsReturnsEveryDomainInTheDirectory() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        directoryServer.add(
+                "dc=other,dc=com",
+                new Attribute("objectClass", "zimbraDomain"),
+                new Attribute("dc", "other"),
+                new Attribute("zimbraDomainName", "other.com"));
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"));
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        List<String> domains = adapter.listDomains();
+
+        assertEquals(List.of("other.com"), domains);
+    }
+
+    @Test
+    void listDomainsReturnsEmptyListWhenNoDomainsMatch() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        assertEquals(List.of(), adapter.listDomains());
+    }
+
     private InMemoryDirectoryServer startDirectoryServer(SSLSocketFactory startTlsSocketFactory) throws Exception {
         InMemoryDirectoryServerConfig config =
                 new InMemoryDirectoryServerConfig("dc=example,dc=com", "dc=other,dc=com");


### PR DESCRIPTION
## Summary
- Adds a `listDomains()` default method to `AccountDiscovery`, delegating to `discover(LdapObjectType.DOMAIN)`.
- Domains are enumerated whole-directory the same way as other LDAP object types (there's no per-domain scoping concept for domains themselves), so this stays a thin, name-clarifying wrapper around the existing generic `discover`/`discoverForDomain` methods added in #275/#276, rather than duplicating the search logic in `UnboundIdLdapAdapter`.

Closes #277 (sub-task of #256).

## Test plan
- [x] Added `UnboundIdLdapAdapterTest` cases verifying `listDomains()` returns only `zimbraDomain` entries' `zimbraDomainName`, and an empty list when none match.
- [x] `./gradlew :zimbra:test` — all 12 tests pass.
- [x] `./gradlew build` — full multi-module build succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAEBnpLzWdJ9iwBcCitGiy)_