### PR TITLE
Add full-backup integration test with WireMock mailbox endpoint

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation("org.yaml:snakeyaml:2.6")
     implementation("info.picocli:picocli:4.7.6")
     testImplementation("com.unboundid:unboundid-ldapsdk:7.0.5")
+    testImplementation("org.wiremock:wiremock:3.13.1")
     testImplementation("io.cucumber:cucumber-java:7.34.7")
     testImplementation("io.cucumber:cucumber-junit-platform-engine:7.34.7")
     testImplementation("org.junit.platform:junit-platform-suite:1.11.4")

--- a/app/src/test/java/io/zmbackup/app/cucumber/BackupIntegrationSteps.java
+++ b/app/src/test/java/io/zmbackup/app/cucumber/BackupIntegrationSteps.java
@@ -1,9 +1,14 @@
 package io.zmbackup.app.cucumber;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
 import com.unboundid.ldap.sdk.Attribute;
@@ -18,16 +23,14 @@ import io.zmbackup.core.domain.BackupAccountRecord;
 import io.zmbackup.core.domain.BackupSession;
 import io.zmbackup.core.domain.BackupType;
 import io.zmbackup.core.domain.SessionStatus;
-import io.zmbackup.core.port.ZimbraMailboxExporter;
 import io.zmbackup.core.service.BackupService;
 import io.zmbackup.core.service.HousekeepService;
 import io.zmbackup.core.service.SessionService;
 import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
 import io.zmbackup.zimbra.UnboundIdLdapAdapter;
+import io.zmbackup.zimbra.ZimbraRestMailboxExporter;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -51,9 +54,12 @@ public class BackupIntegrationSteps {
 
     private static final String BIND_DN = "uid=zimbra,cn=admins,cn=zimbra";
     private static final String BIND_PASSWORD = "secret";
+    private static final String MAILBOX_ADMIN_USER = "zimbra";
+    private static final String MAILBOX_ADMIN_PASSWORD = "secret";
 
     private Path tempDir;
     private InMemoryDirectoryServer directoryServer;
+    private WireMockServer mailboxServer;
     private Connection sqliteAnchor;
     private SqliteMetadataStore metadataStore;
     private LocalStorageProvider storageProvider;
@@ -83,6 +89,11 @@ public class BackupIntegrationSteps {
         UnboundIdLdapAdapter ldapAdapter = new UnboundIdLdapAdapter(
                 "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
 
+        mailboxServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        mailboxServer.start();
+        ZimbraRestMailboxExporter mailboxExporter =
+                new ZimbraRestMailboxExporter(mailboxServer.baseUrl(), MAILBOX_ADMIN_USER, MAILBOX_ADMIN_PASSWORD);
+
         String cacheName = "cucumber-" + UUID.randomUUID();
         String sqliteUrl = "jdbc:sqlite:file:" + cacheName + "?mode=memory&cache=shared";
         sqliteAnchor = DriverManager.getConnection(sqliteUrl);
@@ -90,8 +101,7 @@ public class BackupIntegrationSteps {
 
         storageProvider = new LocalStorageProvider(tempDir);
 
-        backupService =
-                new BackupService(ldapAdapter, ldapAdapter, new NoOpMailboxExporter(), storageProvider, metadataStore);
+        backupService = new BackupService(ldapAdapter, ldapAdapter, mailboxExporter, storageProvider, metadataStore);
         housekeepService = new HousekeepService(storageProvider, metadataStore);
         sessionService = new SessionService(storageProvider, metadataStore);
     }
@@ -100,6 +110,9 @@ public class BackupIntegrationSteps {
     public void tearDown() throws IOException, SQLException {
         if (directoryServer != null) {
             directoryServer.shutDown(true);
+        }
+        if (mailboxServer != null) {
+            mailboxServer.stop();
         }
         if (sqliteAnchor != null) {
             sqliteAnchor.close();
@@ -159,6 +172,23 @@ public class BackupIntegrationSteps {
         lastSession = secondNamedSession;
     }
 
+    @Given("the mailbox export endpoint for {string} returns tgz content {string}")
+    public void theMailboxExportEndpointForReturnsTgzContent(String account, String tgzContent) {
+        mailboxServer.stubFor(get(urlPathEqualTo("/home/" + account + "/"))
+                .willReturn(aResponse().withStatus(200).withBody(tgzContent)));
+    }
+
+    @Given("the mailbox export endpoint for {string} returns HTTP {int}")
+    public void theMailboxExportEndpointForReturnsHttp(String account, int status) {
+        mailboxServer.stubFor(
+                get(urlPathEqualTo("/home/" + account + "/")).willReturn(aResponse().withStatus(status)));
+    }
+
+    @When("I run a full backup")
+    public void iRunAFullBackup() throws IOException {
+        lastSession = backupService.backup(BackupType.FULL).orElseThrow();
+    }
+
     @When("I run a domain backup")
     public void iRunADomainBackup() throws IOException {
         lastSession = backupService.backup(BackupType.DOMAIN).orElseThrow();
@@ -205,6 +235,13 @@ public class BackupIntegrationSteps {
         Path ldif = tempDir.resolve(lastSession.sessionId()).resolve(identifier + ".ldiff");
         assertTrue(Files.exists(ldif), "expected " + ldif + " to exist");
         assertTrue(Files.readString(ldif).contains(expectedContent));
+    }
+
+    @Then("the mailbox archive for {string} contains {string}")
+    public void theMailboxArchiveForContains(String identifier, String expectedContent) throws IOException {
+        Path tgz = tempDir.resolve(lastSession.sessionId()).resolve(identifier + ".tgz");
+        assertTrue(Files.exists(tgz), "expected " + tgz + " to exist");
+        assertEquals(expectedContent, Files.readString(tgz));
     }
 
     @Then("the metadata store has {int} account records for the session")
@@ -257,18 +294,5 @@ public class BackupIntegrationSteps {
                 return FileVisitResult.CONTINUE;
             }
         });
-    }
-
-    /** Unused by the current LDAP-only scenarios; satisfies {@link BackupService}'s constructor. */
-    private static final class NoOpMailboxExporter implements ZimbraMailboxExporter {
-        @Override
-        public boolean export(String account, OutputStream destination, Instant since) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void restore(String account, InputStream source) {
-            throw new UnsupportedOperationException();
-        }
     }
 }

--- a/app/src/test/resources/features/backup_integration.feature
+++ b/app/src/test/resources/features/backup_integration.feature
@@ -2,8 +2,9 @@ Feature: Backup lifecycle across real adapters
 
   BackupService, HousekeepService, and SessionService wired against real port
   implementations: UnboundIdLdapAdapter backed by an in-memory LDAP directory,
-  LocalStorageProvider backed by a temp directory, and SqliteMetadataStore
-  backed by an in-memory SQLite database.
+  ZimbraRestMailboxExporter backed by a WireMock server standing in for
+  Zimbra's REST mailbox endpoint, LocalStorageProvider backed by a temp
+  directory, and SqliteMetadataStore backed by an in-memory SQLite database.
 
   Scenario: Back up discovered LDAP accounts writes real LDIF and SQLite metadata
     Given an in-memory LDAP directory with accounts:
@@ -47,3 +48,22 @@ Feature: Backup lifecycle across real adapters
     When I rotate sessions older than 7 days
     Then the old session's LDIF file no longer exists
     And the metadata store has no record of the old session
+
+  Scenario: A full backup writes real LDIF and the WireMock mailbox archive
+    Given an in-memory LDAP directory with accounts:
+      | alice@example.com |
+    And the mailbox export endpoint for "alice@example.com" returns tgz content "mailbox-bytes"
+    When I run a full backup
+    Then the backup session status is FINISHED
+    And the LDIF file for "alice@example.com" contains "dn: uid=alice,dc=example,dc=com"
+    And the mailbox archive for "alice@example.com" contains "mailbox-bytes"
+    And the metadata store has 1 account records for the session
+
+  Scenario: A full backup marks the session FAILED when the mailbox endpoint errors
+    Given an in-memory LDAP directory with accounts:
+      | alice@example.com |
+    And the mailbox export endpoint for "alice@example.com" returns HTTP 500
+    When I run a full backup
+    Then the backup session status is FAILED
+    And the LDIF file for "alice@example.com" contains "dn: uid=alice,dc=example,dc=com"
+    And the metadata store has 0 account records for the session


### PR DESCRIPTION
## Summary
- Closes #302 (sub-task of #258): extends the `backup_integration.feature` cucumber suite so `BackupService` is wired against a real `ZimbraRestMailboxExporter` backed by a `WireMockServer`, instead of the placeholder `NoOpMailboxExporter`.
- Adds two `FULL` backup scenarios: one where the WireMock mailbox endpoint returns a 200 with tgz content (session FINISHED, LDIF + tgz files written, one account record), and one where it returns HTTP 500 (session FAILED, LDIF still written from the LDAP step, no account record).

## Test plan
- [x] `./gradlew :app:test --tests "io.zmbackup.app.cucumber.RunCucumberTest"` — all 7 scenarios pass
- [x] `./gradlew test` — full multi-module suite passes