### PR TITLE
Add zmbackup backup full Picocli command

### DIFF
--- a/app/src/main/java/io/zmbackup/app/cli/BackupCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupCommand.java
@@ -8,12 +8,13 @@ import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Spec;
 
 /**
- * Groups the LDAP-only backup subcommands: {@code ldap}, {@code alias}, {@code distlist}, {@code
- * signature}, {@code domain}.
+ * Groups the backup subcommands: {@code full}, {@code ldap}, {@code alias}, {@code distlist},
+ * {@code signature}, {@code domain}.
  */
 @Command(
         name = "backup",
         subcommands = {
+            BackupFullCommand.class,
             BackupLdapCommand.class,
             BackupAliasCommand.class,
             BackupDistlistCommand.class,

--- a/app/src/main/java/io/zmbackup/app/cli/BackupFullCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupFullCommand.java
@@ -1,0 +1,38 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.BackupType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/**
+ * Backs up Zimbra accounts from LDAP and their mailbox content, mirroring {@code zmbackup -f -a}
+ * in the bash tool.
+ */
+@Command(name = "full", description = "Back up Zimbra accounts from LDAP and their mailbox content.")
+public final class BackupFullCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private BackupCommand parent;
+
+    @Option(names = "--account", description = "Back up only this account (repeatable); default: every account.")
+    private List<String> accounts = new ArrayList<>();
+
+    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
+    private String domain;
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
+        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.FULL, accounts, domain);
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
@@ -3,12 +3,15 @@ package io.zmbackup.app.cli;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
 import com.unboundid.ldap.sdk.Attribute;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
@@ -25,11 +28,16 @@ class BackupCommandTest {
     Path tempDir;
 
     private InMemoryDirectoryServer directoryServer;
+    private HttpServer mailboxServer;
+    private String mailboxRestBaseUrl = "https://127.0.0.1:7071";
 
     @AfterEach
     void tearDown() {
         if (directoryServer != null) {
             directoryServer.shutDown(true);
+        }
+        if (mailboxServer != null) {
+            mailboxServer.stop(0);
         }
     }
 
@@ -89,6 +97,49 @@ class BackupCommandTest {
 
         assertEquals(0, exitCode);
         assertTrue(Files.exists(tempDir.resolve("ldap-" + sessionSuffixOf(out) + "/alice@example.com.ldiff")));
+    }
+
+    @Test
+    void fullBacksUpEveryDiscoveredAccountIncludingMailbox() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        startMailboxServer("/home/alice@example.com/", 200, "tgz-content".getBytes());
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "backup", "full");
+
+        assertEquals(0, exitCode);
+        String output = out.toString();
+        assertTrue(output.contains("full-"));
+        assertTrue(output.contains("FINISHED"));
+    }
+
+    @Test
+    void fullWithAccountOptionBacksUpOnlyThatAccountsMailbox() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        startMailboxServer("/home/alice@example.com/", 200, "tgz-content".getBytes());
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode =
+                cmd.execute("--config", configFile.toString(), "backup", "full", "--account", "alice@example.com");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("FINISHED"));
     }
 
     @Test
@@ -195,6 +246,19 @@ class BackupCommandTest {
         return server;
     }
 
+    private void startMailboxServer(String path, int statusCode, byte[] responseBody) throws IOException {
+        mailboxServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        mailboxServer.createContext(path, (HttpExchange exchange) -> {
+            exchange.sendResponseHeaders(statusCode, responseBody.length == 0 ? -1 : responseBody.length);
+            if (responseBody.length > 0) {
+                exchange.getResponseBody().write(responseBody);
+            }
+            exchange.close();
+        });
+        mailboxServer.start();
+        mailboxRestBaseUrl = "http://127.0.0.1:" + mailboxServer.getAddress().getPort();
+    }
+
     private Path writeConfig() throws IOException {
         Path configFile = tempDir.resolve("zmbackup.yaml");
         Files.writeString(
@@ -208,7 +272,7 @@ class BackupCommandTest {
                 zimbraMailbox:
                   backupUser: zimbra
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
-                  restBaseUrl: https://127.0.0.1:7071
+                  restBaseUrl: %s
                   adminUser: zimbra
                   adminPassword: secret
                 backup:
@@ -221,6 +285,7 @@ class BackupCommandTest {
                 """
                         .formatted(
                                 directoryServer.getListenPort(),
+                                mailboxRestBaseUrl,
                                 tempDir,
                                 tempDir.resolve("zmbackup.log"),
                                 tempDir.resolve("blockedlist.conf")));


### PR DESCRIPTION
## Summary
- Adds the `zmbackup backup full` subcommand (`--account`, `--domain`), running `BackupType.FULL` through the existing `BackupRunner` — matches the pattern of `backup ldap`/`backup signature`/etc.
- Registers it under `BackupCommand`'s subcommands.

## Test plan
- [x] `./gradlew build` (full project build, all modules)
- [x] New `BackupCommandTest` cases: `backup full` backs up every discovered account (LDAP + mailbox via a stub HTTP server), and `backup full --account` scopes to one account.

Closes #299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)