### PR TITLE
Add zmbackup backup incremental Picocli command

### DIFF
--- a/app/src/main/java/io/zmbackup/app/cli/BackupCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupCommand.java
@@ -8,13 +8,14 @@ import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Spec;
 
 /**
- * Groups the backup subcommands: {@code full}, {@code mailbox}, {@code ldap}, {@code alias},
- * {@code distlist}, {@code signature}, {@code domain}.
+ * Groups the backup subcommands: {@code full}, {@code incremental}, {@code mailbox}, {@code
+ * ldap}, {@code alias}, {@code distlist}, {@code signature}, {@code domain}.
  */
 @Command(
         name = "backup",
         subcommands = {
             BackupFullCommand.class,
+            BackupIncrementalCommand.class,
             BackupMailboxCommand.class,
             BackupLdapCommand.class,
             BackupAliasCommand.class,

--- a/app/src/main/java/io/zmbackup/app/cli/BackupIncrementalCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupIncrementalCommand.java
@@ -1,0 +1,38 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.BackupType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/**
+ * Backs up mail received since each account's last successful backup, mirroring {@code zmbackup
+ * -i -a} in the bash tool.
+ */
+@Command(name = "incremental", description = "Back up mail received since each account's last successful backup.")
+public final class BackupIncrementalCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private BackupCommand parent;
+
+    @Option(names = "--account", description = "Back up only this account (repeatable); default: every account.")
+    private List<String> accounts = new ArrayList<>();
+
+    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
+    private String domain;
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
+        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.INCREMENTAL, accounts, domain);
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
@@ -143,6 +143,49 @@ class BackupCommandTest {
     }
 
     @Test
+    void incrementalBacksUpEveryDiscoveredAccountIncludingMailbox() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        startMailboxServer("/home/alice@example.com/", 200, "tgz-content".getBytes());
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "backup", "incremental");
+
+        assertEquals(0, exitCode);
+        String output = out.toString();
+        assertTrue(output.contains("inc-"));
+        assertTrue(output.contains("FINISHED"));
+    }
+
+    @Test
+    void incrementalWithAccountOptionBacksUpOnlyThatAccountsMailbox() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        startMailboxServer("/home/alice@example.com/", 200, "tgz-content".getBytes());
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute(
+                "--config", configFile.toString(), "backup", "incremental", "--account", "alice@example.com");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("FINISHED"));
+    }
+
+    @Test
     void mailboxBacksUpEveryDiscoveredAccountsMailbox() throws Exception {
         directoryServer = startDirectoryServer();
         directoryServer.add(


### PR DESCRIPTION
## Summary
- Adds `BackupIncrementalCommand` (`zmbackup backup incremental [--account] [--domain]`), registered as a subcommand of `backup`, mirroring `BackupFullCommand`. Closes #307.
- Adds CLI-level integration tests for the incremental subcommand (whole-directory and `--account` cases), mirroring the existing `full` tests.
- Confirms #308 and #309 are already satisfied by `BackupServiceTest#incrementalTypePassesFortyEightHourCutoffToExporter` and `#incrementalTypeFallsBackToFullExportWhenNoPriorBackup` (added in 5198baf), so no further test changes were needed for those.

## Test plan
- [x] `./gradlew test` (full suite, all modules) passes