### PR TITLE
Publish JUnit results from test-java so CircleCI's Tests tab shows real data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,17 @@ jobs:
       - run:
           name: Run Java tests
           command: ./gradlew test
+      - run:
+          name: Collect JUnit test results
+          command: |
+            mkdir -p ~/test-results/junit
+            find . -path '*/build/test-results/test' -type d \
+              -exec sh -c 'cp -R "$1"/*.xml ~/test-results/junit/ 2>/dev/null' _ {} \;
+          when: always
+      - store_test_results:
+          path: ~/test-results/junit
+      - store_artifacts:
+          path: ~/test-results/junit
 
 workflows:
   test-workflow:


### PR DESCRIPTION
## Summary
- `./gradlew test` in the `test-java` CircleCI job already runs and passes every module's suite (verified locally: 20 test suites across `app`, `core`, `local`, `zimbra`, including the Cucumber integration feature), but the job never called `store_test_results`
- Without that step, CircleCI's Tests tab has no real data to show, so it falls back to its generic placeholder example (`/home/circleci/src/node-example/test/test.js`) — which reads like two unrelated, non-existent tests are failing
- Added a step that collects every module's `build/test-results/test/*.xml` into a common directory, then `store_test_results` + `store_artifacts` to publish them (runs with `when: always` so results surface even on a genuine test failure)

## Test plan
- [x] `./gradlew test` passes locally, producing JUnit XML in each module's `build/test-results/test/`
- [x] Verified the collection command gathers all 20 suites from all 4 modules into one directory with no filename collisions
- [x] Validated `.circleci/config.yml` YAML syntax

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBHgk1u9tQzFJfnbuFSyUw)_