### PR TITLE
Unit tests for BackupService with mocked ports

### DIFF
--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -81,6 +81,15 @@ class BackupServiceTest {
     }
 
     @Test
+    void backsUpSignatureType() throws IOException {
+        Optional<BackupSession> result = backupService.backup(BackupType.SIGNATURE, List.of("alice@example.com"));
+
+        assertTrue(result.isPresent());
+        assertTrue(result.get().sessionId().startsWith("signature-"));
+        assertEquals(List.of(LdapObjectType.SIGNATURE), ldapExporter.exportedTypes.get("alice@example.com"));
+    }
+
+    @Test
     void domainTypeDiscoversDomainsAndUsesExportDomain() throws IOException {
         accountDiscovery.wholeDirectory.put(LdapObjectType.DOMAIN, List.of("example.com"));
 


### PR DESCRIPTION
## Summary
- `BackupServiceTest` (added alongside `BackupService` itself in #348) already exercises `BackupService` against in-memory fakes for all four ports it depends on: `AccountDiscovery`, `ZimbraLdapExporter`, `StorageProvider`, and `MetadataStore`.
- Covers discovery-based backup, explicit-identifier backup (bypassing discovery), domain-scoped discovery, the `DOMAIN` type using `exportDomain`, an empty-result no-op, a partial-export-failure marking the session `FAILED`, and rejection of mailbox-inclusive types.
- The one gap: `SIGNATURE`'s `LdapObjectType` mapping was only exercised via the empty-result case, not an actual export. Adds `backsUpSignatureType`, which backs up an explicit identifier with `BackupType.SIGNATURE` and asserts it maps to `LdapObjectType.SIGNATURE` and uses the `signature-` session prefix.

## Test plan
- [x] `./gradlew :core:test --tests "io.zmbackup.core.service.BackupServiceTest"` — all 8 cases pass.
- [x] `./gradlew build` — full multi-module build passes.

Closes #291. Sub-task of #257.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AeJG65ujgxG9JtdVR9Wb6c)_