### PR TITLE
Implement ZimbraRestMailboxExporter over Zimbra's REST mailbox endpoint

### DIFF
--- a/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
@@ -1,0 +1,119 @@
+package io.zmbackup.zimbra;
+
+import io.zmbackup.core.port.ZimbraMailboxExporter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * Exports a single account's mailbox content as a {@code .tgz} archive over Zimbra's REST
+ * interface, mirroring {@code mailbox_backup} in the bash tool's {@code ParallelAction.sh}: {@code
+ * getRestURL "/?fmt=tgz&resolve=skip[&query=after:"<date>"]"}.
+ *
+ * <p>Uses the JDK's {@link HttpClient} directly, with an HTTP Basic {@code Authorization} header
+ * built from the configured admin credentials.
+ */
+public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
+
+    /**
+     * Matches the bash tool's {@code date +%m/%d/%Y} formatting of the incremental cutoff passed
+     * to Zimbra's {@code query=after:"<date>"} REST parameter.
+     */
+    private static final DateTimeFormatter AFTER_DATE_FORMAT =
+            DateTimeFormatter.ofPattern("MM/dd/yyyy").withZone(ZoneId.systemDefault());
+
+    private final URI baseUri;
+    private final String adminUser;
+    private final String adminPassword;
+    private final HttpClient httpClient;
+
+    /**
+     * @param baseUrl       the Zimbra server's REST base URL, e.g. {@code
+     *                      "https://mail.example.com:7071"}
+     * @param adminUser     the Zimbra admin account used for HTTP Basic authentication
+     * @param adminPassword the admin account's password
+     */
+    public ZimbraRestMailboxExporter(String baseUrl, String adminUser, String adminPassword) {
+        Objects.requireNonNull(baseUrl, "baseUrl must not be null");
+        this.baseUri = URI.create(baseUrl);
+        this.adminUser = Objects.requireNonNull(adminUser, "adminUser must not be null");
+        this.adminPassword = Objects.requireNonNull(adminPassword, "adminPassword must not be null");
+        this.httpClient = HttpClient.newHttpClient();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Issues an HTTP GET against {@code {baseUrl}/home/{account}/?fmt=tgz&resolve=skip},
+     * appending {@code &query=after:"<date>"} when {@code since} is non-null. HTTP 204 (no new
+     * content) returns {@code false} without writing to {@code destination}; any other non-200
+     * response is reported as an {@link IOException}.
+     */
+    @Override
+    public boolean export(String account, OutputStream destination, Instant since) throws IOException {
+        HttpRequest request = HttpRequest.newBuilder(exportUri(account, since))
+                .header("Authorization", basicAuthHeader())
+                .GET()
+                .build();
+
+        HttpResponse<InputStream> response;
+        try {
+            response = httpClient.send(request, BodyHandlers.ofInputStream());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while exporting mailbox for " + account, e);
+        }
+
+        try (InputStream body = response.body()) {
+            return switch (response.statusCode()) {
+                case 200 -> {
+                    body.transferTo(destination);
+                    yield true;
+                }
+                case 204 -> false;
+                default -> throw new IOException(
+                        "Failed to export mailbox for " + account + ": HTTP " + response.statusCode());
+            };
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Not yet implemented.
+     */
+    @Override
+    public void restore(String account, InputStream source) throws IOException {
+        throw new UnsupportedOperationException("ZimbraRestMailboxExporter.restore() is not yet implemented");
+    }
+
+    private URI exportUri(String account, Instant since) throws IOException {
+        String path = (baseUri.getRawPath() == null ? "" : baseUri.getRawPath()) + "/home/" + account + "/";
+        String query = "fmt=tgz&resolve=skip";
+        if (since != null) {
+            query += "&query=after:\"" + AFTER_DATE_FORMAT.format(since) + "\"";
+        }
+        try {
+            return new URI(baseUri.getScheme(), baseUri.getAuthority(), path, query, null);
+        } catch (URISyntaxException e) {
+            throw new IOException("Invalid Zimbra REST URL for " + account, e);
+        }
+    }
+
+    private String basicAuthHeader() {
+        String credentials = adminUser + ":" + adminPassword;
+        return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/zimbra/src/test/java/io/zmbackup/zimbra/ZimbraRestMailboxExporterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/ZimbraRestMailboxExporterTest.java
@@ -1,0 +1,141 @@
+package io.zmbackup.zimbra;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Base64;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ZimbraRestMailboxExporterTest {
+
+    private static final String ADMIN_USER = "zimbra";
+    private static final String ADMIN_PASSWORD = "secret";
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void exportsFullMailboxContentOnHttp200() throws Exception {
+        byte[] tgzBytes = "tgz-content".getBytes(StandardCharsets.UTF_8);
+        RecordingHandler handler = new RecordingHandler(200, tgzBytes);
+        String baseUrl = startServer("/home/alice@example.com/", handler);
+        ZimbraRestMailboxExporter exporter = new ZimbraRestMailboxExporter(baseUrl, ADMIN_USER, ADMIN_PASSWORD);
+
+        ByteArrayOutputStream destination = new ByteArrayOutputStream();
+        boolean wroteContent = exporter.export("alice@example.com", destination, null);
+
+        assertTrue(wroteContent);
+        assertEquals("tgz-content", destination.toString(StandardCharsets.UTF_8));
+        assertEquals("fmt=tgz&resolve=skip", handler.capturedQuery);
+        assertEquals(
+                "Basic " + Base64.getEncoder().encodeToString((ADMIN_USER + ":" + ADMIN_PASSWORD).getBytes()),
+                handler.capturedAuthorization);
+    }
+
+    @Test
+    void appendsAfterQueryParameterWhenSinceIsGiven() throws Exception {
+        RecordingHandler handler = new RecordingHandler(200, new byte[0]);
+        String baseUrl = startServer("/home/alice@example.com/", handler);
+        ZimbraRestMailboxExporter exporter = new ZimbraRestMailboxExporter(baseUrl, ADMIN_USER, ADMIN_PASSWORD);
+        Instant since = ZonedDateTime.of(2026, 7, 2, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant();
+
+        exporter.export("alice@example.com", new ByteArrayOutputStream(), since);
+
+        assertEquals("fmt=tgz&resolve=skip&query=after:%2207/02/2026%22", handler.capturedQuery);
+    }
+
+    @Test
+    void returnsFalseWithoutWritingOnHttp204() throws Exception {
+        RecordingHandler handler = new RecordingHandler(204, new byte[0]);
+        String baseUrl = startServer("/home/alice@example.com/", handler);
+        ZimbraRestMailboxExporter exporter = new ZimbraRestMailboxExporter(baseUrl, ADMIN_USER, ADMIN_PASSWORD);
+
+        ByteArrayOutputStream destination = new ByteArrayOutputStream();
+        boolean wroteContent = exporter.export("alice@example.com", destination, Instant.now());
+
+        assertFalse(wroteContent);
+        assertEquals(0, destination.size());
+    }
+
+    @Test
+    void throwsIOExceptionOnNonSuccessStatus() throws Exception {
+        RecordingHandler handler = new RecordingHandler(500, "boom".getBytes(StandardCharsets.UTF_8));
+        String baseUrl = startServer("/home/alice@example.com/", handler);
+        ZimbraRestMailboxExporter exporter = new ZimbraRestMailboxExporter(baseUrl, ADMIN_USER, ADMIN_PASSWORD);
+
+        IOException exception = assertThrows(
+                IOException.class,
+                () -> exporter.export("alice@example.com", new ByteArrayOutputStream(), null));
+        assertTrue(exception.getMessage().contains("500"));
+    }
+
+    @Test
+    void wrapsUnreachableServerInIOException() {
+        ZimbraRestMailboxExporter exporter =
+                new ZimbraRestMailboxExporter("http://127.0.0.1:1", ADMIN_USER, ADMIN_PASSWORD);
+
+        assertThrows(
+                IOException.class,
+                () -> exporter.export("alice@example.com", new ByteArrayOutputStream(), null));
+    }
+
+    @Test
+    void restoreIsNotYetImplemented() {
+        ZimbraRestMailboxExporter exporter =
+                new ZimbraRestMailboxExporter("http://127.0.0.1:1", ADMIN_USER, ADMIN_PASSWORD);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> exporter.restore("alice@example.com", InputStream.nullInputStream()));
+    }
+
+    private String startServer(String path, RecordingHandler handler) throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(path, handler);
+        server.start();
+        return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    /** Records the request it received and replies with a fixed status code and body. */
+    private static final class RecordingHandler implements com.sun.net.httpserver.HttpHandler {
+        private final int statusCode;
+        private final byte[] responseBody;
+        private volatile String capturedQuery;
+        private volatile String capturedAuthorization;
+
+        RecordingHandler(int statusCode, byte[] responseBody) {
+            this.statusCode = statusCode;
+            this.responseBody = responseBody;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            capturedQuery = exchange.getRequestURI().getRawQuery();
+            capturedAuthorization = exchange.getRequestHeaders().getFirst("Authorization");
+            exchange.sendResponseHeaders(statusCode, responseBody.length == 0 ? -1 : responseBody.length);
+            if (responseBody.length > 0) {
+                exchange.getResponseBody().write(responseBody);
+            }
+            exchange.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ZimbraRestMailboxExporter`, a `zimbra`-module implementation of the existing `core` port `ZimbraMailboxExporter`, using `java.net.http.HttpClient` (no extra dependency)
- Issues `GET {baseUrl}/home/{account}/?fmt=tgz&resolve=skip`, appending `&query=after:"<date>"` (formatted `MM/dd/yyyy`, matching the bash tool's `date +%m/%d/%Y`) when an incremental `since` cutoff is given, mirroring `mailbox_backup` in the bash tool's `ParallelAction.sh`
- Sends an HTTP Basic `Authorization` header built from the configured admin user/password
- Treats HTTP 204 as "nothing to export" (returns `false` without writing to the destination), and wraps any other non-200 status in an `IOException`
- `restore(...)` throws `UnsupportedOperationException` for now, matching the same not-yet-implemented pattern used by `UnboundIdLdapAdapter.restore()`

This is a sub-task of #294 (itself under #258); wiring the exporter into `AppContext`/`BackupService`/the CLI is left to the later sub-tasks in that epic.

## Test plan

- Added `ZimbraRestMailboxExporterTest`, which spins up a local `com.sun.net.httpserver.HttpServer` (JDK built-in, consistent with the project's preference for exercising real local servers over LDAP in `UnboundIdLdapAdapterTest` rather than mocks) to verify: full export on HTTP 200, the `after` query parameter when `since` is given, HTTP 204 returning `false` without writing, non-200 statuses raising `IOException`, connection failures wrapped in `IOException`, and `restore()` throwing `UnsupportedOperationException`
- `./gradlew build` — succeeds
- `./gradlew test` — all modules pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01XxYQVBhhLv6wibvszCXPpD)_