### PR TITLE
Add zmbackup delete command

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -42,7 +42,7 @@ public final class AppContext {
                 config.zimbraLdap().sslEnabled());
         this.accountDiscovery = ldapAdapter;
         this.ldapExporter = ldapAdapter;
-        this.sessionService = new SessionService(metadataStore);
+        this.sessionService = new SessionService(storageProvider, metadataStore);
         this.backupService = new BackupService(accountDiscovery, ldapExporter, storageProvider, metadataStore);
     }
 

--- a/app/src/main/java/io/zmbackup/app/cli/DeleteCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/DeleteCommand.java
@@ -1,20 +1,38 @@
 package io.zmbackup.app.cli;
 
+import io.zmbackup.app.AppContext;
+import java.io.PrintWriter;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Spec;
 
-/** Stub for the delete subcommand; real deletion logic lands once the zimbra module is implemented. */
-@Command(name = "delete", description = "Delete a stored backup session (not yet implemented).")
+/** Deletes a stored backup session, mirroring the bash tool's {@code delete_one}. */
+@Command(name = "delete", description = "Delete a stored backup session.")
 public final class DeleteCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private Main parent;
+
+    @Option(names = "--session", required = true, description = "ID of the session to delete.")
+    private String sessionId;
 
     @Spec
     private CommandSpec spec;
 
     @Override
-    public Integer call() {
-        spec.commandLine().getErr().println("delete: not yet implemented");
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.configFile());
+        PrintWriter out = spec.commandLine().getOut();
+
+        out.println("Removing session " + sessionId + " - please wait.");
+        if (context.sessionService().deleteSession(sessionId)) {
+            out.println("Backup session " + sessionId + " removed.");
+            return 0;
+        }
+        spec.commandLine().getErr().println("Session " + sessionId + " not found in database - ignoring.");
         return 1;
     }
 }

--- a/app/src/test/java/io/zmbackup/app/cli/MainTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MainTest.java
@@ -88,13 +88,46 @@ class MainTest {
     }
 
     @Test
-    void deleteIsStubbed() {
-        assertStubbed("delete");
+    void housekeepIsStubbed() {
+        assertStubbed("housekeep");
     }
 
     @Test
-    void housekeepIsStubbed() {
-        assertStubbed("housekeep");
+    void deleteRemovesStoredSession() throws IOException {
+        Path configFile = writeConfig();
+        new SqliteMetadataStore(tempDir.resolve("sessions.sqlite3"))
+                .save(
+                        new BackupSession(
+                                "full-20260101120000",
+                                BackupType.FULL,
+                                SessionStatus.FINISHED,
+                                Instant.parse("2026-01-01T12:00:00Z"),
+                                Instant.parse("2026-01-01T12:05:00Z"),
+                                "10M"));
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode =
+                cmd.execute("--config", configFile.toString(), "delete", "--session", "full-20260101120000");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("Backup session full-20260101120000 removed."));
+        assertTrue(
+                new SqliteMetadataStore(tempDir.resolve("sessions.sqlite3"))
+                        .findSession("full-20260101120000")
+                        .isEmpty());
+    }
+
+    @Test
+    void deleteReportsSessionNotFound() throws IOException {
+        Path configFile = writeConfig();
+        StringWriter err = new StringWriter();
+        CommandLine cmd = commandLine(new StringWriter(), err);
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "delete", "--session", "does-not-exist");
+
+        assertEquals(1, exitCode);
+        assertTrue(err.toString().contains("does-not-exist not found in database"));
     }
 
     private void assertStubbed(String subcommand) {

--- a/core/src/main/java/io/zmbackup/core/service/SessionService.java
+++ b/core/src/main/java/io/zmbackup/core/service/SessionService.java
@@ -2,20 +2,24 @@ package io.zmbackup.core.service;
 
 import io.zmbackup.core.domain.BackupSession;
 import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.StorageProvider;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
 /**
- * Read-only queries over stored backup sessions, driving {@code zmbackup list}. Mirrors the
- * bash tool's {@code list_sessions} in {@code SessionAction.sh}.
+ * Queries and deletion over stored backup sessions, driving {@code zmbackup list} and
+ * {@code zmbackup delete}. Mirrors the bash tool's {@code list_sessions} in
+ * {@code SessionAction.sh} and {@code delete_one} in {@code DeleteAction.sh}.
  */
 public class SessionService {
 
+    private final StorageProvider storageProvider;
     private final MetadataStore metadataStore;
 
-    public SessionService(MetadataStore metadataStore) {
+    public SessionService(StorageProvider storageProvider, MetadataStore metadataStore) {
+        this.storageProvider = Objects.requireNonNull(storageProvider, "storageProvider must not be null");
         this.metadataStore = Objects.requireNonNull(metadataStore, "metadataStore must not be null");
     }
 
@@ -24,5 +28,21 @@ public class SessionService {
         return metadataStore.listSessions().stream()
                 .sorted(Comparator.comparing(BackupSession::startedAt).reversed())
                 .toList();
+    }
+
+    /**
+     * Deletes the session with the given ID, mirroring {@code delete_one}: removes its stored
+     * content and metadata.
+     *
+     * @return {@code true} if the session existed and was removed, {@code false} if no session
+     *     with that ID was found
+     */
+    public boolean deleteSession(String sessionId) throws IOException {
+        if (metadataStore.findSession(sessionId).isEmpty()) {
+            return false;
+        }
+        storageProvider.deleteSession(sessionId);
+        metadataStore.deleteSession(sessionId);
+        return true;
     }
 }

--- a/core/src/test/java/io/zmbackup/core/service/SessionServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/SessionServiceTest.java
@@ -1,13 +1,18 @@
 package io.zmbackup.core.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.zmbackup.core.domain.BackupAccountRecord;
 import io.zmbackup.core.domain.BackupSession;
 import io.zmbackup.core.domain.BackupType;
 import io.zmbackup.core.domain.SessionStatus;
 import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.StorageProvider;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -15,12 +20,14 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class SessionServiceTest {
 
+    private final InMemoryStorageProvider storageProvider = new InMemoryStorageProvider();
     private final InMemoryMetadataStore metadataStore = new InMemoryMetadataStore();
-    private final SessionService sessionService = new SessionService(metadataStore);
+    private final SessionService sessionService = new SessionService(storageProvider, metadataStore);
 
     @Test
     void listsSessionsMostRecentlyStartedFirst() throws IOException {
@@ -42,8 +49,66 @@ class SessionServiceTest {
         assertEquals(List.of(), sessionService.listSessions());
     }
 
+    @Test
+    void deleteSessionRemovesStorageAndMetadata() throws IOException {
+        BackupSession session = session("ldap-20260701120000", Instant.now());
+        metadataStore.save(session);
+        storageProvider.content.put("ldap-20260701120000/alice@example.com.ldiff", new byte[0]);
+
+        boolean deleted = sessionService.deleteSession("ldap-20260701120000");
+
+        assertTrue(deleted);
+        assertEquals(Optional.empty(), metadataStore.findSession("ldap-20260701120000"));
+        assertTrue(storageProvider.deletedSessions.contains("ldap-20260701120000"));
+    }
+
+    @Test
+    void deleteSessionReturnsFalseWhenSessionNotFound() throws IOException {
+        boolean deleted = sessionService.deleteSession("does-not-exist");
+
+        assertFalse(deleted);
+        assertTrue(storageProvider.deletedSessions.isEmpty());
+    }
+
     private static BackupSession session(String sessionId, Instant startedAt) {
         return new BackupSession(sessionId, BackupType.LDAP, SessionStatus.FINISHED, startedAt, startedAt, "1K");
+    }
+
+    /** In-memory {@link StorageProvider} fake that records which sessions were deleted. */
+    private static final class InMemoryStorageProvider implements StorageProvider {
+        final Map<String, byte[]> content = new LinkedHashMap<>();
+        final Set<String> deletedSessions = new java.util.HashSet<>();
+
+        @Override
+        public OutputStream openWrite(String sessionId, String account, String suffix) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public InputStream openRead(String sessionId, String account, String suffix) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean exists(String sessionId, String account, String suffix) {
+            return content.containsKey(sessionId + "/" + account + "." + suffix);
+        }
+
+        @Override
+        public String sizeOfAccount(String sessionId, String account) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String sizeOfSession(String sessionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void deleteSession(String sessionId) {
+            deletedSessions.add(sessionId);
+            content.keySet().removeIf(key -> key.startsWith(sessionId + "/"));
+        }
     }
 
     /** In-memory {@link MetadataStore} fake backed by simple maps. */


### PR DESCRIPTION
## Summary
- Adds `SessionService.deleteSession(sessionId)`, mirroring the bash tool's `delete_one`: removes the session's stored content via `StorageProvider` and its metadata row via `MetadataStore`, returning whether the session existed.
- Replaces the `DeleteCommand` stub with a real implementation: `zmbackup delete --session <id>` (per #257), printing the same user-facing messages as `delete_one`/`__DELETEBACKUP` in `DeleteAction.sh` and exiting `1` when the session isn't found.
- Closes #289 (sub-task of #257).

## Test plan
- [x] `./gradlew test` — full project build and test suite succeeds, including new `SessionServiceTest` cases (`deleteSessionRemovesStorageAndMetadata`, `deleteSessionReturnsFalseWhenSessionNotFound`) and new `MainTest` cases (`deleteRemovesStoredSession`, `deleteReportsSessionNotFound`) replacing the old `deleteIsStubbed` test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4Xpss6NDF1Qp6YgbQ3fkF)_