### PR TITLE
Implement lastSuccessfulBackupTime in SqliteMetadataStore

### DIFF
--- a/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
+++ b/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
@@ -193,7 +193,25 @@ public class SqliteMetadataStore implements MetadataStore {
 
     @Override
     public Optional<Instant> lastSuccessfulBackupTime(String email) throws IOException {
-        throw new UnsupportedOperationException("lastSuccessfulBackupTime is implemented in a later delivery (#259)");
+        String sql =
+                """
+                select max(ba.conclusion_date) as last_backup
+                from backup_account ba
+                join backup_session bs on ba.sessionID = bs.sessionID
+                where ba.email = ?
+                  and bs.status = ?
+                  and (ba.sessionID like 'full%' or ba.sessionID like 'inc%' or ba.sessionID like 'mbox%')
+                """;
+        try (Connection connection = connect();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, email);
+            statement.setString(2, SessionStatus.FINISHED.dbValue());
+            try (ResultSet rs = statement.executeQuery()) {
+                return rs.next() ? Optional.ofNullable(fromDb(rs.getString("last_backup"))) : Optional.empty();
+            }
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
     }
 
     private Connection connect() throws SQLException {

--- a/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
+++ b/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
@@ -2,7 +2,6 @@ package io.zmbackup.local;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.zmbackup.core.domain.BackupAccountRecord;
 import io.zmbackup.core.domain.BackupSession;
@@ -140,8 +139,48 @@ class SqliteMetadataStoreTest {
     }
 
     @Test
-    void lastSuccessfulBackupTimeIsNotYetImplemented() {
-        assertThrows(UnsupportedOperationException.class, () -> store.lastSuccessfulBackupTime("user@example.com"));
+    void lastSuccessfulBackupTimeIsEmptyWhenAccountNeverBackedUp() throws IOException {
+        assertEquals(Optional.empty(), store.lastSuccessfulBackupTime("user@example.com"));
+    }
+
+    @Test
+    void lastSuccessfulBackupTimeReturnsMostRecentFinishedMailboxSession() throws IOException {
+        Instant now = Instant.now();
+        Instant older = now.minus(2, ChronoUnit.DAYS);
+        Instant newer = now.minus(1, ChronoUnit.DAYS);
+        store.save(session("full-1", BackupType.FULL, SessionStatus.FINISHED, older));
+        store.save(session("inc-1", BackupType.INCREMENTAL, SessionStatus.FINISHED, newer));
+        store.recordAccountBackup(accountRecord("full-1", "user@example.com", older));
+        store.recordAccountBackup(accountRecord("inc-1", "user@example.com", newer));
+
+        assertEquals(Optional.of(newer), store.lastSuccessfulBackupTime("user@example.com"));
+    }
+
+    @Test
+    void lastSuccessfulBackupTimeIgnoresUnfinishedSessions() throws IOException {
+        Instant now = Instant.now();
+        store.save(session("full-1", BackupType.FULL, SessionStatus.IN_PROGRESS, null));
+        store.recordAccountBackup(accountRecord("full-1", "user@example.com", now));
+
+        assertEquals(Optional.empty(), store.lastSuccessfulBackupTime("user@example.com"));
+    }
+
+    @Test
+    void lastSuccessfulBackupTimeIgnoresNonMailboxSessionTypes() throws IOException {
+        Instant now = Instant.now();
+        store.save(session("ldap-1", BackupType.LDAP, SessionStatus.FINISHED, now));
+        store.recordAccountBackup(accountRecord("ldap-1", "user@example.com", now));
+
+        assertEquals(Optional.empty(), store.lastSuccessfulBackupTime("user@example.com"));
+    }
+
+    @Test
+    void lastSuccessfulBackupTimeIgnoresOtherAccounts() throws IOException {
+        Instant now = Instant.now();
+        store.save(session("full-1", BackupType.FULL, SessionStatus.FINISHED, now));
+        store.recordAccountBackup(accountRecord("full-1", "other@example.com", now));
+
+        assertEquals(Optional.empty(), store.lastSuccessfulBackupTime("user@example.com"));
     }
 
     private static BackupSession session(String sessionId, SessionStatus status, String size) {
@@ -150,8 +189,17 @@ class SqliteMetadataStoreTest {
         return new BackupSession(sessionId, BackupType.FULL, status, now, completedAt, size);
     }
 
+    private static BackupSession session(String sessionId, BackupType type, SessionStatus status, Instant completedAt) {
+        Instant now = Instant.now();
+        return new BackupSession(sessionId, type, status, now, completedAt, "1M");
+    }
+
     private static BackupAccountRecord accountRecord(String sessionId, String email) {
         Instant now = Instant.now();
         return new BackupAccountRecord(null, sessionId, email, "1M", now, now);
+    }
+
+    private static BackupAccountRecord accountRecord(String sessionId, String email, Instant completedAt) {
+        return new BackupAccountRecord(null, sessionId, email, "1M", completedAt, completedAt);
     }
 }


### PR DESCRIPTION
## Summary
- Implements `SqliteMetadataStore.lastSuccessfulBackupTime(email)`, replacing the `UnsupportedOperationException` stub.
- Query mirrors the spec in #259: `MAX(conclusion_date)` across `backup_account`/`backup_session` rows joined on `sessionID`, filtered to `status = 'FINISHED'` and session IDs prefixed `full`, `inc`, or `mbox`.

## Test plan
- [x] `./gradlew :local:test --tests "io.zmbackup.local.SqliteMetadataStoreTest"` — added tests: empty when never backed up, returns most recent finished mailbox session, ignores unfinished sessions, ignores non-mailbox session types (e.g. `ldap`), ignores other accounts.
- [x] `./gradlew build`

Closes #304 (sub-task of #259).

---
_Generated by [Claude Code](https://claude.ai/code/session_01F81qWAPeRtcCbQYzZprP8u)_