### PR TITLE
Add zmbackup accounts list Picocli command

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(project(":local"))
     implementation("org.yaml:snakeyaml:2.6")
     implementation("info.picocli:picocli:4.7.6")
+    testImplementation("com.unboundid:unboundid-ldapsdk:7.0.5")
 }
 
 // Bundle the repo-root VERSION file into the jar so VersionProvider can read it at runtime,

--- a/app/src/main/java/io/zmbackup/app/cli/AccountsCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/AccountsCommand.java
@@ -1,0 +1,30 @@
+package io.zmbackup.app.cli;
+
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/** Groups diagnostic LDAP account/domain enumeration subcommands. */
+@Command(name = "accounts", subcommands = AccountsListCommand.class)
+public final class AccountsCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private Main parent;
+
+    @Spec
+    private CommandSpec spec;
+
+    Main parent() {
+        return parent;
+    }
+
+    /** No subcommand given: show usage instead of doing nothing silently. */
+    @Override
+    public Integer call() {
+        spec.commandLine().usage(spec.commandLine().getOut());
+        return CommandLine.ExitCode.USAGE;
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/AccountsListCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/AccountsListCommand.java
@@ -1,0 +1,46 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.LdapObjectType;
+import io.zmbackup.core.port.AccountDiscovery;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/**
+ * Prints every Zimbra account found in LDAP, mirroring {@code zmbackup -f -ldp} in the bash tool.
+ * Diagnostic only: it does not perform a backup.
+ */
+@Command(name = "list", description = "List Zimbra accounts from LDAP (diagnostic; not a backup operation).")
+public final class AccountsListCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private AccountsCommand parent;
+
+    @Option(names = "--domain", description = "Restrict the listing to this Zimbra domain (e.g. example.com).")
+    private String domain;
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
+        AccountDiscovery accountDiscovery = context.accountDiscovery();
+        List<String> accounts =
+                domain == null
+                        ? accountDiscovery.discover(LdapObjectType.ACCOUNT)
+                        : accountDiscovery.discoverForDomain(LdapObjectType.ACCOUNT, domain);
+
+        PrintWriter out = spec.commandLine().getOut();
+        for (String account : accounts) {
+            out.println(account);
+        }
+        return 0;
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/Main.java
+++ b/app/src/main/java/io/zmbackup/app/cli/Main.java
@@ -21,7 +21,8 @@ import picocli.CommandLine.Spec;
             RestoreCommand.class,
             ListCommand.class,
             DeleteCommand.class,
-            HousekeepCommand.class
+            HousekeepCommand.class,
+            AccountsCommand.class
         })
 public final class Main implements Callable<Integer> {
 

--- a/app/src/test/java/io/zmbackup/app/cli/AccountsCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/AccountsCommandTest.java
@@ -1,0 +1,144 @@
+package io.zmbackup.app.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.unboundid.ldap.listener.InMemoryDirectoryServer;
+import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
+import com.unboundid.ldap.sdk.Attribute;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+class AccountsCommandTest {
+
+    private static final String BIND_DN = "uid=zimbra,cn=admins,cn=zimbra";
+    private static final String BIND_PASSWORD = "secret";
+
+    @TempDir
+    Path tempDir;
+
+    private InMemoryDirectoryServer directoryServer;
+
+    @AfterEach
+    void tearDown() {
+        if (directoryServer != null) {
+            directoryServer.shutDown(true);
+        }
+    }
+
+    @Test
+    void noSubcommandPrintsUsage() {
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("accounts");
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(out.toString().contains("Usage: zmbackup accounts"));
+    }
+
+    @Test
+    void listPrintsEveryAccount() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"));
+        directoryServer.add(
+                "uid=carol,dc=other,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "carol"),
+                new Attribute("zimbraMailDeliveryAddress", "carol@other.com"));
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "accounts", "list");
+
+        assertEquals(0, exitCode);
+        String output = out.toString();
+        assertTrue(output.contains("alice@example.com"));
+        assertTrue(output.contains("carol@other.com"));
+    }
+
+    @Test
+    void listWithDomainFiltersToThatDomain() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"));
+        directoryServer.add(
+                "uid=carol,dc=other,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "carol"),
+                new Attribute("zimbraMailDeliveryAddress", "carol@other.com"));
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "accounts", "list", "--domain", "example.com");
+
+        assertEquals(0, exitCode);
+        String output = out.toString();
+        assertTrue(output.contains("alice@example.com"));
+        assertTrue(!output.contains("carol@other.com"));
+    }
+
+    private InMemoryDirectoryServer startDirectoryServer() throws Exception {
+        InMemoryDirectoryServerConfig config =
+                new InMemoryDirectoryServerConfig("dc=example,dc=com", "dc=other,dc=com");
+        config.addAdditionalBindCredentials(BIND_DN, BIND_PASSWORD);
+        config.setSchema(null);
+        InMemoryDirectoryServer server = new InMemoryDirectoryServer(config);
+        server.startListening();
+        server.add("dc=example,dc=com", new Attribute("objectClass", "domain"), new Attribute("dc", "example"));
+        server.add("dc=other,dc=com", new Attribute("objectClass", "domain"), new Attribute("dc", "other"));
+        return server;
+    }
+
+    private Path writeConfig() throws IOException {
+        Path configFile = tempDir.resolve("zmbackup.yaml");
+        Files.writeString(
+                configFile,
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:%d
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                  sslEnabled: false
+                zimbraMailbox:
+                  backupUser: zimbra
+                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                backup:
+                  workDir: %s
+                  logFile: %s
+                  blockedListFile: %s
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """
+                        .formatted(
+                                directoryServer.getListenPort(),
+                                tempDir,
+                                tempDir.resolve("zmbackup.log"),
+                                tempDir.resolve("blockedlist.conf")));
+        return configFile;
+    }
+
+    private static CommandLine commandLine(StringWriter out, StringWriter err) {
+        CommandLine cmd = new CommandLine(new Main());
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(err));
+        return cmd;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an `accounts` command group with a `list` subcommand: `zmbackup accounts list [--domain <domain>]`
- Wires the existing `AccountDiscovery` port (backed by `UnboundIdLdapAdapter`) into the CLI, printing one account address per line — a diagnostic command, not a backup operation, mirroring `zmbackup -f -ldp` in the bash tool
- Registers `AccountsCommand` as a subcommand of `Main`

## Test plan
- [x] `./gradlew build` passes (all modules)
- [x] New `AccountsCommandTest` spins up an in-memory LDAP directory (UnboundID `InMemoryDirectoryServer`) and verifies `accounts list` (with and without `--domain`) and the no-subcommand usage output

Closes #279.

---
_Generated by [Claude Code](https://claude.ai/code/session_017FLPyMxWdK9C9A5NjkZXwc)_