### PR TITLE
Add zmbackup backup mailbox Picocli command

### DIFF
--- a/app/src/main/java/io/zmbackup/app/cli/BackupCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupCommand.java
@@ -8,13 +8,14 @@ import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Spec;
 
 /**
- * Groups the backup subcommands: {@code full}, {@code ldap}, {@code alias}, {@code distlist},
- * {@code signature}, {@code domain}.
+ * Groups the backup subcommands: {@code full}, {@code mailbox}, {@code ldap}, {@code alias},
+ * {@code distlist}, {@code signature}, {@code domain}.
  */
 @Command(
         name = "backup",
         subcommands = {
             BackupFullCommand.class,
+            BackupMailboxCommand.class,
             BackupLdapCommand.class,
             BackupAliasCommand.class,
             BackupDistlistCommand.class,

--- a/app/src/main/java/io/zmbackup/app/cli/BackupMailboxCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupMailboxCommand.java
@@ -1,0 +1,38 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.BackupType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/**
+ * Backs up Zimbra accounts' mailbox content only, mirroring {@code zmbackup -f -m -a} in the bash
+ * tool.
+ */
+@Command(name = "mailbox", description = "Back up Zimbra accounts' mailbox content only.")
+public final class BackupMailboxCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private BackupCommand parent;
+
+    @Option(names = "--account", description = "Back up only this account (repeatable); default: every account.")
+    private List<String> accounts = new ArrayList<>();
+
+    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
+    private String domain;
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
+        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.MAILBOX, accounts, domain);
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
@@ -143,6 +143,49 @@ class BackupCommandTest {
     }
 
     @Test
+    void mailboxBacksUpEveryDiscoveredAccountsMailbox() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        startMailboxServer("/home/alice@example.com/", 200, "tgz-content".getBytes());
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "backup", "mailbox");
+
+        assertEquals(0, exitCode);
+        String output = out.toString();
+        assertTrue(output.contains("mbox-"));
+        assertTrue(output.contains("FINISHED"));
+    }
+
+    @Test
+    void mailboxWithAccountOptionBacksUpOnlyThatAccountsMailbox() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        startMailboxServer("/home/alice@example.com/", 200, "tgz-content".getBytes());
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute(
+                "--config", configFile.toString(), "backup", "mailbox", "--account", "alice@example.com");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("FINISHED"));
+    }
+
+    @Test
     void aliasBacksUpExplicitAlias() throws Exception {
         directoryServer = startDirectoryServer();
         directoryServer.add(


### PR DESCRIPTION
## Summary
- Adds the `zmbackup backup mailbox` subcommand, mirroring `zmbackup -f -m -a` in the bash tool
- Registers it alongside `full`/`ldap`/`alias`/`distlist`/`signature`/`domain` under `backup`
- Reuses the existing `BackupType.MAILBOX` and `BackupRunner` plumbing added in prior deliveries

Closes #300 (sub-task of #258).

## Test plan
- [x] `./gradlew test` passes, including new `mailboxBacksUpEveryDiscoveredAccountsMailbox` and `mailboxWithAccountOptionBacksUpOnlyThatAccountsMailbox` tests in `BackupCommandTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)