### PR TITLE
Implement zmbackup housekeep command

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -7,6 +7,7 @@ import io.zmbackup.core.port.MetadataStore;
 import io.zmbackup.core.port.StorageProvider;
 import io.zmbackup.core.port.ZimbraLdapExporter;
 import io.zmbackup.core.service.BackupService;
+import io.zmbackup.core.service.HousekeepService;
 import io.zmbackup.core.service.SessionService;
 import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
@@ -30,6 +31,7 @@ public final class AppContext {
     private final ZimbraLdapExporter ldapExporter;
     private final SessionService sessionService;
     private final BackupService backupService;
+    private final HousekeepService housekeepService;
 
     public AppContext(AppConfig config) throws IOException {
         this.config = config;
@@ -44,6 +46,7 @@ public final class AppContext {
         this.ldapExporter = ldapAdapter;
         this.sessionService = new SessionService(storageProvider, metadataStore);
         this.backupService = new BackupService(accountDiscovery, ldapExporter, storageProvider, metadataStore);
+        this.housekeepService = new HousekeepService(storageProvider, metadataStore);
     }
 
     /** Reads {@code configFile} and wires the components it describes. */
@@ -73,5 +76,9 @@ public final class AppContext {
 
     public BackupService backupService() {
         return backupService;
+    }
+
+    public HousekeepService housekeepService() {
+        return housekeepService;
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/HousekeepCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/HousekeepCommand.java
@@ -1,20 +1,48 @@
 package io.zmbackup.app.cli;
 
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.service.HousekeepService;
+import java.io.PrintWriter;
+import java.util.List;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Spec;
 
-/** Stub for the housekeep subcommand; real cleanup logic lands once the zimbra module is implemented. */
-@Command(name = "housekeep", description = "Prune old backup sessions (not yet implemented).")
+/**
+ * Prunes old and empty backup sessions, mirroring the bash tool's {@code delete_old} and {@code
+ * clean_empty} functions in {@code DeleteAction.sh}.
+ */
+@Command(name = "housekeep", description = "Prune old and empty backup sessions.")
 public final class HousekeepCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private Main parent;
 
     @Spec
     private CommandSpec spec;
 
     @Override
-    public Integer call() {
-        spec.commandLine().getErr().println("housekeep: not yet implemented");
-        return 1;
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.configFile());
+        PrintWriter out = spec.commandLine().getOut();
+        HousekeepService housekeepService = context.housekeepService();
+
+        out.println("Removing old backup sessions - please wait.");
+        List<BackupSession> rotated =
+                housekeepService.rotateOldSessions(context.config().backup().rotateDays());
+        for (BackupSession session : rotated) {
+            out.println("Backup session " + session.sessionId() + " removed.");
+        }
+
+        out.println("Removing empty backup sessions - please wait.");
+        List<BackupSession> emptied = housekeepService.cleanEmpty();
+        for (BackupSession session : emptied) {
+            out.println("Backup session " + session.sessionId() + " removed.");
+        }
+
+        return 0;
     }
 }

--- a/app/src/test/java/io/zmbackup/app/cli/HousekeepCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/HousekeepCommandTest.java
@@ -1,0 +1,108 @@
+package io.zmbackup.app.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+class HousekeepCommandTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void removesOldAndEmptySessions() throws Exception {
+        Path configFile = writeConfig(7);
+        AppContext context = AppContext.fromConfigFile(configFile);
+        Instant now = Instant.now();
+
+        BackupSession old = session("ldap-old", now.minus(10, ChronoUnit.DAYS));
+        context.metadataStore().save(old);
+        context.metadataStore()
+                .recordAccountBackup(
+                        new BackupAccountRecord(null, "ldap-old", "alice@example.com", "1K", now, now));
+        try (var writer = context.storageProvider().openWrite("ldap-old", "alice@example.com", "ldiff")) {
+            writer.write("dn: uid=alice\n".getBytes());
+        }
+
+        BackupSession recent = session("ldap-recent", now.minus(1, ChronoUnit.DAYS));
+        context.metadataStore().save(recent);
+        context.metadataStore()
+                .recordAccountBackup(
+                        new BackupAccountRecord(null, "ldap-recent", "bob@example.com", "1K", now, now));
+
+        BackupSession empty = session("ldap-empty", now);
+        context.metadataStore().save(empty);
+
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out);
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "housekeep");
+
+        assertEquals(0, exitCode);
+        String output = out.toString();
+        assertTrue(output.contains("Backup session ldap-old removed."));
+        assertTrue(output.contains("Backup session ldap-empty removed."));
+        assertFalse(output.contains("ldap-recent removed"));
+        assertTrue(context.metadataStore().findSession("ldap-old").isEmpty());
+        assertTrue(context.metadataStore().findSession("ldap-empty").isEmpty());
+        assertTrue(context.metadataStore().findSession("ldap-recent").isPresent());
+    }
+
+    private static BackupSession session(String sessionId, Instant completedAt) {
+        return new BackupSession(
+                sessionId, BackupType.LDAP, SessionStatus.FINISHED, completedAt.minusSeconds(60), completedAt, "1K");
+    }
+
+    private Path writeConfig(int rotateDays) throws IOException {
+        Path configFile = tempDir.resolve("zmbackup.yaml");
+        Files.writeString(
+                configFile,
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:389
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                  sslEnabled: false
+                zimbraMailbox:
+                  backupUser: zimbra
+                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                backup:
+                  workDir: %s
+                  logFile: %s
+                  blockedListFile: %s
+                  rotateDays: %d
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """
+                        .formatted(
+                                tempDir,
+                                tempDir.resolve("zmbackup.log"),
+                                tempDir.resolve("blockedlist.conf"),
+                                rotateDays));
+        return configFile;
+    }
+
+    private static CommandLine commandLine(StringWriter out) {
+        CommandLine cmd = new CommandLine(new Main());
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(new StringWriter()));
+        return cmd;
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cli/MainTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MainTest.java
@@ -88,8 +88,28 @@ class MainTest {
     }
 
     @Test
-    void housekeepIsStubbed() {
-        assertStubbed("housekeep");
+    void housekeepRemovesOldSessions() throws IOException {
+        Path configFile = writeConfig();
+        new SqliteMetadataStore(tempDir.resolve("sessions.sqlite3"))
+                .save(
+                        new BackupSession(
+                                "full-20200101120000",
+                                BackupType.FULL,
+                                SessionStatus.FINISHED,
+                                Instant.parse("2020-01-01T12:00:00Z"),
+                                Instant.parse("2020-01-01T12:05:00Z"),
+                                "10M"));
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "housekeep");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("Backup session full-20200101120000 removed."));
+        assertTrue(
+                new SqliteMetadataStore(tempDir.resolve("sessions.sqlite3"))
+                        .findSession("full-20200101120000")
+                        .isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Wires the `HousekeepService` built for #257 into the CLI: `HousekeepCommand` now rotates sessions older than `backup.rotateDays` and removes empty sessions, instead of returning the "not yet implemented" stub.
- Adds `HousekeepService` to `AppContext` alongside the existing `SessionService`/`BackupService`.
- Output mirrors the bash tool's `delete_old`/`clean_empty` messaging and the existing `delete` command's `"Backup session X removed."` line.

Closes #290.

## Test plan
- [x] `HousekeepCommandTest`: seeds an old session, a recent session, and an empty session via `AppContext`, runs `zmbackup housekeep`, and asserts the old and empty sessions are removed while the recent one is kept.
- [x] Updated `MainTest.housekeepIsStubbed` → `housekeepRemovesOldSessions` to reflect the real behavior.
- [x] `./gradlew test` passes across all modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDhoYCURWh6qR96t58UsE7

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDhoYCURWh6qR96t58UsE7)_