### PR TITLE
Implement exportAccount(email, LdapObjectType) on UnboundIdLdapAdapter

### DIFF
--- a/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
@@ -2,6 +2,7 @@ package io.zmbackup.zimbra;
 
 import com.unboundid.ldap.sdk.Entry;
 import com.unboundid.ldap.sdk.ExtendedResult;
+import com.unboundid.ldap.sdk.Filter;
 import com.unboundid.ldap.sdk.LDAPConnection;
 import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldap.sdk.LDAPURL;
@@ -10,11 +11,15 @@ import com.unboundid.ldap.sdk.SearchRequest;
 import com.unboundid.ldap.sdk.SearchResult;
 import com.unboundid.ldap.sdk.SearchScope;
 import com.unboundid.ldap.sdk.extensions.StartTLSExtendedRequest;
+import com.unboundid.ldif.LDIFWriter;
 import com.unboundid.util.ssl.SSLUtil;
 import com.unboundid.util.ssl.TrustAllTrustManager;
 import io.zmbackup.core.domain.LdapObjectType;
 import io.zmbackup.core.port.AccountDiscovery;
+import io.zmbackup.core.port.ZimbraLdapExporter;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,9 +27,9 @@ import javax.net.ssl.SSLContext;
 
 /**
  * Connects to Zimbra's LDAP directory via the UnboundID LDAP SDK, mirroring the {@code
- * ldapsearch} invocations in the bash tool's {@code MiscAction.sh}.
+ * ldapsearch} invocations in the bash tool's {@code MiscAction.sh} and {@code ParallelAction.sh}.
  */
-public class UnboundIdLdapAdapter implements AccountDiscovery {
+public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporter {
 
     private final String host;
     private final int port;
@@ -73,6 +78,56 @@ public class UnboundIdLdapAdapter implements AccountDiscovery {
     @Override
     public List<String> discoverForDomain(LdapObjectType type, String domain) throws IOException {
         return search(domainBaseDn(domain), type);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Mirrors {@code ldap_backup} in the bash tool's {@code ParallelAction.sh}: {@code
+     * ldapsearch -b '' -LLL "(&(|(mail=<identifier>)(uid=<identifier>))<objectFilter>)"}, with the
+     * matching entries serialised to LDIF.
+     *
+     * <p>Domain entries have no {@code mail}/{@code uid} attribute to match against, so {@link
+     * LdapObjectType#DOMAIN} is not supported here; domain export has its own base-scoped search.
+     */
+    @Override
+    public void export(String identifier, LdapObjectType type, OutputStream destination) throws IOException {
+        if (type == LdapObjectType.DOMAIN) {
+            throw new UnsupportedOperationException(
+                    "UnboundIdLdapAdapter.export() does not support LdapObjectType.DOMAIN");
+        }
+        Filter filter;
+        try {
+            filter = Filter.createANDFilter(
+                    Filter.createORFilter(
+                            Filter.createEqualityFilter("mail", identifier),
+                            Filter.createEqualityFilter("uid", identifier)),
+                    Filter.create(type.objectFilter()));
+        } catch (LDAPException e) {
+            throw new IOException("Invalid LDAP filter for object type " + type, e);
+        }
+        try (LDAPConnection connection = connect()) {
+            SearchRequest searchRequest = new SearchRequest("", SearchScope.SUB, filter);
+            SearchResult searchResult = connection.search(searchRequest);
+            LDIFWriter ldifWriter = new LDIFWriter(destination);
+            for (Entry entry : searchResult.getSearchEntries()) {
+                ldifWriter.writeEntry(entry);
+            }
+            ldifWriter.flush();
+        } catch (LDAPException e) {
+            throw new IOException(
+                    "Failed to export " + identifier + " from Zimbra LDAP at " + host + ":" + port, e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Not yet implemented.
+     */
+    @Override
+    public void restore(LdapObjectType type, InputStream source) throws IOException {
+        throw new UnsupportedOperationException("UnboundIdLdapAdapter.restore() is not yet implemented");
     }
 
     private static String domainBaseDn(String domain) {

--- a/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
@@ -18,6 +18,7 @@ import com.unboundid.util.ssl.cert.PublicKeyAlgorithmIdentifier;
 import com.unboundid.util.ssl.cert.SignatureAlgorithmIdentifier;
 import com.unboundid.util.ssl.cert.X509Certificate;
 import io.zmbackup.core.domain.LdapObjectType;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -198,6 +199,86 @@ class UnboundIdLdapAdapterTest {
                 "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
 
         assertEquals(List.of(), adapter.listDomains());
+    }
+
+    @Test
+    void exportWritesMatchingEntryAsLdif() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        ByteArrayOutputStream destination = new ByteArrayOutputStream();
+        adapter.export("alice@example.com", LdapObjectType.ACCOUNT, destination);
+
+        String ldif = destination.toString();
+        assertTrue(ldif.contains("dn: uid=alice,dc=example,dc=com"));
+        assertTrue(ldif.contains("mail: alice@example.com"));
+    }
+
+    @Test
+    void exportMatchesByUidWhenMailAttributeIsAbsent() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        directoryServer.add(
+                "cn=engineering,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraDistributionList"),
+                new Attribute("cn", "engineering"),
+                new Attribute("uid", "engineering@example.com"));
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        ByteArrayOutputStream destination = new ByteArrayOutputStream();
+        adapter.export("engineering@example.com", LdapObjectType.DISTRIBUTION_LIST, destination);
+
+        assertTrue(destination.toString().contains("dn: cn=engineering,dc=example,dc=com"));
+    }
+
+    @Test
+    void exportWritesNothingWhenNoEntryMatches() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        ByteArrayOutputStream destination = new ByteArrayOutputStream();
+        adapter.export("nobody@example.com", LdapObjectType.ACCOUNT, destination);
+
+        assertEquals("", destination.toString());
+    }
+
+    @Test
+    void exportRejectsDomainObjectType() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> adapter.export("example.com", LdapObjectType.DOMAIN, new ByteArrayOutputStream()));
+    }
+
+    @Test
+    void exportWrapsUnreachableServerInIOException() {
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false);
+
+        assertThrows(
+                IOException.class,
+                () -> adapter.export("alice@example.com", LdapObjectType.ACCOUNT, new ByteArrayOutputStream()));
+    }
+
+    @Test
+    void restoreIsNotYetImplemented() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> adapter.restore(LdapObjectType.ACCOUNT, java.io.InputStream.nullInputStream()));
     }
 
     private InMemoryDirectoryServer startDirectoryServer(SSLSocketFactory startTlsSocketFactory) throws Exception {


### PR DESCRIPTION
## Summary
- `UnboundIdLdapAdapter` now also implements `ZimbraLdapExporter`
- `export(identifier, type, destination)` mirrors `ldap_backup` in the bash tool's `ParallelAction.sh`: an LDAP subtree search matching `(mail=<identifier> OR uid=<identifier>) AND <type's objectFilter>`, with results serialised to LDIF via `LDIFWriter`
- `LdapObjectType.DOMAIN` is rejected with `UnsupportedOperationException` since domain entries have no `mail`/`uid` attribute — domain export is a base-scoped search on the domain DN and is covered by a separate task (#283)
- `restore()` is left unimplemented (`UnsupportedOperationException`) — out of scope for this task

## Test plan
- [x] `./gradlew build` (compiles, checkstyle/spotless, full test suite) passes
- [x] New unit tests against an in-memory LDAP server cover: matching by `mail`, matching by `uid`, no-match writes nothing, `DOMAIN` type is rejected, unreachable server wraps in `IOException`, `restore()` throws

https://claude.ai/code/session_01TAtgan1ocGwwxwCANNGtwa


---
_Generated by [Claude Code](https://claude.ai/code/session_01TAtgan1ocGwwxwCANNGtwa)_