### PR TITLE
Implement exportDomain(domain) on UnboundIdLdapAdapter

### DIFF
--- a/core/src/main/java/io/zmbackup/core/port/ZimbraLdapExporter.java
+++ b/core/src/main/java/io/zmbackup/core/port/ZimbraLdapExporter.java
@@ -19,6 +19,12 @@ public interface ZimbraLdapExporter {
     void export(String identifier, LdapObjectType type, OutputStream destination) throws IOException;
 
     /**
+     * Writes the {@code .ldiff} entry for the domain identified by {@code domain} (e.g. {@code
+     * "example.com"}) to {@code destination}.
+     */
+    void exportDomain(String domain, OutputStream destination) throws IOException;
+
+    /**
      * Restores an object of the given {@code type} from a previously exported {@code .ldiff}
      * entry, replacing any existing entry with the same distinguished name.
      */

--- a/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
@@ -123,6 +123,30 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
     /**
      * {@inheritDoc}
      *
+     * <p>Mirrors {@code domain_backup} in the bash tool's {@code ParallelAction.sh}: {@code
+     * ldapsearch -b "dc=<label>,dc=<label>,..." -s base <objectFilter>}, with the matching entry
+     * serialised to LDIF.
+     */
+    @Override
+    public void exportDomain(String domain, OutputStream destination) throws IOException {
+        try (LDAPConnection connection = connect()) {
+            SearchRequest searchRequest = new SearchRequest(
+                    domainBaseDn(domain), SearchScope.BASE, LdapObjectType.DOMAIN.objectFilter());
+            SearchResult searchResult = connection.search(searchRequest);
+            LDIFWriter ldifWriter = new LDIFWriter(destination);
+            for (Entry entry : searchResult.getSearchEntries()) {
+                ldifWriter.writeEntry(entry);
+            }
+            ldifWriter.flush();
+        } catch (LDAPException e) {
+            throw new IOException(
+                    "Failed to export domain " + domain + " from Zimbra LDAP at " + host + ":" + port, e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * <p>Not yet implemented.
      */
     @Override

--- a/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
@@ -271,6 +271,42 @@ class UnboundIdLdapAdapterTest {
     }
 
     @Test
+    void exportDomainWritesMatchingEntryAsLdif() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        directoryServer.add(
+                "dc=other,dc=com",
+                new Attribute("objectClass", "zimbraDomain"),
+                new Attribute("dc", "other"),
+                new Attribute("zimbraDomainName", "other.com"));
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        ByteArrayOutputStream destination = new ByteArrayOutputStream();
+        adapter.exportDomain("other.com", destination);
+
+        String ldif = destination.toString();
+        assertTrue(ldif.contains("dn: dc=other,dc=com"));
+        assertTrue(ldif.contains("zimbraDomainName: other.com"));
+    }
+
+    @Test
+    void exportDomainWrapsUnknownDomainInIOException() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+
+        assertThrows(IOException.class, () -> adapter.exportDomain("nowhere.invalid", new ByteArrayOutputStream()));
+    }
+
+    @Test
+    void exportDomainWrapsUnreachableServerInIOException() {
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false);
+
+        assertThrows(
+                IOException.class, () -> adapter.exportDomain("example.com", new ByteArrayOutputStream()));
+    }
+
+    @Test
     void restoreIsNotYetImplemented() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(


### PR DESCRIPTION
## Summary
- Adds `exportDomain(String domain, OutputStream destination)` to the `ZimbraLdapExporter` port
- Implements it on `UnboundIdLdapAdapter` as a base-scope LDAP search on the domain's DN (built from its dot-separated labels) filtered by `LdapObjectType.DOMAIN`'s object filter, serialised to LDIF via `LDIFWriter` — mirroring `domain_backup` in the bash tool's `ParallelAction.sh` (`ldapsearch -b "dc=..." -s base <objectFilter>`)

Sub-task of #257, closes #283.

## Test plan
- [x] `UnboundIdLdapAdapterTest`: added coverage for exporting a matching domain entry as LDIF, wrapping an unknown domain in `IOException`, and wrapping an unreachable server in `IOException`
- [x] `./gradlew build` passes across all modules


---
_Generated by [Claude Code](https://claude.ai/code/session_01LiiXHA92Ywpa2HC8vssF7b)_