### PR TITLE
Wire ZimbraRestMailboxExporter into AppContext

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -6,12 +6,14 @@ import io.zmbackup.core.port.AccountDiscovery;
 import io.zmbackup.core.port.MetadataStore;
 import io.zmbackup.core.port.StorageProvider;
 import io.zmbackup.core.port.ZimbraLdapExporter;
+import io.zmbackup.core.port.ZimbraMailboxExporter;
 import io.zmbackup.core.service.BackupService;
 import io.zmbackup.core.service.HousekeepService;
 import io.zmbackup.core.service.SessionService;
 import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
 import io.zmbackup.zimbra.UnboundIdLdapAdapter;
+import io.zmbackup.zimbra.ZimbraRestMailboxExporter;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -29,6 +31,7 @@ public final class AppContext {
     private final MetadataStore metadataStore;
     private final AccountDiscovery accountDiscovery;
     private final ZimbraLdapExporter ldapExporter;
+    private final ZimbraMailboxExporter mailboxExporter;
     private final SessionService sessionService;
     private final BackupService backupService;
     private final HousekeepService housekeepService;
@@ -44,6 +47,10 @@ public final class AppContext {
                 config.zimbraLdap().sslEnabled());
         this.accountDiscovery = ldapAdapter;
         this.ldapExporter = ldapAdapter;
+        this.mailboxExporter = new ZimbraRestMailboxExporter(
+                config.zimbraMailbox().restBaseUrl(),
+                config.zimbraMailbox().adminUser(),
+                config.zimbraMailbox().adminPassword());
         this.sessionService = new SessionService(storageProvider, metadataStore);
         this.backupService = new BackupService(accountDiscovery, ldapExporter, storageProvider, metadataStore);
         this.housekeepService = new HousekeepService(storageProvider, metadataStore);
@@ -68,6 +75,10 @@ public final class AppContext {
 
     public AccountDiscovery accountDiscovery() {
         return accountDiscovery;
+    }
+
+    public ZimbraMailboxExporter mailboxExporter() {
+        return mailboxExporter;
     }
 
     public SessionService sessionService() {

--- a/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
+++ b/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
@@ -59,7 +59,10 @@ public final class YamlConfigLoader {
         return new ZimbraMailboxConfig(
                 requireString(root, "zimbraMailbox.backupUser"),
                 requirePath(root, "zimbraMailbox.zmmailboxPath"),
-                optionalBoolean(root, "zimbraMailbox.backupInactiveAccounts", true));
+                optionalBoolean(root, "zimbraMailbox.backupInactiveAccounts", true),
+                requireString(root, "zimbraMailbox.restBaseUrl"),
+                requireString(root, "zimbraMailbox.adminUser"),
+                requireString(root, "zimbraMailbox.adminPassword"));
     }
 
     private static BackupConfig parseBackup(Map<String, Object> root) {

--- a/app/src/main/java/io/zmbackup/app/config/ZimbraMailboxConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/ZimbraMailboxConfig.java
@@ -5,17 +5,31 @@ import java.util.Objects;
 
 /**
  * Zimbra mailbox export settings, mirroring the {@code BACKUPUSER}/{@code ZMMAILBOX}/
- * {@code BACKUP_INACTIVE_ACCOUNTS} fields of the bash tool's {@code zmbackup.conf}.
+ * {@code BACKUP_INACTIVE_ACCOUNTS} fields of the bash tool's {@code zmbackup.conf}, plus the REST
+ * endpoint settings used by {@code ZimbraRestMailboxExporter}.
  *
  * @param backupUser              the Zimbra service account used to start/stop the service and
  *                                run {@code zmmailbox}, e.g. {@code "zimbra"}
  * @param zmmailboxPath           location of the {@code zmmailbox} binary
  * @param backupInactiveAccounts whether to include disabled accounts
+ * @param restBaseUrl             the Zimbra server's REST base URL, e.g.
+ *                                {@code "https://mail.example.com:7071"}
+ * @param adminUser               the Zimbra admin account used for REST HTTP Basic authentication
+ * @param adminPassword           the admin account's password
  */
-public record ZimbraMailboxConfig(String backupUser, Path zmmailboxPath, boolean backupInactiveAccounts) {
+public record ZimbraMailboxConfig(
+        String backupUser,
+        Path zmmailboxPath,
+        boolean backupInactiveAccounts,
+        String restBaseUrl,
+        String adminUser,
+        String adminPassword) {
 
     public ZimbraMailboxConfig {
         Objects.requireNonNull(backupUser, "backupUser must not be null");
         Objects.requireNonNull(zmmailboxPath, "zmmailboxPath must not be null");
+        Objects.requireNonNull(restBaseUrl, "restBaseUrl must not be null");
+        Objects.requireNonNull(adminUser, "adminUser must not be null");
+        Objects.requireNonNull(adminPassword, "adminPassword must not be null");
     }
 }

--- a/app/src/test/java/io/zmbackup/app/AppContextTest.java
+++ b/app/src/test/java/io/zmbackup/app/AppContextTest.java
@@ -13,6 +13,7 @@ import io.zmbackup.app.config.ZimbraMailboxConfig;
 import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
 import io.zmbackup.zimbra.UnboundIdLdapAdapter;
+import io.zmbackup.zimbra.ZimbraRestMailboxExporter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,6 +35,7 @@ class AppContextTest {
         assertInstanceOf(LocalStorageProvider.class, context.storageProvider());
         assertInstanceOf(SqliteMetadataStore.class, context.metadataStore());
         assertInstanceOf(UnboundIdLdapAdapter.class, context.accountDiscovery());
+        assertInstanceOf(ZimbraRestMailboxExporter.class, context.mailboxExporter());
         assertTrue(Files.exists(tempDir.resolve("sessions.sqlite3")));
     }
 
@@ -50,6 +52,9 @@ class AppContextTest {
                 zimbraMailbox:
                   backupUser: zimbra
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
                 backup:
                   workDir: %s
                   logFile: %s
@@ -70,7 +75,13 @@ class AppContextTest {
     private static AppConfig configWithWorkDir(Path workDir) {
         return new AppConfig(
                 new ZimbraLdapConfig("ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true),
-                new ZimbraMailboxConfig("zimbra", Path.of("/opt/zimbra/bin/zmmailbox"), true),
+                new ZimbraMailboxConfig(
+                        "zimbra",
+                        Path.of("/opt/zimbra/bin/zmmailbox"),
+                        true,
+                        "https://127.0.0.1:7071",
+                        "zimbra",
+                        "secret"),
                 new BackupConfig(
                         workDir,
                         workDir.resolve("zmbackup.log"),

--- a/app/src/test/java/io/zmbackup/app/cli/AccountsCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/AccountsCommandTest.java
@@ -119,6 +119,9 @@ class AccountsCommandTest {
                 zimbraMailbox:
                   backupUser: zimbra
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
                 backup:
                   workDir: %s
                   logFile: %s

--- a/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
@@ -208,6 +208,9 @@ class BackupCommandTest {
                 zimbraMailbox:
                   backupUser: zimbra
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
                 backup:
                   workDir: %s
                   logFile: %s

--- a/app/src/test/java/io/zmbackup/app/cli/HousekeepCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/HousekeepCommandTest.java
@@ -82,6 +82,9 @@ class HousekeepCommandTest {
                 zimbraMailbox:
                   backupUser: zimbra
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
                 backup:
                   workDir: %s
                   logFile: %s

--- a/app/src/test/java/io/zmbackup/app/cli/MainTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MainTest.java
@@ -172,6 +172,9 @@ class MainTest {
                 zimbraMailbox:
                   backupUser: zimbra
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
                 backup:
                   workDir: %s
                   logFile: %s

--- a/app/src/test/java/io/zmbackup/app/cli/ShadowJarSmokeTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/ShadowJarSmokeTest.java
@@ -77,6 +77,9 @@ class ShadowJarSmokeTest {
                 zimbraMailbox:
                   backupUser: zimbra
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
                 backup:
                   workDir: %s
                   logFile: %s

--- a/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
@@ -26,6 +26,9 @@ class YamlConfigLoaderTest {
             zimbraMailbox:
               backupUser: zimbra
               zmmailboxPath: /opt/zimbra/bin/zmmailbox
+              restBaseUrl: https://127.0.0.1:7071
+              adminUser: zimbra
+              adminPassword: secret
               backupInactiveAccounts: false
             backup:
               workDir: /opt/zimbra/backup
@@ -49,6 +52,9 @@ class YamlConfigLoaderTest {
             zimbraMailbox:
               backupUser: zimbra
               zmmailboxPath: /opt/zimbra/bin/zmmailbox
+              restBaseUrl: https://127.0.0.1:7071
+              adminUser: zimbra
+              adminPassword: secret
             backup:
               workDir: /opt/zimbra/backup
               logFile: /opt/zimbra/log/zmbackup.log
@@ -70,6 +76,9 @@ class YamlConfigLoaderTest {
         assertEquals("zimbra", config.zimbraMailbox().backupUser());
         assertEquals(Path.of("/opt/zimbra/bin/zmmailbox"), config.zimbraMailbox().zmmailboxPath());
         assertEquals(false, config.zimbraMailbox().backupInactiveAccounts());
+        assertEquals("https://127.0.0.1:7071", config.zimbraMailbox().restBaseUrl());
+        assertEquals("zimbra", config.zimbraMailbox().adminUser());
+        assertEquals("secret", config.zimbraMailbox().adminPassword());
 
         assertEquals(Path.of("/opt/zimbra/backup"), config.backup().workDir());
         assertEquals(Path.of("/opt/zimbra/log/zmbackup.log"), config.backup().logFile());
@@ -130,6 +139,9 @@ class YamlConfigLoaderTest {
                 zimbraMailbox:
                   backupUser: zimbra
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
                 backup:
                   workDir: /opt/zimbra/backup
                   logFile: /opt/zimbra/log/zmbackup.log
@@ -152,6 +164,9 @@ class YamlConfigLoaderTest {
                 zimbraMailbox:
                   backupUser: zimbra
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
                 backup:
                   workDir: /opt/zimbra/backup
                   logFile: /opt/zimbra/log/zmbackup.log
@@ -178,6 +193,9 @@ class YamlConfigLoaderTest {
                 zimbraMailbox:
                   backupUser: zimbra
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
                 backup:
                   workDir: /opt/zimbra/backup
                   logFile: /opt/zimbra/log/zmbackup.log
@@ -203,6 +221,9 @@ class YamlConfigLoaderTest {
                 zimbraMailbox:
                   backupUser: zimbra
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
                 backup:
                   workDir: /opt/zimbra/backup
                   logFile: /opt/zimbra/log/zmbackup.log

--- a/project/config/zmbackup.yaml
+++ b/project/config/zmbackup.yaml
@@ -19,6 +19,12 @@ zimbraMailbox:
   zmmailboxPath: /opt/zimbra/bin/zmmailbox
   # Whether to include disabled accounts. Optional, defaults to true.
   backupInactiveAccounts: true
+  # Zimbra server's REST base URL, used to export mailbox content.
+  restBaseUrl: https://127.0.0.1:7071
+  # Zimbra admin account used for REST HTTP Basic authentication.
+  adminUser: zimbra
+  # The admin account's password.
+  adminPassword: changeme
 
 backup:
   # Directory backups and session metadata are stored under.


### PR DESCRIPTION
## Summary
- Add `restBaseUrl`, `adminUser`, and `adminPassword` to `zimbraMailbox` config (`ZimbraMailboxConfig`, `YamlConfigLoader`, `zmbackup.yaml`), mirroring the settings `ZimbraRestMailboxExporter` needs.
- Construct a `ZimbraRestMailboxExporter` in `AppContext` from those settings and expose it via a new `mailboxExporter()` getter, alongside the existing LDAP wiring.

This is scoped to wiring the exporter into `AppContext` only (per #296); actually using it from `BackupService` for `MAILBOX`/`FULL` backup types is separate follow-up work (#297, #298).

## Test plan
- [x] `./gradlew :app:compileJava :app:compileTestJava`
- [x] `./gradlew :app:test --tests "io.zmbackup.app.AppContextTest" --tests "io.zmbackup.app.config.YamlConfigLoaderTest" --tests "io.zmbackup.app.cli.*"`

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbqJxz96CxMCtCxEu5bPe9)_