### PR TITLE
Implement BackupService for LDAP-only types

### DIFF
--- a/core/src/main/java/io/zmbackup/core/service/BackupService.java
+++ b/core/src/main/java/io/zmbackup/core/service/BackupService.java
@@ -1,0 +1,149 @@
+package io.zmbackup.core.service;
+
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.LdapObjectType;
+import io.zmbackup.core.domain.SessionStatus;
+import io.zmbackup.core.port.AccountDiscovery;
+import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.StorageProvider;
+import io.zmbackup.core.port.ZimbraLdapExporter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Runs backup sessions for the LDAP-only {@link BackupType}s ({@code LDAP}, {@code ALIAS}, {@code
+ * DISTRIBUTION_LIST}, {@code SIGNATURE}, {@code DOMAIN}), mirroring {@code backup_main} and its
+ * {@code __backupLdap}/{@code __backupDomain} helpers in the bash tool's {@code BackupAction.sh}.
+ * Mailbox-inclusive types ({@code FULL}, {@code INCREMENTAL}, {@code MAILBOX}) are handled by a
+ * separate service.
+ */
+public class BackupService {
+
+    private static final DateTimeFormatter SESSION_TIMESTAMP =
+            DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneId.systemDefault());
+    private static final String LDIFF_SUFFIX = "ldiff";
+
+    private final AccountDiscovery accountDiscovery;
+    private final ZimbraLdapExporter ldapExporter;
+    private final StorageProvider storageProvider;
+    private final MetadataStore metadataStore;
+
+    public BackupService(
+            AccountDiscovery accountDiscovery,
+            ZimbraLdapExporter ldapExporter,
+            StorageProvider storageProvider,
+            MetadataStore metadataStore) {
+        this.accountDiscovery = Objects.requireNonNull(accountDiscovery, "accountDiscovery must not be null");
+        this.ldapExporter = Objects.requireNonNull(ldapExporter, "ldapExporter must not be null");
+        this.storageProvider = Objects.requireNonNull(storageProvider, "storageProvider must not be null");
+        this.metadataStore = Objects.requireNonNull(metadataStore, "metadataStore must not be null");
+    }
+
+    /** Backs up every object of {@code type} found across the whole directory. */
+    public Optional<BackupSession> backup(BackupType type) throws IOException {
+        return backup(type, List.of(), null);
+    }
+
+    /** Backs up only the given {@code identifiers} (accounts, or domains for {@link BackupType#DOMAIN}). */
+    public Optional<BackupSession> backup(BackupType type, List<String> identifiers) throws IOException {
+        return backup(type, identifiers, null);
+    }
+
+    /**
+     * Runs one backup session of {@code type}, mirroring {@code backup_main}: resolves the
+     * objects to back up, records an {@code IN PROGRESS} session, exports and stores each object,
+     * then updates the session to its final status.
+     *
+     * @param type        an LDAP-only backup type: {@code LDAP}, {@code ALIAS}, {@code
+     *                    DISTRIBUTION_LIST}, {@code SIGNATURE}, or {@code DOMAIN}
+     * @param identifiers explicit accounts (or domains, for {@code DOMAIN}) to back up, bypassing
+     *                    discovery; empty to discover automatically
+     * @param domain      when {@code identifiers} is empty and {@code type != DOMAIN}, restricts
+     *                    discovery to this domain (e.g. {@code "example.com"}); {@code null} to
+     *                    search the whole directory
+     * @return the completed session, or empty if there was nothing to back up
+     */
+    public Optional<BackupSession> backup(BackupType type, List<String> identifiers, String domain)
+            throws IOException {
+        if (!type.includesLdap() || type.includesMailbox()) {
+            throw new IllegalArgumentException("BackupService only supports LDAP-only backup types, got " + type);
+        }
+
+        List<String> resolved = resolveIdentifiers(type, identifiers, domain);
+        if (resolved.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String sessionId = type.sessionPrefix() + "-" + SESSION_TIMESTAMP.format(Instant.now());
+        Instant sessionStart = Instant.now();
+        metadataStore.save(new BackupSession(sessionId, type, SessionStatus.IN_PROGRESS, sessionStart, null, null));
+
+        boolean allSucceeded = true;
+        for (String identifier : resolved) {
+            if (!backupOne(sessionId, type, identifier)) {
+                allSucceeded = false;
+            }
+        }
+
+        Instant sessionEnd = Instant.now();
+        String size = storageProvider.sizeOfSession(sessionId);
+        SessionStatus status = allSucceeded ? SessionStatus.FINISHED : SessionStatus.FAILED;
+        BackupSession completed = new BackupSession(sessionId, type, status, sessionStart, sessionEnd, size);
+        metadataStore.save(completed);
+        return Optional.of(completed);
+    }
+
+    /** Exports and stores a single object, recording its result. Returns {@code false} on failure. */
+    private boolean backupOne(String sessionId, BackupType type, String identifier) throws IOException {
+        Instant startedAt = Instant.now();
+        try {
+            try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, LDIFF_SUFFIX)) {
+                if (type == BackupType.DOMAIN) {
+                    ldapExporter.exportDomain(identifier, destination);
+                } else {
+                    ldapExporter.export(identifier, objectTypeFor(type), destination);
+                }
+            }
+        } catch (IOException e) {
+            return false;
+        }
+        Instant completedAt = Instant.now();
+        String size = storageProvider.sizeOfAccount(sessionId, identifier);
+        metadataStore.recordAccountBackup(
+                new BackupAccountRecord(null, sessionId, identifier, size, startedAt, completedAt));
+        return true;
+    }
+
+    private List<String> resolveIdentifiers(BackupType type, List<String> identifiers, String domain)
+            throws IOException {
+        if (!identifiers.isEmpty()) {
+            return identifiers;
+        }
+        if (type == BackupType.DOMAIN) {
+            return accountDiscovery.listDomains();
+        }
+        LdapObjectType objectType = objectTypeFor(type);
+        return domain == null
+                ? accountDiscovery.discover(objectType)
+                : accountDiscovery.discoverForDomain(objectType, domain);
+    }
+
+    private static LdapObjectType objectTypeFor(BackupType type) {
+        return switch (type) {
+            case LDAP -> LdapObjectType.ACCOUNT;
+            case ALIAS -> LdapObjectType.ALIAS;
+            case DISTRIBUTION_LIST -> LdapObjectType.DISTRIBUTION_LIST;
+            case SIGNATURE -> LdapObjectType.SIGNATURE;
+            case DOMAIN -> LdapObjectType.DOMAIN;
+            default -> throw new IllegalArgumentException("No LdapObjectType mapping for " + type);
+        };
+    }
+}

--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -1,0 +1,294 @@
+package io.zmbackup.core.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.LdapObjectType;
+import io.zmbackup.core.domain.SessionStatus;
+import io.zmbackup.core.port.AccountDiscovery;
+import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.StorageProvider;
+import io.zmbackup.core.port.ZimbraLdapExporter;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class BackupServiceTest {
+
+    private final FakeAccountDiscovery accountDiscovery = new FakeAccountDiscovery();
+    private final FakeZimbraLdapExporter ldapExporter = new FakeZimbraLdapExporter();
+    private final InMemoryStorageProvider storageProvider = new InMemoryStorageProvider();
+    private final InMemoryMetadataStore metadataStore = new InMemoryMetadataStore();
+    private final BackupService backupService =
+            new BackupService(accountDiscovery, ldapExporter, storageProvider, metadataStore);
+
+    @Test
+    void backsUpDiscoveredAccountsForLdapType() throws IOException {
+        accountDiscovery.wholeDirectory.put(LdapObjectType.ACCOUNT, List.of("alice@example.com", "bob@example.com"));
+
+        Optional<BackupSession> result = backupService.backup(BackupType.LDAP);
+
+        assertTrue(result.isPresent());
+        BackupSession session = result.get();
+        assertTrue(session.sessionId().startsWith("ldap-"));
+        assertEquals(BackupType.LDAP, session.type());
+        assertEquals(SessionStatus.FINISHED, session.status());
+
+        List<BackupAccountRecord> records = metadataStore.findAccountsForSession(session.sessionId());
+        assertEquals(2, records.size());
+        assertEquals(Set.of("alice@example.com", "bob@example.com"), namesOf(records));
+        assertEquals(
+                Set.of(LdapObjectType.ACCOUNT),
+                ldapExporter.exportedTypesFor("alice@example.com", "bob@example.com"));
+    }
+
+    @Test
+    void backsUpExplicitIdentifiersWithoutDiscovery() throws IOException {
+        Optional<BackupSession> result = backupService.backup(BackupType.ALIAS, List.of("alias@example.com"));
+
+        assertTrue(result.isPresent());
+        assertTrue(accountDiscovery.discoverCalls.isEmpty());
+        assertEquals(List.of(LdapObjectType.ALIAS), ldapExporter.exportedTypes.get("alias@example.com"));
+    }
+
+    @Test
+    void scopesDiscoveryToDomainWhenGiven() throws IOException {
+        accountDiscovery.byDomain.put(
+                Map.entry(LdapObjectType.DISTRIBUTION_LIST, "example.com"), List.of("list@example.com"));
+
+        Optional<BackupSession> result =
+                backupService.backup(BackupType.DISTRIBUTION_LIST, List.of(), "example.com");
+
+        assertTrue(result.isPresent());
+        assertEquals(1, metadataStore.findAccountsForSession(result.get().sessionId()).size());
+    }
+
+    @Test
+    void domainTypeDiscoversDomainsAndUsesExportDomain() throws IOException {
+        accountDiscovery.wholeDirectory.put(LdapObjectType.DOMAIN, List.of("example.com"));
+
+        Optional<BackupSession> result = backupService.backup(BackupType.DOMAIN);
+
+        assertTrue(result.isPresent());
+        assertTrue(ldapExporter.domainExports.contains("example.com"));
+        assertTrue(ldapExporter.exportedTypes.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyAndSkipsSessionWhenNothingToBackUp() throws IOException {
+        Optional<BackupSession> result = backupService.backup(BackupType.SIGNATURE);
+
+        assertTrue(result.isEmpty());
+        assertTrue(metadataStore.listSessions().isEmpty());
+    }
+
+    @Test
+    void marksSessionFailedWhenAnyExportFails() throws IOException {
+        ldapExporter.failing.add("bad@example.com");
+
+        Optional<BackupSession> result =
+                backupService.backup(BackupType.LDAP, List.of("good@example.com", "bad@example.com"));
+
+        assertTrue(result.isPresent());
+        assertEquals(SessionStatus.FAILED, result.get().status());
+        List<BackupAccountRecord> records = metadataStore.findAccountsForSession(result.get().sessionId());
+        assertEquals(Set.of("good@example.com"), namesOf(records));
+    }
+
+    @Test
+    void rejectsMailboxInclusiveBackupTypes() {
+        assertThrows(IllegalArgumentException.class, () -> backupService.backup(BackupType.FULL));
+        assertThrows(IllegalArgumentException.class, () -> backupService.backup(BackupType.INCREMENTAL));
+        assertThrows(IllegalArgumentException.class, () -> backupService.backup(BackupType.MAILBOX));
+    }
+
+    private static Set<String> namesOf(List<BackupAccountRecord> records) {
+        Set<String> names = new HashSet<>();
+        for (BackupAccountRecord record : records) {
+            names.add(record.email());
+        }
+        return names;
+    }
+
+    /** In-memory {@link AccountDiscovery} fake returning preconfigured results. */
+    private static final class FakeAccountDiscovery implements AccountDiscovery {
+        final Map<LdapObjectType, List<String>> wholeDirectory = new EnumMap<>(LdapObjectType.class);
+        final Map<Map.Entry<LdapObjectType, String>, List<String>> byDomain = new HashMap<>();
+        final List<LdapObjectType> discoverCalls = new ArrayList<>();
+
+        @Override
+        public List<String> discover(LdapObjectType type) {
+            discoverCalls.add(type);
+            return wholeDirectory.getOrDefault(type, List.of());
+        }
+
+        @Override
+        public List<String> discoverForDomain(LdapObjectType type, String domain) {
+            return byDomain.getOrDefault(Map.entry(type, domain), List.of());
+        }
+    }
+
+    /** In-memory {@link ZimbraLdapExporter} fake that records what was exported. */
+    private static final class FakeZimbraLdapExporter implements ZimbraLdapExporter {
+        final Map<String, List<LdapObjectType>> exportedTypes = new LinkedHashMap<>();
+        final Set<String> domainExports = new HashSet<>();
+        final Set<String> failing = new HashSet<>();
+
+        @Override
+        public void export(String identifier, LdapObjectType type, OutputStream destination) throws IOException {
+            if (failing.contains(identifier)) {
+                throw new IOException("simulated export failure for " + identifier);
+            }
+            exportedTypes.computeIfAbsent(identifier, k -> new ArrayList<>()).add(type);
+            destination.write(("ldiff:" + identifier).getBytes());
+        }
+
+        @Override
+        public void exportDomain(String domain, OutputStream destination) throws IOException {
+            if (failing.contains(domain)) {
+                throw new IOException("simulated export failure for " + domain);
+            }
+            domainExports.add(domain);
+            destination.write(("ldiff:" + domain).getBytes());
+        }
+
+        @Override
+        public void restore(LdapObjectType type, InputStream source) {
+            throw new UnsupportedOperationException();
+        }
+
+        Set<LdapObjectType> exportedTypesFor(String... identifiers) {
+            Set<LdapObjectType> types = new HashSet<>();
+            for (String identifier : identifiers) {
+                types.addAll(exportedTypes.getOrDefault(identifier, List.of()));
+            }
+            return types;
+        }
+    }
+
+    /** In-memory {@link StorageProvider} fake backed by a byte-array map. */
+    private static final class InMemoryStorageProvider implements StorageProvider {
+        final Map<String, byte[]> content = new LinkedHashMap<>();
+
+        @Override
+        public OutputStream openWrite(String sessionId, String account, String suffix) {
+            String key = key(sessionId, account, suffix);
+            return new ByteArrayOutputStream() {
+                @Override
+                public void close() throws IOException {
+                    super.close();
+                    content.put(key, toByteArray());
+                }
+            };
+        }
+
+        @Override
+        public InputStream openRead(String sessionId, String account, String suffix) throws IOException {
+            byte[] bytes = content.get(key(sessionId, account, suffix));
+            if (bytes == null) {
+                throw new IOException("no content for " + key(sessionId, account, suffix));
+            }
+            return new java.io.ByteArrayInputStream(bytes);
+        }
+
+        @Override
+        public boolean exists(String sessionId, String account, String suffix) {
+            return content.containsKey(key(sessionId, account, suffix));
+        }
+
+        @Override
+        public String sizeOfAccount(String sessionId, String account) {
+            String prefix = sessionId + "/" + account + ".";
+            long total = content.entrySet().stream()
+                    .filter(entry -> entry.getKey().startsWith(prefix))
+                    .mapToLong(entry -> entry.getValue().length)
+                    .sum();
+            return total + "B";
+        }
+
+        @Override
+        public String sizeOfSession(String sessionId) {
+            String prefix = sessionId + "/";
+            long total = content.entrySet().stream()
+                    .filter(entry -> entry.getKey().startsWith(prefix))
+                    .mapToLong(entry -> entry.getValue().length)
+                    .sum();
+            return total + "B";
+        }
+
+        @Override
+        public void deleteSession(String sessionId) {
+            content.keySet().removeIf(key -> key.startsWith(sessionId + "/"));
+        }
+
+        private static String key(String sessionId, String account, String suffix) {
+            return sessionId + "/" + account + "." + suffix;
+        }
+    }
+
+    /** In-memory {@link MetadataStore} fake backed by simple maps. */
+    private static final class InMemoryMetadataStore implements MetadataStore {
+        final Map<String, BackupSession> sessions = new LinkedHashMap<>();
+        final Map<String, List<BackupAccountRecord>> accounts = new LinkedHashMap<>();
+
+        @Override
+        public void save(BackupSession session) {
+            sessions.put(session.sessionId(), session);
+        }
+
+        @Override
+        public Optional<BackupSession> findSession(String sessionId) {
+            return Optional.ofNullable(sessions.get(sessionId));
+        }
+
+        @Override
+        public List<BackupSession> listSessions() {
+            return List.copyOf(sessions.values());
+        }
+
+        @Override
+        public List<BackupSession> findSessionsCompletedBefore(Instant cutoff) {
+            return sessions.values().stream()
+                    .filter(s -> s.completedAt() != null && s.completedAt().isBefore(cutoff))
+                    .toList();
+        }
+
+        @Override
+        public void deleteSession(String sessionId) {
+            sessions.remove(sessionId);
+            accounts.remove(sessionId);
+        }
+
+        @Override
+        public void recordAccountBackup(BackupAccountRecord record) {
+            accounts.computeIfAbsent(record.sessionId(), k -> new ArrayList<>()).add(record);
+        }
+
+        @Override
+        public List<BackupAccountRecord> findAccountsForSession(String sessionId) {
+            return accounts.getOrDefault(sessionId, List.of());
+        }
+
+        @Override
+        public Optional<Instant> lastSuccessfulBackupTime(String email) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `io.zmbackup.core.service.BackupService`, covering the LDAP-only `BackupType`s (`LDAP`, `ALIAS`, `DISTRIBUTION_LIST`, `SIGNATURE`, `DOMAIN`), mirroring `backup_main` and its `__backupLdap`/`__backupDomain` helpers in the bash tool's `BackupAction.sh`.
- Resolves objects to back up via `AccountDiscovery` (whole-directory or domain-scoped) or an explicit identifier list, records an `IN PROGRESS` session in `MetadataStore`, exports each object through `ZimbraLdapExporter` into `StorageProvider` (`DOMAIN` uses `exportDomain`, the rest use `export`), records a per-account result on success, and finalizes the session as `FINISHED` or `FAILED`.
- Rejects mailbox-inclusive types (`FULL`, `INCREMENTAL`, `MAILBOX`) with `IllegalArgumentException` since those are handled by a separate service.
- Returns `Optional.empty()` and skips creating a session when there is nothing to back up, matching the bash tool's "Nothing to do" behavior.

## Test plan
- [x] `./gradlew :core:test` — new `BackupServiceTest` (7 cases: discovery-based backup, explicit identifiers, domain-scoped discovery, `DOMAIN` type using `exportDomain`, empty result, partial failure marking the session `FAILED`, and rejection of mailbox-inclusive types) using in-memory fakes for all four ports.
- [x] `./gradlew build` — full multi-module build passes.

Sub-task of #257 / closes #284.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VWcpPRyi4Fes4uDPSE2koS)_