### PR TITLE
Implement SessionService.listSessions() for zmbackup list

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -5,6 +5,7 @@ import io.zmbackup.app.config.YamlConfigLoader;
 import io.zmbackup.core.port.AccountDiscovery;
 import io.zmbackup.core.port.MetadataStore;
 import io.zmbackup.core.port.StorageProvider;
+import io.zmbackup.core.service.SessionService;
 import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
 import io.zmbackup.zimbra.UnboundIdLdapAdapter;
@@ -24,6 +25,7 @@ public final class AppContext {
     private final StorageProvider storageProvider;
     private final MetadataStore metadataStore;
     private final AccountDiscovery accountDiscovery;
+    private final SessionService sessionService;
 
     public AppContext(AppConfig config) throws IOException {
         this.config = config;
@@ -34,6 +36,7 @@ public final class AppContext {
                 config.zimbraLdap().bindDn(),
                 config.zimbraLdap().bindPassword(),
                 config.zimbraLdap().sslEnabled());
+        this.sessionService = new SessionService(metadataStore);
     }
 
     /** Reads {@code configFile} and wires the components it describes. */
@@ -55,5 +58,9 @@ public final class AppContext {
 
     public AccountDiscovery accountDiscovery() {
         return accountDiscovery;
+    }
+
+    public SessionService sessionService() {
+        return sessionService;
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/ListCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/ListCommand.java
@@ -31,7 +31,7 @@ public final class ListCommand implements Callable<Integer> {
         out.println(BORDER);
         out.printf(ROW_FORMAT, "Session ID", "Started", "Completed", "Size", "Type");
         out.println(BORDER);
-        for (BackupSession session : context.metadataStore().listSessions()) {
+        for (BackupSession session : context.sessionService().listSessions()) {
             out.printf(
                     ROW_FORMAT,
                     session.sessionId(),

--- a/core/src/main/java/io/zmbackup/core/service/SessionService.java
+++ b/core/src/main/java/io/zmbackup/core/service/SessionService.java
@@ -1,0 +1,28 @@
+package io.zmbackup.core.service;
+
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.port.MetadataStore;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Read-only queries over stored backup sessions, driving {@code zmbackup list}. Mirrors the
+ * bash tool's {@code list_sessions} in {@code SessionAction.sh}.
+ */
+public class SessionService {
+
+    private final MetadataStore metadataStore;
+
+    public SessionService(MetadataStore metadataStore) {
+        this.metadataStore = Objects.requireNonNull(metadataStore, "metadataStore must not be null");
+    }
+
+    /** All stored sessions, most recently started first. */
+    public List<BackupSession> listSessions() throws IOException {
+        return metadataStore.listSessions().stream()
+                .sorted(Comparator.comparing(BackupSession::startedAt).reversed())
+                .toList();
+    }
+}

--- a/core/src/test/java/io/zmbackup/core/service/SessionServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/SessionServiceTest.java
@@ -1,0 +1,97 @@
+package io.zmbackup.core.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import io.zmbackup.core.port.MetadataStore;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class SessionServiceTest {
+
+    private final InMemoryMetadataStore metadataStore = new InMemoryMetadataStore();
+    private final SessionService sessionService = new SessionService(metadataStore);
+
+    @Test
+    void listsSessionsMostRecentlyStartedFirst() throws IOException {
+        Instant now = Instant.now();
+        BackupSession oldest = session("ldap-oldest", now.minus(2, ChronoUnit.DAYS));
+        BackupSession middle = session("ldap-middle", now.minus(1, ChronoUnit.DAYS));
+        BackupSession newest = session("ldap-newest", now);
+        metadataStore.save(oldest);
+        metadataStore.save(middle);
+        metadataStore.save(newest);
+
+        List<BackupSession> sessions = sessionService.listSessions();
+
+        assertEquals(List.of(newest, middle, oldest), sessions);
+    }
+
+    @Test
+    void listSessionsReturnsEmptyWhenNoneStored() throws IOException {
+        assertEquals(List.of(), sessionService.listSessions());
+    }
+
+    private static BackupSession session(String sessionId, Instant startedAt) {
+        return new BackupSession(sessionId, BackupType.LDAP, SessionStatus.FINISHED, startedAt, startedAt, "1K");
+    }
+
+    /** In-memory {@link MetadataStore} fake backed by simple maps. */
+    private static final class InMemoryMetadataStore implements MetadataStore {
+        final Map<String, BackupSession> sessions = new LinkedHashMap<>();
+        final Map<String, List<BackupAccountRecord>> accounts = new LinkedHashMap<>();
+
+        @Override
+        public void save(BackupSession session) {
+            sessions.put(session.sessionId(), session);
+        }
+
+        @Override
+        public Optional<BackupSession> findSession(String sessionId) {
+            return Optional.ofNullable(sessions.get(sessionId));
+        }
+
+        @Override
+        public List<BackupSession> listSessions() {
+            return List.copyOf(sessions.values());
+        }
+
+        @Override
+        public List<BackupSession> findSessionsCompletedBefore(Instant cutoff) {
+            return sessions.values().stream()
+                    .filter(s -> s.completedAt() != null && s.completedAt().isBefore(cutoff))
+                    .toList();
+        }
+
+        @Override
+        public void deleteSession(String sessionId) {
+            sessions.remove(sessionId);
+            accounts.remove(sessionId);
+        }
+
+        @Override
+        public void recordAccountBackup(BackupAccountRecord record) {
+            accounts.computeIfAbsent(record.sessionId(), k -> new ArrayList<>()).add(record);
+        }
+
+        @Override
+        public List<BackupAccountRecord> findAccountsForSession(String sessionId) {
+            return accounts.getOrDefault(sessionId, List.of());
+        }
+
+        @Override
+        public Optional<Instant> lastSuccessfulBackupTime(String email) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SessionService` in the `core` module, driving `zmbackup list` per #286 (sub-task of #257).
- `listSessions()` queries `MetadataStore` and returns stored backup sessions ordered most recently started first.
- Wires `AppContext.sessionService()` and updates `ListCommand` to use it instead of calling `MetadataStore` directly.

## Test plan
- [x] `./gradlew :core:test --tests "io.zmbackup.core.service.*"` — new `SessionServiceTest` passes alongside existing `BackupServiceTest`/`HousekeepServiceTest`.
- [x] `./gradlew build` — full project build succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Liqm2akyYAYQ2v7TwhcnQd)_