### PR TITLE
Extend BackupService for MAILBOX type

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -52,7 +52,8 @@ public final class AppContext {
                 config.zimbraMailbox().adminUser(),
                 config.zimbraMailbox().adminPassword());
         this.sessionService = new SessionService(storageProvider, metadataStore);
-        this.backupService = new BackupService(accountDiscovery, ldapExporter, storageProvider, metadataStore);
+        this.backupService =
+                new BackupService(accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore);
         this.housekeepService = new HousekeepService(storageProvider, metadataStore);
     }
 

--- a/app/src/test/java/io/zmbackup/app/cucumber/BackupIntegrationSteps.java
+++ b/app/src/test/java/io/zmbackup/app/cucumber/BackupIntegrationSteps.java
@@ -18,6 +18,7 @@ import io.zmbackup.core.domain.BackupAccountRecord;
 import io.zmbackup.core.domain.BackupSession;
 import io.zmbackup.core.domain.BackupType;
 import io.zmbackup.core.domain.SessionStatus;
+import io.zmbackup.core.port.ZimbraMailboxExporter;
 import io.zmbackup.core.service.BackupService;
 import io.zmbackup.core.service.HousekeepService;
 import io.zmbackup.core.service.SessionService;
@@ -25,6 +26,8 @@ import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
 import io.zmbackup.zimbra.UnboundIdLdapAdapter;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -87,7 +90,8 @@ public class BackupIntegrationSteps {
 
         storageProvider = new LocalStorageProvider(tempDir);
 
-        backupService = new BackupService(ldapAdapter, ldapAdapter, storageProvider, metadataStore);
+        backupService =
+                new BackupService(ldapAdapter, ldapAdapter, new NoOpMailboxExporter(), storageProvider, metadataStore);
         housekeepService = new HousekeepService(storageProvider, metadataStore);
         sessionService = new SessionService(storageProvider, metadataStore);
     }
@@ -253,5 +257,18 @@ public class BackupIntegrationSteps {
                 return FileVisitResult.CONTINUE;
             }
         });
+    }
+
+    /** Unused by the current LDAP-only scenarios; satisfies {@link BackupService}'s constructor. */
+    private static final class NoOpMailboxExporter implements ZimbraMailboxExporter {
+        @Override
+        public boolean export(String account, OutputStream destination, Instant since) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void restore(String account, InputStream source) {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/core/src/main/java/io/zmbackup/core/service/BackupService.java
+++ b/core/src/main/java/io/zmbackup/core/service/BackupService.java
@@ -9,6 +9,7 @@ import io.zmbackup.core.port.AccountDiscovery;
 import io.zmbackup.core.port.MetadataStore;
 import io.zmbackup.core.port.StorageProvider;
 import io.zmbackup.core.port.ZimbraLdapExporter;
+import io.zmbackup.core.port.ZimbraMailboxExporter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.Instant;
@@ -20,29 +21,33 @@ import java.util.Optional;
 
 /**
  * Runs backup sessions for the LDAP-only {@link BackupType}s ({@code LDAP}, {@code ALIAS}, {@code
- * DISTRIBUTION_LIST}, {@code SIGNATURE}, {@code DOMAIN}), mirroring {@code backup_main} and its
- * {@code __backupLdap}/{@code __backupDomain} helpers in the bash tool's {@code BackupAction.sh}.
- * Mailbox-inclusive types ({@code FULL}, {@code INCREMENTAL}, {@code MAILBOX}) are handled by a
- * separate service.
+ * DISTRIBUTION_LIST}, {@code SIGNATURE}, {@code DOMAIN}) as well as {@code MAILBOX}, mirroring
+ * {@code backup_main} and its {@code __backupLdap}/{@code __backupDomain}/{@code __backupMailbox}
+ * helpers in the bash tool's {@code BackupAction.sh}. The combined LDAP+mailbox types ({@code
+ * FULL}, {@code INCREMENTAL}) are handled by a separate service.
  */
 public class BackupService {
 
     private static final DateTimeFormatter SESSION_TIMESTAMP =
             DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneId.systemDefault());
     private static final String LDIFF_SUFFIX = "ldiff";
+    private static final String TGZ_SUFFIX = "tgz";
 
     private final AccountDiscovery accountDiscovery;
     private final ZimbraLdapExporter ldapExporter;
+    private final ZimbraMailboxExporter mailboxExporter;
     private final StorageProvider storageProvider;
     private final MetadataStore metadataStore;
 
     public BackupService(
             AccountDiscovery accountDiscovery,
             ZimbraLdapExporter ldapExporter,
+            ZimbraMailboxExporter mailboxExporter,
             StorageProvider storageProvider,
             MetadataStore metadataStore) {
         this.accountDiscovery = Objects.requireNonNull(accountDiscovery, "accountDiscovery must not be null");
         this.ldapExporter = Objects.requireNonNull(ldapExporter, "ldapExporter must not be null");
+        this.mailboxExporter = Objects.requireNonNull(mailboxExporter, "mailboxExporter must not be null");
         this.storageProvider = Objects.requireNonNull(storageProvider, "storageProvider must not be null");
         this.metadataStore = Objects.requireNonNull(metadataStore, "metadataStore must not be null");
     }
@@ -62,8 +67,9 @@ public class BackupService {
      * objects to back up, records an {@code IN PROGRESS} session, exports and stores each object,
      * then updates the session to its final status.
      *
-     * @param type        an LDAP-only backup type: {@code LDAP}, {@code ALIAS}, {@code
-     *                    DISTRIBUTION_LIST}, {@code SIGNATURE}, or {@code DOMAIN}
+     * @param type        an LDAP-only backup type ({@code LDAP}, {@code ALIAS}, {@code
+     *                    DISTRIBUTION_LIST}, {@code SIGNATURE}, or {@code DOMAIN}), or {@code
+     *                    MAILBOX}
      * @param identifiers explicit accounts (or domains, for {@code DOMAIN}) to back up, bypassing
      *                    discovery; empty to discover automatically
      * @param domain      when {@code identifiers} is empty and {@code type != DOMAIN}, restricts
@@ -73,8 +79,9 @@ public class BackupService {
      */
     public Optional<BackupSession> backup(BackupType type, List<String> identifiers, String domain)
             throws IOException {
-        if (!type.includesLdap() || type.includesMailbox()) {
-            throw new IllegalArgumentException("BackupService only supports LDAP-only backup types, got " + type);
+        if (type.includesLdap() && type.includesMailbox()) {
+            throw new IllegalArgumentException(
+                    "BackupService does not support combined LDAP+mailbox backup types, got " + type);
         }
 
         List<String> resolved = resolveIdentifiers(type, identifiers, domain);
@@ -105,11 +112,17 @@ public class BackupService {
     private boolean backupOne(String sessionId, BackupType type, String identifier) throws IOException {
         Instant startedAt = Instant.now();
         try {
-            try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, LDIFF_SUFFIX)) {
-                if (type == BackupType.DOMAIN) {
-                    ldapExporter.exportDomain(identifier, destination);
-                } else {
-                    ldapExporter.export(identifier, objectTypeFor(type), destination);
+            if (type == BackupType.MAILBOX) {
+                try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, TGZ_SUFFIX)) {
+                    mailboxExporter.export(identifier, destination);
+                }
+            } else {
+                try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, LDIFF_SUFFIX)) {
+                    if (type == BackupType.DOMAIN) {
+                        ldapExporter.exportDomain(identifier, destination);
+                    } else {
+                        ldapExporter.export(identifier, objectTypeFor(type), destination);
+                    }
                 }
             }
         } catch (IOException e) {
@@ -138,7 +151,7 @@ public class BackupService {
 
     private static LdapObjectType objectTypeFor(BackupType type) {
         return switch (type) {
-            case LDAP -> LdapObjectType.ACCOUNT;
+            case LDAP, MAILBOX -> LdapObjectType.ACCOUNT;
             case ALIAS -> LdapObjectType.ALIAS;
             case DISTRIBUTION_LIST -> LdapObjectType.DISTRIBUTION_LIST;
             case SIGNATURE -> LdapObjectType.SIGNATURE;

--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -14,6 +14,7 @@ import io.zmbackup.core.port.AccountDiscovery;
 import io.zmbackup.core.port.MetadataStore;
 import io.zmbackup.core.port.StorageProvider;
 import io.zmbackup.core.port.ZimbraLdapExporter;
+import io.zmbackup.core.port.ZimbraMailboxExporter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,10 +35,11 @@ class BackupServiceTest {
 
     private final FakeAccountDiscovery accountDiscovery = new FakeAccountDiscovery();
     private final FakeZimbraLdapExporter ldapExporter = new FakeZimbraLdapExporter();
+    private final FakeZimbraMailboxExporter mailboxExporter = new FakeZimbraMailboxExporter();
     private final InMemoryStorageProvider storageProvider = new InMemoryStorageProvider();
     private final InMemoryMetadataStore metadataStore = new InMemoryMetadataStore();
-    private final BackupService backupService =
-            new BackupService(accountDiscovery, ldapExporter, storageProvider, metadataStore);
+    private final BackupService backupService = new BackupService(
+            accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore);
 
     @Test
     void backsUpDiscoveredAccountsForLdapType() throws IOException {
@@ -122,10 +124,49 @@ class BackupServiceTest {
     }
 
     @Test
-    void rejectsMailboxInclusiveBackupTypes() {
+    void rejectsCombinedLdapAndMailboxBackupTypes() {
         assertThrows(IllegalArgumentException.class, () -> backupService.backup(BackupType.FULL));
         assertThrows(IllegalArgumentException.class, () -> backupService.backup(BackupType.INCREMENTAL));
-        assertThrows(IllegalArgumentException.class, () -> backupService.backup(BackupType.MAILBOX));
+    }
+
+    @Test
+    void backsUpDiscoveredAccountsForMailboxType() throws IOException {
+        accountDiscovery.wholeDirectory.put(LdapObjectType.ACCOUNT, List.of("alice@example.com", "bob@example.com"));
+
+        Optional<BackupSession> result = backupService.backup(BackupType.MAILBOX);
+
+        assertTrue(result.isPresent());
+        BackupSession session = result.get();
+        assertTrue(session.sessionId().startsWith("mbox-"));
+        assertEquals(BackupType.MAILBOX, session.type());
+        assertEquals(SessionStatus.FINISHED, session.status());
+
+        List<BackupAccountRecord> records = metadataStore.findAccountsForSession(session.sessionId());
+        assertEquals(Set.of("alice@example.com", "bob@example.com"), namesOf(records));
+        assertEquals(Set.of("alice@example.com", "bob@example.com"), mailboxExporter.exported.keySet());
+        assertTrue(ldapExporter.exportedTypes.isEmpty());
+    }
+
+    @Test
+    void mailboxTypeSucceedsWithoutWritingWhenNoNewContent() throws IOException {
+        mailboxExporter.noNewContent.add("alice@example.com");
+
+        Optional<BackupSession> result = backupService.backup(BackupType.MAILBOX, List.of("alice@example.com"));
+
+        assertTrue(result.isPresent());
+        assertEquals(SessionStatus.FINISHED, result.get().status());
+        assertEquals(1, metadataStore.findAccountsForSession(result.get().sessionId()).size());
+    }
+
+    @Test
+    void marksSessionFailedWhenMailboxExportFails() throws IOException {
+        mailboxExporter.failing.add("bad@example.com");
+
+        Optional<BackupSession> result = backupService.backup(BackupType.MAILBOX, List.of("bad@example.com"));
+
+        assertTrue(result.isPresent());
+        assertEquals(SessionStatus.FAILED, result.get().status());
+        assertTrue(metadataStore.findAccountsForSession(result.get().sessionId()).isEmpty());
     }
 
     private static Set<String> namesOf(List<BackupAccountRecord> records) {
@@ -189,6 +230,31 @@ class BackupServiceTest {
                 types.addAll(exportedTypes.getOrDefault(identifier, List.of()));
             }
             return types;
+        }
+    }
+
+    /** In-memory {@link ZimbraMailboxExporter} fake that records what was exported. */
+    private static final class FakeZimbraMailboxExporter implements ZimbraMailboxExporter {
+        final Map<String, Instant> exported = new LinkedHashMap<>();
+        final Set<String> noNewContent = new HashSet<>();
+        final Set<String> failing = new HashSet<>();
+
+        @Override
+        public boolean export(String account, OutputStream destination, Instant since) throws IOException {
+            if (failing.contains(account)) {
+                throw new IOException("simulated export failure for " + account);
+            }
+            if (noNewContent.contains(account)) {
+                return false;
+            }
+            exported.put(account, since);
+            destination.write(("tgz:" + account).getBytes());
+            return true;
+        }
+
+        @Override
+        public void restore(String account, InputStream source) {
+            throw new UnsupportedOperationException();
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `ZimbraMailboxExporter` as a `BackupService` dependency and wires it into `AppContext`
- `BackupService.backup(MAILBOX, ...)` now discovers accounts (same `ACOBJECT` filter as LDAP) and exports each mailbox to a `.tgz` via the mailbox exporter, mirroring `__backupMailbox`/`mailbox_backup` in the bash tool's `BackupAction.sh`/`ParallelAction.sh`
- The combined `FULL`/`INCREMENTAL` types are still rejected — they're handled by #298

Closes #297

## Test plan
- [x] `./gradlew build` (unit tests + cucumber integration suite) passes
- [x] New unit tests: discovers accounts and exports mailboxes, treats "no new content" as success without failing the session, marks the session `FAILED` when a mailbox export throws