### PR TITLE
Wire UnboundIdLdapAdapter into AppContext

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -2,10 +2,12 @@ package io.zmbackup.app;
 
 import io.zmbackup.app.config.AppConfig;
 import io.zmbackup.app.config.YamlConfigLoader;
+import io.zmbackup.core.port.AccountDiscovery;
 import io.zmbackup.core.port.MetadataStore;
 import io.zmbackup.core.port.StorageProvider;
 import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
+import io.zmbackup.zimbra.UnboundIdLdapAdapter;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -21,11 +23,17 @@ public final class AppContext {
     private final AppConfig config;
     private final StorageProvider storageProvider;
     private final MetadataStore metadataStore;
+    private final AccountDiscovery accountDiscovery;
 
     public AppContext(AppConfig config) throws IOException {
         this.config = config;
         this.storageProvider = new LocalStorageProvider(config.backup().workDir());
         this.metadataStore = new SqliteMetadataStore(config.backup().workDir().resolve(METADATA_STORE_FILENAME));
+        this.accountDiscovery = new UnboundIdLdapAdapter(
+                config.zimbraLdap().url(),
+                config.zimbraLdap().bindDn(),
+                config.zimbraLdap().bindPassword(),
+                config.zimbraLdap().sslEnabled());
     }
 
     /** Reads {@code configFile} and wires the components it describes. */
@@ -43,5 +51,9 @@ public final class AppContext {
 
     public MetadataStore metadataStore() {
         return metadataStore;
+    }
+
+    public AccountDiscovery accountDiscovery() {
+        return accountDiscovery;
     }
 }

--- a/app/src/test/java/io/zmbackup/app/AppContextTest.java
+++ b/app/src/test/java/io/zmbackup/app/AppContextTest.java
@@ -12,6 +12,7 @@ import io.zmbackup.app.config.ZimbraLdapConfig;
 import io.zmbackup.app.config.ZimbraMailboxConfig;
 import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
+import io.zmbackup.zimbra.UnboundIdLdapAdapter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,6 +33,7 @@ class AppContextTest {
         assertEquals(config, context.config());
         assertInstanceOf(LocalStorageProvider.class, context.storageProvider());
         assertInstanceOf(SqliteMetadataStore.class, context.metadataStore());
+        assertInstanceOf(UnboundIdLdapAdapter.class, context.accountDiscovery());
         assertTrue(Files.exists(tempDir.resolve("sessions.sqlite3")));
     }
 


### PR DESCRIPTION
## Summary
- `AppContext` now constructs a `UnboundIdLdapAdapter` from the parsed `zimbraLdap` config (url, bindDn, bindPassword, sslEnabled → startTls) and exposes it as `AccountDiscovery` via a new `accountDiscovery()` accessor.
- This gives CLI commands (e.g. the upcoming `zmbackup accounts list`) a wired path to LDAP account discovery through the app's existing DI stand-in.

## Test plan
- [x] `./gradlew :app:test :zimbra:test :core:test :local:test` — all pass
- [x] Extended `AppContextTest.wiresComponentsFromConfig` to assert `context.accountDiscovery()` is an `UnboundIdLdapAdapter`

Closes #278.

---
_Generated by [Claude Code](https://claude.ai/code/session_019bSUg2dG827rjdLhjmohXs)_