### PR TITLE
Add all LDAP backup Picocli commands (ldap, alias, distlist, signature, domain)

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -5,6 +5,8 @@ import io.zmbackup.app.config.YamlConfigLoader;
 import io.zmbackup.core.port.AccountDiscovery;
 import io.zmbackup.core.port.MetadataStore;
 import io.zmbackup.core.port.StorageProvider;
+import io.zmbackup.core.port.ZimbraLdapExporter;
+import io.zmbackup.core.service.BackupService;
 import io.zmbackup.core.service.SessionService;
 import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
@@ -25,18 +27,23 @@ public final class AppContext {
     private final StorageProvider storageProvider;
     private final MetadataStore metadataStore;
     private final AccountDiscovery accountDiscovery;
+    private final ZimbraLdapExporter ldapExporter;
     private final SessionService sessionService;
+    private final BackupService backupService;
 
     public AppContext(AppConfig config) throws IOException {
         this.config = config;
         this.storageProvider = new LocalStorageProvider(config.backup().workDir());
         this.metadataStore = new SqliteMetadataStore(config.backup().workDir().resolve(METADATA_STORE_FILENAME));
-        this.accountDiscovery = new UnboundIdLdapAdapter(
+        UnboundIdLdapAdapter ldapAdapter = new UnboundIdLdapAdapter(
                 config.zimbraLdap().url(),
                 config.zimbraLdap().bindDn(),
                 config.zimbraLdap().bindPassword(),
                 config.zimbraLdap().sslEnabled());
+        this.accountDiscovery = ldapAdapter;
+        this.ldapExporter = ldapAdapter;
         this.sessionService = new SessionService(metadataStore);
+        this.backupService = new BackupService(accountDiscovery, ldapExporter, storageProvider, metadataStore);
     }
 
     /** Reads {@code configFile} and wires the components it describes. */
@@ -62,5 +69,9 @@ public final class AppContext {
 
     public SessionService sessionService() {
         return sessionService;
+    }
+
+    public BackupService backupService() {
+        return backupService;
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupAliasCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupAliasCommand.java
@@ -1,0 +1,32 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.BackupType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/** Backs up Zimbra aliases from LDAP, mirroring {@code zmbackup -f -alp} in the bash tool. */
+@Command(name = "alias", description = "Back up Zimbra aliases from LDAP.")
+public final class BackupAliasCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private BackupCommand parent;
+
+    @Option(names = "--account", description = "Back up only this alias (repeatable); default: every alias.")
+    private List<String> accounts = new ArrayList<>();
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
+        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.ALIAS, accounts, null);
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/BackupCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupCommand.java
@@ -1,20 +1,41 @@
 package io.zmbackup.app.cli;
 
 import java.util.concurrent.Callable;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Spec;
 
-/** Stub for the backup subcommand; real backup logic lands once the zimbra module is implemented. */
-@Command(name = "backup", description = "Run a backup (not yet implemented).")
+/**
+ * Groups the LDAP-only backup subcommands: {@code ldap}, {@code alias}, {@code distlist}, {@code
+ * signature}, {@code domain}.
+ */
+@Command(
+        name = "backup",
+        subcommands = {
+            BackupLdapCommand.class,
+            BackupAliasCommand.class,
+            BackupDistlistCommand.class,
+            BackupSignatureCommand.class,
+            BackupDomainCommand.class
+        })
 public final class BackupCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private Main parent;
 
     @Spec
     private CommandSpec spec;
 
+    Main parent() {
+        return parent;
+    }
+
+    /** No subcommand given: show usage instead of doing nothing silently. */
     @Override
     public Integer call() {
-        spec.commandLine().getErr().println("backup: not yet implemented");
-        return 1;
+        spec.commandLine().usage(spec.commandLine().getOut());
+        return CommandLine.ExitCode.USAGE;
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupDistlistCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupDistlistCommand.java
@@ -1,0 +1,34 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.BackupType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/** Backs up Zimbra distribution lists from LDAP, mirroring {@code zmbackup -f -dl} in the bash tool. */
+@Command(name = "distlist", description = "Back up Zimbra distribution lists from LDAP.")
+public final class BackupDistlistCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private BackupCommand parent;
+
+    @Option(
+            names = "--account",
+            description = "Back up only this distribution list (repeatable); default: every distribution list.")
+    private List<String> accounts = new ArrayList<>();
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
+        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.DISTRIBUTION_LIST, accounts, null);
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/BackupDomainCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupDomainCommand.java
@@ -1,0 +1,32 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.BackupType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/** Backs up Zimbra domains from LDAP, mirroring {@code zmbackup -f -dom} in the bash tool. */
+@Command(name = "domain", description = "Back up Zimbra domains from LDAP.")
+public final class BackupDomainCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private BackupCommand parent;
+
+    @Option(names = "--domain", description = "Back up only this domain (repeatable); default: every domain.")
+    private List<String> domains = new ArrayList<>();
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
+        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.DOMAIN, domains, null);
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/BackupLdapCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupLdapCommand.java
@@ -1,0 +1,35 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.BackupType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/** Backs up Zimbra accounts from LDAP, mirroring {@code zmbackup -f -ldp} in the bash tool. */
+@Command(name = "ldap", description = "Back up Zimbra accounts from LDAP.")
+public final class BackupLdapCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private BackupCommand parent;
+
+    @Option(names = "--account", description = "Back up only this account (repeatable); default: every account.")
+    private List<String> accounts = new ArrayList<>();
+
+    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
+    private String domain;
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
+        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.LDAP, accounts, domain);
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/BackupRunner.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupRunner.java
@@ -1,0 +1,38 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Optional;
+
+/** Shared body for the {@code backup ldap/alias/distlist/signature/domain} subcommands. */
+final class BackupRunner {
+
+    private BackupRunner() {}
+
+    /**
+     * Runs one backup session of {@code type} against {@code context}, printing its outcome to
+     * {@code out}.
+     *
+     * @return {@code 0} if the session finished (or there was nothing to back up), {@code 1} if
+     *     any object in the session failed to export
+     */
+    static int run(
+            AppContext context, PrintWriter out, BackupType type, List<String> identifiers, String domain)
+            throws IOException {
+        Optional<BackupSession> result = context.backupService().backup(type, identifiers, domain);
+        if (result.isEmpty()) {
+            out.println("Nothing found to back up for " + type.sessionPrefix() + ".");
+            return 0;
+        }
+        BackupSession session = result.get();
+        out.printf(
+                "Session %s (%s): %s, size %s%n",
+                session.sessionId(), session.type(), session.status(), session.size());
+        return session.status() == SessionStatus.FINISHED ? 0 : 1;
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/BackupSignatureCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupSignatureCommand.java
@@ -1,0 +1,34 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.BackupType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/** Backs up Zimbra signatures from LDAP, mirroring {@code zmbackup -f -sig} in the bash tool. */
+@Command(name = "signature", description = "Back up Zimbra signatures from LDAP.")
+public final class BackupSignatureCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private BackupCommand parent;
+
+    @Option(
+            names = "--account",
+            description = "Back up only this account's signatures (repeatable); default: every account.")
+    private List<String> accounts = new ArrayList<>();
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
+        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.SIGNATURE, accounts, null);
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
@@ -1,0 +1,233 @@
+package io.zmbackup.app.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.unboundid.ldap.listener.InMemoryDirectoryServer;
+import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
+import com.unboundid.ldap.sdk.Attribute;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+class BackupCommandTest {
+
+    private static final String BIND_DN = "uid=zimbra,cn=admins,cn=zimbra";
+    private static final String BIND_PASSWORD = "secret";
+
+    @TempDir
+    Path tempDir;
+
+    private InMemoryDirectoryServer directoryServer;
+
+    @AfterEach
+    void tearDown() {
+        if (directoryServer != null) {
+            directoryServer.shutDown(true);
+        }
+    }
+
+    @Test
+    void noSubcommandPrintsUsage() {
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("backup");
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(out.toString().contains("Usage: zmbackup backup"));
+    }
+
+    @Test
+    void ldapBacksUpEveryDiscoveredAccount() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "backup", "ldap");
+
+        assertEquals(0, exitCode);
+        String output = out.toString();
+        assertTrue(output.contains("ldap-"));
+        assertTrue(output.contains("FINISHED"));
+    }
+
+    @Test
+    void ldapWithAccountOptionBacksUpOnlyThatAccount() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        directoryServer.add(
+                "uid=bob,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "bob"),
+                new Attribute("zimbraMailDeliveryAddress", "bob@example.com"),
+                new Attribute("mail", "bob@example.com"));
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode =
+                cmd.execute("--config", configFile.toString(), "backup", "ldap", "--account", "alice@example.com");
+
+        assertEquals(0, exitCode);
+        assertTrue(Files.exists(tempDir.resolve("ldap-" + sessionSuffixOf(out) + "/alice@example.com.ldiff")));
+    }
+
+    @Test
+    void aliasBacksUpExplicitAlias() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alias1,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAlias"),
+                new Attribute("uid", "alias@example.com"));
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode =
+                cmd.execute("--config", configFile.toString(), "backup", "alias", "--account", "alias@example.com");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("FINISHED"));
+    }
+
+    @Test
+    void distlistBacksUpDiscoveredList() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "cn=engineering,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraDistributionList"),
+                new Attribute("cn", "engineering"),
+                new Attribute("mail", "engineering@example.com"));
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "backup", "distlist");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("FINISHED"));
+    }
+
+    @Test
+    void signaturePrintsNothingFoundWhenDirectoryHasNoSignatures() throws Exception {
+        directoryServer = startDirectoryServer();
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "backup", "signature");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("Nothing found to back up"));
+    }
+
+    @Test
+    void domainBacksUpDiscoveredDomains() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "dc=other,dc=com",
+                new Attribute("objectClass", "zimbraDomain"),
+                new Attribute("dc", "other"),
+                new Attribute("zimbraDomainName", "other.com"));
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "backup", "domain");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("domain-"));
+        assertTrue(out.toString().contains("FINISHED"));
+    }
+
+    @Test
+    void domainWithDomainOptionBacksUpOnlyThatDomain() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "dc=other,dc=com",
+                new Attribute("objectClass", "zimbraDomain"),
+                new Attribute("dc", "other"),
+                new Attribute("zimbraDomainName", "other.com"));
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "backup", "domain", "--domain", "other.com");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("FINISHED"));
+    }
+
+    private static String sessionSuffixOf(StringWriter out) {
+        String output = out.toString();
+        int start = output.indexOf("ldap-") + "ldap-".length();
+        int end = output.indexOf(' ', start);
+        return output.substring(start, end);
+    }
+
+    private InMemoryDirectoryServer startDirectoryServer() throws Exception {
+        InMemoryDirectoryServerConfig config =
+                new InMemoryDirectoryServerConfig("dc=example,dc=com", "dc=other,dc=com");
+        config.addAdditionalBindCredentials(BIND_DN, BIND_PASSWORD);
+        config.setSchema(null);
+        InMemoryDirectoryServer server = new InMemoryDirectoryServer(config);
+        server.startListening();
+        server.add("dc=example,dc=com", new Attribute("objectClass", "domain"), new Attribute("dc", "example"));
+        return server;
+    }
+
+    private Path writeConfig() throws IOException {
+        Path configFile = tempDir.resolve("zmbackup.yaml");
+        Files.writeString(
+                configFile,
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:%d
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                  sslEnabled: false
+                zimbraMailbox:
+                  backupUser: zimbra
+                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                backup:
+                  workDir: %s
+                  logFile: %s
+                  blockedListFile: %s
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """
+                        .formatted(
+                                directoryServer.getListenPort(),
+                                tempDir,
+                                tempDir.resolve("zmbackup.log"),
+                                tempDir.resolve("blockedlist.conf")));
+        return configFile;
+    }
+
+    private static CommandLine commandLine(StringWriter out, StringWriter err) {
+        CommandLine cmd = new CommandLine(new Main());
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(err));
+        return cmd;
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cli/MainTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MainTest.java
@@ -83,11 +83,6 @@ class MainTest {
     }
 
     @Test
-    void backupIsStubbed() {
-        assertStubbed("backup");
-    }
-
-    @Test
     void restoreIsStubbed() {
         assertStubbed("restore");
     }


### PR DESCRIPTION
## Summary
- Turns `backup` into a command group (like `accounts`), adding five subcommands per #287 (sub-task of #257):
  - `backup ldap [--account ...] [--domain ...]`
  - `backup alias [--account ...]`
  - `backup distlist [--account ...]`
  - `backup signature [--account ...]`
  - `backup domain [--domain ...]`
- Wires `BackupService` into `AppContext`, alongside the `ZimbraLdapExporter` side of `UnboundIdLdapAdapter`.
- Each subcommand prints the resulting session ID/type/status/size and exits `0` on `FINISHED` (or nothing to back up), `1` on `FAILED`.

## Test plan
- [x] `./gradlew :app:test --tests "io.zmbackup.app.cli.*"` — new `BackupCommandTest` (in-memory LDAP + temp work dir) covers all five subcommands, plus updated `MainTest`.
- [x] `./gradlew build` — full project build succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnwiHWFWPkaRh6HgpAhwwf)_