### PR TITLE
Restore, parallelism, blocklist, notifications (#311-#322)

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -1,10 +1,12 @@
 package io.zmbackup.app;
 
 import io.zmbackup.app.config.AppConfig;
+import io.zmbackup.app.config.EmailNotifyLevel;
 import io.zmbackup.app.config.YamlConfigLoader;
 import io.zmbackup.core.port.AccountDiscovery;
 import io.zmbackup.core.port.Blocklist;
 import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.Notifier;
 import io.zmbackup.core.port.StorageProvider;
 import io.zmbackup.core.port.ZimbraLdapExporter;
 import io.zmbackup.core.port.ZimbraMailboxExporter;
@@ -12,6 +14,7 @@ import io.zmbackup.core.service.BackupService;
 import io.zmbackup.core.service.HousekeepService;
 import io.zmbackup.core.service.RestoreService;
 import io.zmbackup.core.service.SessionService;
+import io.zmbackup.local.EmailNotifier;
 import io.zmbackup.local.FileBlocklist;
 import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
@@ -28,6 +31,14 @@ public final class AppContext {
 
     /** Filename of the SQLite database within {@link io.zmbackup.app.config.BackupConfig#workDir()}. */
     private static final String METADATA_STORE_FILENAME = "sessions.sqlite3";
+
+    /**
+     * Host/port of the local SMTP relay {@link EmailNotifier} submits through, matching the bash
+     * tool's use of the {@code sendmail} command to submit to the machine's own MTA.
+     */
+    private static final String NOTIFY_SMTP_HOST = "localhost";
+
+    private static final int NOTIFY_SMTP_PORT = 25;
 
     private final AppConfig config;
     private final StorageProvider storageProvider;
@@ -56,6 +67,7 @@ public final class AppContext {
                 config.zimbraMailbox().adminUser(),
                 config.zimbraMailbox().adminPassword());
         Blocklist blocklist = new FileBlocklist(config.backup().blockedListFile());
+        Notifier notifier = emailNotifier(config);
         this.sessionService = new SessionService(storageProvider, metadataStore);
         this.backupService = new BackupService(
                 accountDiscovery,
@@ -64,10 +76,30 @@ public final class AppContext {
                 storageProvider,
                 metadataStore,
                 blocklist,
+                notifier,
                 config.backup().maxParallelProcesses());
         this.restoreService = new RestoreService(
                 ldapExporter, mailboxExporter, storageProvider, metadataStore, config.backup().maxParallelProcesses());
         this.housekeepService = new HousekeepService(storageProvider, metadataStore);
+    }
+
+    /**
+     * Builds an {@link EmailNotifier} from {@code config}'s {@code backup.emailNotify} section,
+     * translating {@link EmailNotifyLevel} into which lifecycle events it notifies on.
+     */
+    private static EmailNotifier emailNotifier(AppConfig config) {
+        EmailNotifyLevel level = config.backup().emailNotify().level();
+        boolean notifyOnBegin = level == EmailNotifyLevel.ALL || level == EmailNotifyLevel.START;
+        boolean notifyOnFinishSuccess = level == EmailNotifyLevel.ALL || level == EmailNotifyLevel.FINISH;
+        boolean notifyOnFinishError = level == EmailNotifyLevel.ALL || level == EmailNotifyLevel.ERROR;
+        return new EmailNotifier(
+                NOTIFY_SMTP_HOST,
+                NOTIFY_SMTP_PORT,
+                config.backup().emailNotify().sender(),
+                config.backup().emailNotify().recipient(),
+                notifyOnBegin,
+                notifyOnFinishSuccess,
+                notifyOnFinishError);
     }
 
     /** Reads {@code configFile} and wires the components it describes. */

--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -9,6 +9,7 @@ import io.zmbackup.core.port.ZimbraLdapExporter;
 import io.zmbackup.core.port.ZimbraMailboxExporter;
 import io.zmbackup.core.service.BackupService;
 import io.zmbackup.core.service.HousekeepService;
+import io.zmbackup.core.service.RestoreService;
 import io.zmbackup.core.service.SessionService;
 import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
@@ -34,6 +35,7 @@ public final class AppContext {
     private final ZimbraMailboxExporter mailboxExporter;
     private final SessionService sessionService;
     private final BackupService backupService;
+    private final RestoreService restoreService;
     private final HousekeepService housekeepService;
 
     public AppContext(AppConfig config) throws IOException {
@@ -54,6 +56,7 @@ public final class AppContext {
         this.sessionService = new SessionService(storageProvider, metadataStore);
         this.backupService =
                 new BackupService(accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore);
+        this.restoreService = new RestoreService(ldapExporter, mailboxExporter, storageProvider, metadataStore);
         this.housekeepService = new HousekeepService(storageProvider, metadataStore);
     }
 
@@ -88,6 +91,10 @@ public final class AppContext {
 
     public BackupService backupService() {
         return backupService;
+    }
+
+    public RestoreService restoreService() {
+        return restoreService;
     }
 
     public HousekeepService housekeepService() {

--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -54,9 +54,15 @@ public final class AppContext {
                 config.zimbraMailbox().adminUser(),
                 config.zimbraMailbox().adminPassword());
         this.sessionService = new SessionService(storageProvider, metadataStore);
-        this.backupService =
-                new BackupService(accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore);
-        this.restoreService = new RestoreService(ldapExporter, mailboxExporter, storageProvider, metadataStore);
+        this.backupService = new BackupService(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                config.backup().maxParallelProcesses());
+        this.restoreService = new RestoreService(
+                ldapExporter, mailboxExporter, storageProvider, metadataStore, config.backup().maxParallelProcesses());
         this.housekeepService = new HousekeepService(storageProvider, metadataStore);
     }
 

--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -3,6 +3,7 @@ package io.zmbackup.app;
 import io.zmbackup.app.config.AppConfig;
 import io.zmbackup.app.config.YamlConfigLoader;
 import io.zmbackup.core.port.AccountDiscovery;
+import io.zmbackup.core.port.Blocklist;
 import io.zmbackup.core.port.MetadataStore;
 import io.zmbackup.core.port.StorageProvider;
 import io.zmbackup.core.port.ZimbraLdapExporter;
@@ -11,6 +12,7 @@ import io.zmbackup.core.service.BackupService;
 import io.zmbackup.core.service.HousekeepService;
 import io.zmbackup.core.service.RestoreService;
 import io.zmbackup.core.service.SessionService;
+import io.zmbackup.local.FileBlocklist;
 import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
 import io.zmbackup.zimbra.UnboundIdLdapAdapter;
@@ -53,6 +55,7 @@ public final class AppContext {
                 config.zimbraMailbox().restBaseUrl(),
                 config.zimbraMailbox().adminUser(),
                 config.zimbraMailbox().adminPassword());
+        Blocklist blocklist = new FileBlocklist(config.backup().blockedListFile());
         this.sessionService = new SessionService(storageProvider, metadataStore);
         this.backupService = new BackupService(
                 accountDiscovery,
@@ -60,6 +63,7 @@ public final class AppContext {
                 mailboxExporter,
                 storageProvider,
                 metadataStore,
+                blocklist,
                 config.backup().maxParallelProcesses());
         this.restoreService = new RestoreService(
                 ldapExporter, mailboxExporter, storageProvider, metadataStore, config.backup().maxParallelProcesses());

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
@@ -1,20 +1,70 @@
 package io.zmbackup.app.cli;
 
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.RestoreResult;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Spec;
 
-/** Stub for the restore subcommand; real restore logic lands once the zimbra module is implemented. */
-@Command(name = "restore", description = "Restore a backup session (not yet implemented).")
+/**
+ * Restores a backup session, mirroring {@code zmbackup -r full-*}/{@code -r mbox-*} usage in the
+ * bash tool. With no subcommand, restores both LDAP and mailbox content (or, with {@code --into},
+ * restores the mailbox alone into a different destination account); the {@code ldap}, {@code
+ * domain}, and {@code mailbox} subcommands restore one kind of content on its own.
+ */
+@Command(
+        name = "restore",
+        description = "Restore a backup session (LDAP + mailbox).",
+        subcommands = {RestoreLdapCommand.class, RestoreDomainCommand.class, RestoreMailboxCommand.class})
 public final class RestoreCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private Main parent;
+
+    // Not required=true: picocli would enforce that even when a subcommand (which declares its
+    // own --session) is invoked instead of this command's own call().
+    @Option(names = "--session", description = "ID of the session to restore.")
+    private String sessionId;
+
+    @Option(names = "--account", description = "Restore only this account (repeatable); default: every account in the session.")
+    private List<String> accounts = new ArrayList<>();
+
+    @Option(
+            names = "--into",
+            description = "Restore the mailbox into a different destination account (requires exactly one --account).")
+    private String destination;
 
     @Spec
     private CommandSpec spec;
 
+    Main parent() {
+        return parent;
+    }
+
     @Override
-    public Integer call() {
-        spec.commandLine().getErr().println("restore: not yet implemented");
-        return 1;
+    public Integer call() throws Exception {
+        PrintWriter err = spec.commandLine().getErr();
+        if (sessionId == null) {
+            err.println("restore: missing required option '--session=<sessionId>'");
+            return CommandLine.ExitCode.USAGE;
+        }
+        if (destination != null && accounts.size() != 1) {
+            err.println("restore: --into requires exactly one --account");
+            return CommandLine.ExitCode.USAGE;
+        }
+
+        AppContext context = AppContext.fromConfigFile(parent.configFile());
+        PrintWriter out = spec.commandLine().getOut();
+        RestoreResult result = destination != null
+                ? context.restoreService().restoreMailbox(sessionId, accounts, destination)
+                : context.restoreService().restoreFull(sessionId, accounts);
+        return RestoreRunner.printResult(out, sessionId, result);
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreDomainCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreDomainCommand.java
@@ -1,0 +1,36 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.RestoreResult;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/** Restores Zimbra domain LDAP entries from a backup session, mirroring {@code zmbackup -r domain-*} in the bash tool. */
+@Command(name = "domain", description = "Restore Zimbra domain LDAP entries from a backup session.")
+public final class RestoreDomainCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private RestoreCommand parent;
+
+    @Option(names = "--session", required = true, description = "ID of the session to restore.")
+    private String sessionId;
+
+    @Option(names = "--domain", description = "Restore only this domain (repeatable); default: every domain in the session.")
+    private List<String> domains = new ArrayList<>();
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
+        RestoreResult result = context.restoreService().restoreDomain(sessionId, domains);
+        return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreLdapCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreLdapCommand.java
@@ -1,0 +1,36 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.RestoreResult;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/** Restores LDAP entries from a backup session, mirroring {@code zmbackup -r ldap-*} in the bash tool. */
+@Command(name = "ldap", description = "Restore LDAP entries from a backup session.")
+public final class RestoreLdapCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private RestoreCommand parent;
+
+    @Option(names = "--session", required = true, description = "ID of the session to restore.")
+    private String sessionId;
+
+    @Option(names = "--account", description = "Restore only this account (repeatable); default: every account in the session.")
+    private List<String> accounts = new ArrayList<>();
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
+        RestoreResult result = context.restoreService().restoreLdap(sessionId, accounts);
+        return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreMailboxCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreMailboxCommand.java
@@ -1,0 +1,49 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.RestoreResult;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/** Restores mailbox content from a backup session, mirroring {@code zmbackup -r mbox-*} in the bash tool. */
+@Command(name = "mailbox", description = "Restore mailbox content from a backup session.")
+public final class RestoreMailboxCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private RestoreCommand parent;
+
+    @Option(names = "--session", required = true, description = "ID of the session to restore.")
+    private String sessionId;
+
+    @Option(names = "--account", description = "Restore only this account (repeatable); default: every account in the session.")
+    private List<String> accounts = new ArrayList<>();
+
+    @Option(
+            names = "--into",
+            description = "Restore into a different destination account (requires exactly one --account).")
+    private String destination;
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        PrintWriter err = spec.commandLine().getErr();
+        if (destination != null && accounts.size() != 1) {
+            err.println("restore mailbox: --into requires exactly one --account");
+            return CommandLine.ExitCode.USAGE;
+        }
+
+        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
+        RestoreResult result = context.restoreService().restoreMailbox(sessionId, accounts, destination);
+        return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreRunner.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreRunner.java
@@ -1,0 +1,27 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.core.domain.RestoreResult;
+import java.io.PrintWriter;
+
+/** Shared body for printing a {@link RestoreResult} from the {@code restore} subcommands. */
+final class RestoreRunner {
+
+    private RestoreRunner() {}
+
+    /**
+     * Prints the outcome of restoring {@code sessionId} to {@code out}.
+     *
+     * @return {@code 0} if every account (or domain) restored successfully, {@code 1} if any failed
+     */
+    static int printResult(PrintWriter out, String sessionId, RestoreResult result) {
+        int succeeded = result.succeededCount();
+        if (result.allSucceeded()) {
+            out.printf("Restore session %s completed (%d/%d accounts restored)%n", sessionId, succeeded, result.total());
+            return 0;
+        }
+        out.printf(
+                "Restore session %s completed with errors (%d/%d accounts restored, %d failed)%n",
+                sessionId, succeeded, result.total(), result.failedAccounts().size());
+        return 1;
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cli/MainTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MainTest.java
@@ -83,11 +83,6 @@ class MainTest {
     }
 
     @Test
-    void restoreIsStubbed() {
-        assertStubbed("restore");
-    }
-
-    @Test
     void housekeepRemovesOldSessions() throws IOException {
         Path configFile = writeConfig();
         new SqliteMetadataStore(tempDir.resolve("sessions.sqlite3"))
@@ -148,16 +143,6 @@ class MainTest {
 
         assertEquals(1, exitCode);
         assertTrue(err.toString().contains("does-not-exist not found in database"));
-    }
-
-    private void assertStubbed(String subcommand) {
-        StringWriter err = new StringWriter();
-        CommandLine cmd = commandLine(new StringWriter(), err);
-
-        int exitCode = cmd.execute(subcommand);
-
-        assertEquals(1, exitCode);
-        assertTrue(err.toString().contains("not yet implemented"));
     }
 
     private Path writeConfig() throws IOException {

--- a/app/src/test/java/io/zmbackup/app/cli/RestoreCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/RestoreCommandTest.java
@@ -1,0 +1,290 @@
+package io.zmbackup.app.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import com.unboundid.ldap.listener.InMemoryDirectoryServer;
+import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
+import com.unboundid.ldap.sdk.Attribute;
+import com.unboundid.ldap.sdk.Entry;
+import com.unboundid.ldap.sdk.Modification;
+import com.unboundid.ldap.sdk.ModificationType;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+/**
+ * Exercises the {@code restore}/{@code restore ldap}/{@code restore domain}/{@code restore
+ * mailbox} commands end to end: a real backup is taken first (against an in-memory LDAP directory
+ * and a plain {@link HttpServer} standing in for Zimbra's REST mailbox endpoint), the underlying
+ * data is then mutated, and the restore command's effect is verified.
+ */
+class RestoreCommandTest {
+
+    private static final String BIND_DN = "uid=zimbra,cn=admins,cn=zimbra";
+    private static final String BIND_PASSWORD = "secret";
+
+    @TempDir
+    Path tempDir;
+
+    private InMemoryDirectoryServer directoryServer;
+    private HttpServer mailboxServer;
+    private String mailboxRestBaseUrl = "https://127.0.0.1:7071";
+    private final List<String> mailboxRestorePosts = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        if (directoryServer != null) {
+            directoryServer.shutDown(true);
+        }
+        if (mailboxServer != null) {
+            mailboxServer.stop(0);
+        }
+    }
+
+    @Test
+    void ldapSubcommandRestoresAccountEntry() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"),
+                new Attribute("description", "original"));
+        Path configFile = writeConfig();
+        StringWriter backupOut = new StringWriter();
+        StringWriter backupErr = new StringWriter();
+        int backupExit = commandLine(backupOut, backupErr)
+                .execute("--config", configFile.toString(), "backup", "ldap", "--account", "alice@example.com");
+        assertEquals(0, backupExit, backupErr.toString());
+        String sessionId = sessionIdOf(backupOut, "ldap-");
+
+        directoryServer.modify(
+                "uid=alice,dc=example,dc=com",
+                new Modification(ModificationType.REPLACE, "description", "corrupted"));
+
+        StringWriter restoreOut = new StringWriter();
+        int restoreExit = commandLine(restoreOut, new StringWriter())
+                .execute(
+                        "--config", configFile.toString(), "restore", "ldap", "--session", sessionId, "--account",
+                        "alice@example.com");
+
+        assertEquals(0, restoreExit);
+        assertTrue(restoreOut.toString().contains("completed"));
+        Entry restored = directoryServer.getEntry("uid=alice,dc=example,dc=com");
+        assertEquals("original", restored.getAttributeValue("description"));
+    }
+
+    @Test
+    void domainSubcommandRestoresDomainEntry() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "dc=other,dc=com",
+                new Attribute("objectClass", "zimbraDomain"),
+                new Attribute("dc", "other"),
+                new Attribute("zimbraDomainName", "other.com"));
+        Path configFile = writeConfig();
+        StringWriter backupOut = new StringWriter();
+        int backupExit = commandLine(backupOut, new StringWriter())
+                .execute("--config", configFile.toString(), "backup", "domain", "--domain", "other.com");
+        assertEquals(0, backupExit);
+        String sessionId = sessionIdOf(backupOut, "domain-");
+
+        StringWriter restoreOut = new StringWriter();
+        int restoreExit = commandLine(restoreOut, new StringWriter())
+                .execute(
+                        "--config", configFile.toString(), "restore", "domain", "--session", sessionId, "--domain",
+                        "other.com");
+
+        assertEquals(0, restoreExit);
+        assertTrue(restoreOut.toString().contains("completed"));
+    }
+
+    @Test
+    void mailboxSubcommandPostsArchiveToRestoreEndpoint() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        startMailboxServer();
+        Path configFile = writeConfig();
+        StringWriter backupOut = new StringWriter();
+        int backupExit = commandLine(backupOut, new StringWriter())
+                .execute("--config", configFile.toString(), "backup", "mailbox", "--account", "alice@example.com");
+        assertEquals(0, backupExit);
+        String sessionId = sessionIdOf(backupOut, "mbox-");
+
+        StringWriter restoreOut = new StringWriter();
+        int restoreExit = commandLine(restoreOut, new StringWriter())
+                .execute(
+                        "--config", configFile.toString(), "restore", "mailbox", "--session", sessionId, "--account",
+                        "alice@example.com");
+
+        assertEquals(0, restoreExit);
+        assertEquals(List.of("POST /home/alice@example.com/"), mailboxRestorePosts);
+    }
+
+    @Test
+    void mailboxSubcommandWithIntoRestoresIntoDestinationAccount() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        startMailboxServer();
+        Path configFile = writeConfig();
+        StringWriter backupOut = new StringWriter();
+        commandLine(backupOut, new StringWriter())
+                .execute("--config", configFile.toString(), "backup", "mailbox", "--account", "alice@example.com");
+        String sessionId = sessionIdOf(backupOut, "mbox-");
+
+        StringWriter restoreOut = new StringWriter();
+        int restoreExit = commandLine(restoreOut, new StringWriter())
+                .execute(
+                        "--config", configFile.toString(), "restore", "mailbox", "--session", sessionId, "--account",
+                        "alice@example.com", "--into", "bob@example.com");
+
+        assertEquals(0, restoreExit);
+        assertEquals(List.of("POST /home/bob@example.com/"), mailboxRestorePosts);
+    }
+
+    @Test
+    void topLevelRestoreWithIntoRequiresExactlyOneAccount() throws Exception {
+        directoryServer = startDirectoryServer();
+        Path configFile = writeConfig();
+        StringWriter err = new StringWriter();
+
+        int exitCode = commandLine(new StringWriter(), err)
+                .execute(
+                        "--config", configFile.toString(), "restore", "--session", "full-1", "--account",
+                        "alice@example.com", "--account", "bob@example.com", "--into", "carol@example.com");
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(err.toString().contains("--into requires exactly one --account"));
+    }
+
+    @Test
+    void topLevelRestoreRestoresLdapAndMailbox() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        startMailboxServer();
+        Path configFile = writeConfig();
+        StringWriter backupOut = new StringWriter();
+        int backupExit = commandLine(backupOut, new StringWriter())
+                .execute("--config", configFile.toString(), "backup", "full", "--account", "alice@example.com");
+        assertEquals(0, backupExit);
+        String sessionId = sessionIdOf(backupOut, "full-");
+
+        StringWriter restoreOut = new StringWriter();
+        int restoreExit = commandLine(restoreOut, new StringWriter())
+                .execute("--config", configFile.toString(), "restore", "--session", sessionId);
+
+        assertEquals(0, restoreExit);
+        assertEquals(List.of("POST /home/alice@example.com/"), mailboxRestorePosts);
+    }
+
+    private static String sessionIdOf(StringWriter out, String prefix) {
+        String output = out.toString();
+        int start = output.indexOf(prefix);
+        int end = output.indexOf(' ', start);
+        return output.substring(start, end);
+    }
+
+    private InMemoryDirectoryServer startDirectoryServer() throws Exception {
+        InMemoryDirectoryServerConfig config =
+                new InMemoryDirectoryServerConfig("dc=example,dc=com", "dc=other,dc=com");
+        config.addAdditionalBindCredentials(BIND_DN, BIND_PASSWORD);
+        config.setSchema(null);
+        InMemoryDirectoryServer server = new InMemoryDirectoryServer(config);
+        server.startListening();
+        server.add("dc=example,dc=com", new Attribute("objectClass", "domain"), new Attribute("dc", "example"));
+        return server;
+    }
+
+    private void startMailboxServer() throws IOException {
+        mailboxServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        mailboxServer.createContext("/", (HttpExchange exchange) -> {
+            String method = exchange.getRequestMethod();
+            String path = exchange.getRequestURI().getPath();
+            if ("GET".equals(method)) {
+                byte[] body = "tgz-content".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, body.length);
+                exchange.getResponseBody().write(body);
+            } else if ("POST".equals(method)) {
+                mailboxRestorePosts.add("POST " + path);
+                ByteArrayOutputStream drained = new ByteArrayOutputStream();
+                exchange.getRequestBody().transferTo(drained);
+                exchange.sendResponseHeaders(200, -1);
+            } else {
+                exchange.sendResponseHeaders(405, -1);
+            }
+            exchange.close();
+        });
+        mailboxServer.start();
+        mailboxRestBaseUrl = "http://127.0.0.1:" + mailboxServer.getAddress().getPort();
+    }
+
+    private Path writeConfig() throws IOException {
+        Path configFile = tempDir.resolve("zmbackup.yaml");
+        Files.writeString(
+                configFile,
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:%d
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                  sslEnabled: false
+                zimbraMailbox:
+                  backupUser: zimbra
+                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                  restBaseUrl: %s
+                  adminUser: zimbra
+                  adminPassword: secret
+                backup:
+                  workDir: %s
+                  logFile: %s
+                  blockedListFile: %s
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """
+                        .formatted(
+                                directoryServer.getListenPort(),
+                                mailboxRestBaseUrl,
+                                tempDir,
+                                tempDir.resolve("zmbackup.log"),
+                                tempDir.resolve("blockedlist.conf")));
+        return configFile;
+    }
+
+    private static CommandLine commandLine(StringWriter out, StringWriter err) {
+        CommandLine cmd = new CommandLine(new Main());
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(err));
+        return cmd;
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cucumber/BackupIntegrationSteps.java
+++ b/app/src/test/java/io/zmbackup/app/cucumber/BackupIntegrationSteps.java
@@ -1,10 +1,15 @@
 package io.zmbackup.app.cucumber;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -22,9 +27,11 @@ import io.cucumber.java.en.When;
 import io.zmbackup.core.domain.BackupAccountRecord;
 import io.zmbackup.core.domain.BackupSession;
 import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.RestoreResult;
 import io.zmbackup.core.domain.SessionStatus;
 import io.zmbackup.core.service.BackupService;
 import io.zmbackup.core.service.HousekeepService;
+import io.zmbackup.core.service.RestoreService;
 import io.zmbackup.core.service.SessionService;
 import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
@@ -46,9 +53,10 @@ import java.util.Optional;
 import java.util.UUID;
 
 /**
- * Step definitions backing {@code backup_integration.feature}: wires {@link BackupService},
- * {@link HousekeepService}, and {@link SessionService} against real port implementations rather
- * than the mocked ports used by {@code BackupServiceTest}.
+ * Step definitions backing {@code backup_integration.feature} and {@code
+ * restore_integration.feature}: wires {@link BackupService}, {@link RestoreService}, {@link
+ * HousekeepService}, and {@link SessionService} against real port implementations rather than the
+ * mocked ports used by {@code BackupServiceTest}/{@code RestoreServiceTest}.
  */
 public class BackupIntegrationSteps {
 
@@ -64,6 +72,7 @@ public class BackupIntegrationSteps {
     private SqliteMetadataStore metadataStore;
     private LocalStorageProvider storageProvider;
     private BackupService backupService;
+    private RestoreService restoreService;
     private HousekeepService housekeepService;
     private SessionService sessionService;
 
@@ -72,6 +81,7 @@ public class BackupIntegrationSteps {
     private BackupSession secondNamedSession;
     private String oldSessionId;
     private String oldSessionAccount;
+    private RestoreResult lastRestoreResult;
 
     @Before
     public void setUp() throws Exception {
@@ -91,6 +101,8 @@ public class BackupIntegrationSteps {
 
         mailboxServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
         mailboxServer.start();
+        // Restore POSTs succeed by default; scenarios only need to stub the GET export endpoint.
+        mailboxServer.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200)));
         ZimbraRestMailboxExporter mailboxExporter =
                 new ZimbraRestMailboxExporter(mailboxServer.baseUrl(), MAILBOX_ADMIN_USER, MAILBOX_ADMIN_PASSWORD);
 
@@ -102,6 +114,7 @@ public class BackupIntegrationSteps {
         storageProvider = new LocalStorageProvider(tempDir);
 
         backupService = new BackupService(ldapAdapter, ldapAdapter, mailboxExporter, storageProvider, metadataStore);
+        restoreService = new RestoreService(ldapAdapter, mailboxExporter, storageProvider, metadataStore);
         housekeepService = new HousekeepService(storageProvider, metadataStore);
         sessionService = new SessionService(storageProvider, metadataStore);
     }
@@ -199,9 +212,49 @@ public class BackupIntegrationSteps {
         lastSession = backupService.backup(BackupType.DOMAIN, List.of(identifier)).orElseThrow();
     }
 
+    @Given("I have run a domain backup for {string}")
+    public void iHaveRunADomainBackupFor(String identifier) throws IOException {
+        iRunADomainBackupFor(identifier);
+    }
+
+    @Given("I have run a full backup for {string}")
+    public void iHaveRunAFullBackupFor(String identifier) throws IOException {
+        lastSession = backupService.backup(BackupType.FULL, List.of(identifier)).orElseThrow();
+    }
+
     @When("I delete that session")
     public void iDeleteThatSession() throws IOException {
         assertTrue(sessionService.deleteSession(lastSession.sessionId()));
+    }
+
+    @Given("the LDAP entry for {string} is deleted")
+    public void theLdapEntryForIsDeleted(String account) throws Exception {
+        directoryServer.delete(accountDn(account));
+    }
+
+    @When("I restore LDAP for {string}")
+    public void iRestoreLdapFor(String account) throws IOException {
+        lastRestoreResult = restoreService.restoreLdap(lastSession.sessionId(), List.of(account));
+    }
+
+    @When("I restore LDAP for {string} from session {string}")
+    public void iRestoreLdapForFromSession(String account, String sessionId) throws IOException {
+        lastRestoreResult = restoreService.restoreLdap(sessionId, List.of(account));
+    }
+
+    @When("I restore domain {string}")
+    public void iRestoreDomain(String domain) throws IOException {
+        lastRestoreResult = restoreService.restoreDomain(lastSession.sessionId(), List.of(domain));
+    }
+
+    @When("I restore the mailbox for {string}")
+    public void iRestoreTheMailboxFor(String account) throws IOException {
+        lastRestoreResult = restoreService.restoreMailbox(lastSession.sessionId(), List.of(account));
+    }
+
+    @When("I restore the mailbox for {string} into {string}")
+    public void iRestoreTheMailboxForInto(String account, String destination) throws IOException {
+        lastRestoreResult = restoreService.restoreMailbox(lastSession.sessionId(), List.of(account), destination);
     }
 
     @Given("a stored session {string} completed {int} days ago with account {string}")
@@ -275,6 +328,27 @@ public class BackupIntegrationSteps {
     @Then("the metadata store has no record of the old session")
     public void theMetadataStoreHasNoRecordOfTheOldSession() throws IOException {
         assertEquals(Optional.empty(), metadataStore.findSession(oldSessionId));
+    }
+
+    @Then("the {word} restore result has {int} failed accounts")
+    public void theRestoreResultHasFailedAccounts(String kind, int expectedFailedCount) {
+        assertEquals(expectedFailedCount, lastRestoreResult.failedAccounts().size());
+    }
+
+    @Then("the LDAP entry for {string} exists again")
+    public void theLdapEntryForExistsAgain(String account) throws Exception {
+        assertNotNull(directoryServer.getEntry(accountDn(account)));
+    }
+
+    @Then("the WireMock server received a mailbox restore POST for {string} with body {string}")
+    public void theWireMockServerReceivedAMailboxRestorePostForWithBody(String account, String expectedBody) {
+        mailboxServer.verify(postRequestedFor(urlPathEqualTo("/home/" + account + "/"))
+                .withRequestBody(equalTo(expectedBody)));
+    }
+
+    private static String accountDn(String account) {
+        String uid = account.substring(0, account.indexOf('@'));
+        return "uid=" + uid + ",dc=example,dc=com";
     }
 
     private static void deleteRecursively(Path root) throws IOException {

--- a/app/src/test/resources/features/restore_integration.feature
+++ b/app/src/test/resources/features/restore_integration.feature
@@ -1,0 +1,41 @@
+Feature: Restore lifecycle across real adapters
+
+  RestoreService wired against the same real port implementations as
+  backup_integration.feature. Each scenario first runs a real backup to
+  produce genuine LDIF/tgz artifacts, then restores from them.
+
+  Scenario: Restoring LDAP re-adds a deleted account entry
+    Given an in-memory LDAP directory with accounts:
+      | alice@example.com |
+    And I have run an LDAP backup for "alice@example.com"
+    And the LDAP entry for "alice@example.com" is deleted
+    When I restore LDAP for "alice@example.com"
+    Then the LDAP restore result has 0 failed accounts
+    And the LDAP entry for "alice@example.com" exists again
+
+  Scenario: Restoring a domain treats an already-existing entry as success
+    Given an in-memory LDAP directory with domain "other.com"
+    And I have run a domain backup for "other.com"
+    When I restore domain "other.com"
+    Then the domain restore result has 0 failed accounts
+
+  Scenario: Restoring a mailbox posts the archive to the WireMock restore endpoint
+    Given an in-memory LDAP directory with accounts:
+      | alice@example.com |
+    And the mailbox export endpoint for "alice@example.com" returns tgz content "mailbox-bytes"
+    And I have run a full backup for "alice@example.com"
+    When I restore the mailbox for "alice@example.com"
+    Then the WireMock server received a mailbox restore POST for "alice@example.com" with body "mailbox-bytes"
+
+  Scenario: Restoring a mailbox into a different account posts to the destination's endpoint
+    Given an in-memory LDAP directory with accounts:
+      | alice@example.com |
+    And the mailbox export endpoint for "alice@example.com" returns tgz content "mailbox-bytes"
+    And I have run a full backup for "alice@example.com"
+    When I restore the mailbox for "alice@example.com" into "bob@example.com"
+    Then the WireMock server received a mailbox restore POST for "bob@example.com" with body "mailbox-bytes"
+
+  Scenario: A restore failure is reported without throwing
+    Given an in-memory LDAP directory with no data
+    When I restore LDAP for "missing@example.com" from session "ldap-no-such-session"
+    Then the LDAP restore result has 1 failed accounts

--- a/core/src/main/java/io/zmbackup/core/domain/RestoreResult.java
+++ b/core/src/main/java/io/zmbackup/core/domain/RestoreResult.java
@@ -1,0 +1,33 @@
+package io.zmbackup.core.domain;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The outcome of a {@link io.zmbackup.core.service.RestoreService} restore call, mirroring the
+ * {@code TOTAL_COUNT}/{@code SUCCESS_COUNT}/{@code FAIL_COUNT} bookkeeping in the bash tool's
+ * {@code restore_main_ldap}/{@code restore_main_mailbox}/{@code restore_main_domain}.
+ *
+ * @param total          how many accounts (or domains) were attempted
+ * @param failedAccounts the accounts (or domains) that failed to restore
+ */
+public record RestoreResult(int total, List<String> failedAccounts) {
+
+    public RestoreResult {
+        Objects.requireNonNull(failedAccounts, "failedAccounts must not be null");
+        failedAccounts = List.copyOf(failedAccounts);
+        if (total < failedAccounts.size()) {
+            throw new IllegalArgumentException("total must be at least the number of failed accounts");
+        }
+    }
+
+    /** How many accounts (or domains) restored successfully. */
+    public int succeededCount() {
+        return total - failedAccounts.size();
+    }
+
+    /** Whether every attempted account (or domain) restored successfully. */
+    public boolean allSucceeded() {
+        return failedAccounts.isEmpty();
+    }
+}

--- a/core/src/main/java/io/zmbackup/core/port/Blocklist.java
+++ b/core/src/main/java/io/zmbackup/core/port/Blocklist.java
@@ -1,0 +1,11 @@
+package io.zmbackup.core.port;
+
+/**
+ * Accounts that must never be backed up, mirroring {@code ldap_filter}'s blocklist check against
+ * {@code ZMBACKUP_BLOCKEDLIST} in the bash tool's {@code ParallelAction.sh}.
+ */
+public interface Blocklist {
+
+    /** Whether {@code identifier} (an account, or domain) must be skipped. */
+    boolean isBlocked(String identifier);
+}

--- a/core/src/main/java/io/zmbackup/core/port/Notifier.java
+++ b/core/src/main/java/io/zmbackup/core/port/Notifier.java
@@ -1,0 +1,18 @@
+package io.zmbackup.core.port;
+
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import java.io.IOException;
+
+/**
+ * Sends e-mail notifications about a backup session's lifecycle, mirroring {@code
+ * notify_begin}/{@code notify_finish} in the bash tool's {@code NotifyAction.sh}.
+ */
+public interface Notifier {
+
+    /** Notifies that the backup session {@code sessionId} of {@code type} has started. */
+    void notifyBegin(String sessionId, BackupType type) throws IOException;
+
+    /** Notifies that the backup session {@code sessionId} of {@code type} finished with {@code status}. */
+    void notifyFinish(String sessionId, BackupType type, SessionStatus status) throws IOException;
+}

--- a/core/src/main/java/io/zmbackup/core/port/ZimbraLdapExporter.java
+++ b/core/src/main/java/io/zmbackup/core/port/ZimbraLdapExporter.java
@@ -29,4 +29,14 @@ public interface ZimbraLdapExporter {
      * entry, replacing any existing entry with the same distinguished name.
      */
     void restore(LdapObjectType type, InputStream source) throws IOException;
+
+    /**
+     * Restores a domain entry from a previously exported {@code .ldiff} entry, adding it without
+     * first deleting any existing entry. Unlike {@link #restore}, an entry that already exists is
+     * treated as success rather than a failure, mirroring {@code domain_restore}'s handling of
+     * {@code ldapadd}'s "Already exists" error in the bash tool's {@code ParallelAction.sh}: a
+     * clean install's domain parent entries are expected to already exist ahead of account
+     * restores.
+     */
+    void restoreDomain(InputStream source) throws IOException;
 }

--- a/core/src/main/java/io/zmbackup/core/service/BackupService.java
+++ b/core/src/main/java/io/zmbackup/core/service/BackupService.java
@@ -6,6 +6,7 @@ import io.zmbackup.core.domain.BackupType;
 import io.zmbackup.core.domain.LdapObjectType;
 import io.zmbackup.core.domain.SessionStatus;
 import io.zmbackup.core.port.AccountDiscovery;
+import io.zmbackup.core.port.Blocklist;
 import io.zmbackup.core.port.MetadataStore;
 import io.zmbackup.core.port.StorageProvider;
 import io.zmbackup.core.port.ZimbraLdapExporter;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.logging.Logger;
 
 /**
  * Runs backup sessions for the LDAP-only {@link BackupType}s ({@code LDAP}, {@code ALIAS}, {@code
@@ -30,6 +32,9 @@ import java.util.concurrent.Callable;
  * {@code BackupAction.sh}.
  */
 public class BackupService {
+
+    private static final Logger LOG = Logger.getLogger(BackupService.class.getName());
+    private static final Blocklist NO_BLOCKLIST = identifier -> false;
 
     private static final DateTimeFormatter SESSION_TIMESTAMP =
             DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneId.systemDefault());
@@ -47,6 +52,7 @@ public class BackupService {
     private final ZimbraMailboxExporter mailboxExporter;
     private final StorageProvider storageProvider;
     private final MetadataStore metadataStore;
+    private final Blocklist blocklist;
     private final int maxParallelProcesses;
 
     public BackupService(
@@ -55,7 +61,7 @@ public class BackupService {
             ZimbraMailboxExporter mailboxExporter,
             StorageProvider storageProvider,
             MetadataStore metadataStore) {
-        this(accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore, 1);
+        this(accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore, NO_BLOCKLIST, 1);
     }
 
     /**
@@ -69,11 +75,37 @@ public class BackupService {
             StorageProvider storageProvider,
             MetadataStore metadataStore,
             int maxParallelProcesses) {
+        this(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                NO_BLOCKLIST,
+                maxParallelProcesses);
+    }
+
+    /**
+     * @param blocklist            discovered accounts (or domains) found here are skipped rather
+     *                             than backed up, mirroring {@code ldap_filter}'s blocklist check
+     * @param maxParallelProcesses how many accounts to back up concurrently, mirroring the bash
+     *                             tool's {@code MAX_PARALLEL_PROCESS}; values below 1 are treated
+     *                             as 1
+     */
+    public BackupService(
+            AccountDiscovery accountDiscovery,
+            ZimbraLdapExporter ldapExporter,
+            ZimbraMailboxExporter mailboxExporter,
+            StorageProvider storageProvider,
+            MetadataStore metadataStore,
+            Blocklist blocklist,
+            int maxParallelProcesses) {
         this.accountDiscovery = Objects.requireNonNull(accountDiscovery, "accountDiscovery must not be null");
         this.ldapExporter = Objects.requireNonNull(ldapExporter, "ldapExporter must not be null");
         this.mailboxExporter = Objects.requireNonNull(mailboxExporter, "mailboxExporter must not be null");
         this.storageProvider = Objects.requireNonNull(storageProvider, "storageProvider must not be null");
         this.metadataStore = Objects.requireNonNull(metadataStore, "metadataStore must not be null");
+        this.blocklist = Objects.requireNonNull(blocklist, "blocklist must not be null");
         this.maxParallelProcesses = maxParallelProcesses;
     }
 
@@ -183,18 +215,39 @@ public class BackupService {
                 .orElse(null);
     }
 
+    /**
+     * Resolves the objects to back up. Explicit {@code identifiers} are used as-is, bypassing the
+     * blocklist, mirroring {@code backup_main}'s {@code -a}/{@code --account} path (which bypasses
+     * {@code build_listBKP} entirely); discovered objects are filtered against the blocklist, same
+     * as {@code build_listBKP} always does via {@code ldap_filter}.
+     */
     private List<String> resolveIdentifiers(BackupType type, List<String> identifiers, String domain)
             throws IOException {
         if (!identifiers.isEmpty()) {
             return identifiers;
         }
+        List<String> discovered;
         if (type == BackupType.DOMAIN) {
-            return accountDiscovery.listDomains();
+            discovered = accountDiscovery.listDomains();
+        } else {
+            LdapObjectType objectType = objectTypeFor(type);
+            discovered = domain == null
+                    ? accountDiscovery.discover(objectType)
+                    : accountDiscovery.discoverForDomain(objectType, domain);
         }
-        LdapObjectType objectType = objectTypeFor(type);
-        return domain == null
-                ? accountDiscovery.discover(objectType)
-                : accountDiscovery.discoverForDomain(objectType, domain);
+        return filterBlocked(discovered);
+    }
+
+    private List<String> filterBlocked(List<String> identifiers) {
+        List<String> allowed = new ArrayList<>(identifiers.size());
+        for (String identifier : identifiers) {
+            if (blocklist.isBlocked(identifier)) {
+                LOG.info(() -> identifier + " found inside blocked list - skipping.");
+            } else {
+                allowed.add(identifier);
+            }
+        }
+        return allowed;
     }
 
     private static LdapObjectType objectTypeFor(BackupType type) {

--- a/core/src/main/java/io/zmbackup/core/service/BackupService.java
+++ b/core/src/main/java/io/zmbackup/core/service/BackupService.java
@@ -8,6 +8,7 @@ import io.zmbackup.core.domain.SessionStatus;
 import io.zmbackup.core.port.AccountDiscovery;
 import io.zmbackup.core.port.Blocklist;
 import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.Notifier;
 import io.zmbackup.core.port.StorageProvider;
 import io.zmbackup.core.port.ZimbraLdapExporter;
 import io.zmbackup.core.port.ZimbraMailboxExporter;
@@ -35,6 +36,13 @@ public class BackupService {
 
     private static final Logger LOG = Logger.getLogger(BackupService.class.getName());
     private static final Blocklist NO_BLOCKLIST = identifier -> false;
+    private static final Notifier NO_NOTIFIER = new Notifier() {
+        @Override
+        public void notifyBegin(String sessionId, BackupType type) {}
+
+        @Override
+        public void notifyFinish(String sessionId, BackupType type, SessionStatus status) {}
+    };
 
     private static final DateTimeFormatter SESSION_TIMESTAMP =
             DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneId.systemDefault());
@@ -53,6 +61,7 @@ public class BackupService {
     private final StorageProvider storageProvider;
     private final MetadataStore metadataStore;
     private final Blocklist blocklist;
+    private final Notifier notifier;
     private final int maxParallelProcesses;
 
     public BackupService(
@@ -61,7 +70,15 @@ public class BackupService {
             ZimbraMailboxExporter mailboxExporter,
             StorageProvider storageProvider,
             MetadataStore metadataStore) {
-        this(accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore, NO_BLOCKLIST, 1);
+        this(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                NO_BLOCKLIST,
+                NO_NOTIFIER,
+                1);
     }
 
     /**
@@ -82,6 +99,7 @@ public class BackupService {
                 storageProvider,
                 metadataStore,
                 NO_BLOCKLIST,
+                NO_NOTIFIER,
                 maxParallelProcesses);
     }
 
@@ -100,12 +118,42 @@ public class BackupService {
             MetadataStore metadataStore,
             Blocklist blocklist,
             int maxParallelProcesses) {
+        this(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                blocklist,
+                NO_NOTIFIER,
+                maxParallelProcesses);
+    }
+
+    /**
+     * @param blocklist            discovered accounts (or domains) found here are skipped rather
+     *                             than backed up, mirroring {@code ldap_filter}'s blocklist check
+     * @param notifier             notified when a session starts and finishes, mirroring {@code
+     *                             notify_begin}/{@code notify_finish}
+     * @param maxParallelProcesses how many accounts to back up concurrently, mirroring the bash
+     *                             tool's {@code MAX_PARALLEL_PROCESS}; values below 1 are treated
+     *                             as 1
+     */
+    public BackupService(
+            AccountDiscovery accountDiscovery,
+            ZimbraLdapExporter ldapExporter,
+            ZimbraMailboxExporter mailboxExporter,
+            StorageProvider storageProvider,
+            MetadataStore metadataStore,
+            Blocklist blocklist,
+            Notifier notifier,
+            int maxParallelProcesses) {
         this.accountDiscovery = Objects.requireNonNull(accountDiscovery, "accountDiscovery must not be null");
         this.ldapExporter = Objects.requireNonNull(ldapExporter, "ldapExporter must not be null");
         this.mailboxExporter = Objects.requireNonNull(mailboxExporter, "mailboxExporter must not be null");
         this.storageProvider = Objects.requireNonNull(storageProvider, "storageProvider must not be null");
         this.metadataStore = Objects.requireNonNull(metadataStore, "metadataStore must not be null");
         this.blocklist = Objects.requireNonNull(blocklist, "blocklist must not be null");
+        this.notifier = Objects.requireNonNull(notifier, "notifier must not be null");
         this.maxParallelProcesses = maxParallelProcesses;
     }
 
@@ -144,6 +192,7 @@ public class BackupService {
         String sessionId = type.sessionPrefix() + "-" + SESSION_TIMESTAMP.format(Instant.now());
         Instant sessionStart = Instant.now();
         metadataStore.save(new BackupSession(sessionId, type, SessionStatus.IN_PROGRESS, sessionStart, null, null));
+        notifySafely(() -> notifier.notifyBegin(sessionId, type));
 
         List<Callable<Boolean>> tasks = new ArrayList<>(resolved.size());
         for (String identifier : resolved) {
@@ -156,7 +205,25 @@ public class BackupService {
         SessionStatus status = allSucceeded ? SessionStatus.FINISHED : SessionStatus.FAILED;
         BackupSession completed = new BackupSession(sessionId, type, status, sessionStart, sessionEnd, size);
         metadataStore.save(completed);
+        notifySafely(() -> notifier.notifyFinish(sessionId, type, status));
         return Optional.of(completed);
+    }
+
+    private interface NotifierCall {
+        void run() throws IOException;
+    }
+
+    /**
+     * Runs a {@link Notifier} call, logging rather than propagating a failure: a notification
+     * problem must never fail the backup itself, mirroring how the bash tool's {@code
+     * notify_begin}/{@code notify_finish} only log a warning when {@code sendmail} fails.
+     */
+    private void notifySafely(NotifierCall call) {
+        try {
+            call.run();
+        } catch (IOException e) {
+            LOG.warning(() -> "Failed to send backup notification: " + e.getMessage());
+        }
     }
 
     /**

--- a/core/src/main/java/io/zmbackup/core/service/BackupService.java
+++ b/core/src/main/java/io/zmbackup/core/service/BackupService.java
@@ -16,9 +16,11 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 /**
  * Runs backup sessions for the LDAP-only {@link BackupType}s ({@code LDAP}, {@code ALIAS}, {@code
@@ -45,6 +47,7 @@ public class BackupService {
     private final ZimbraMailboxExporter mailboxExporter;
     private final StorageProvider storageProvider;
     private final MetadataStore metadataStore;
+    private final int maxParallelProcesses;
 
     public BackupService(
             AccountDiscovery accountDiscovery,
@@ -52,11 +55,26 @@ public class BackupService {
             ZimbraMailboxExporter mailboxExporter,
             StorageProvider storageProvider,
             MetadataStore metadataStore) {
+        this(accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore, 1);
+    }
+
+    /**
+     * @param maxParallelProcesses how many accounts to back up concurrently, mirroring the bash
+     *     tool's {@code MAX_PARALLEL_PROCESS}; values below 1 are treated as 1
+     */
+    public BackupService(
+            AccountDiscovery accountDiscovery,
+            ZimbraLdapExporter ldapExporter,
+            ZimbraMailboxExporter mailboxExporter,
+            StorageProvider storageProvider,
+            MetadataStore metadataStore,
+            int maxParallelProcesses) {
         this.accountDiscovery = Objects.requireNonNull(accountDiscovery, "accountDiscovery must not be null");
         this.ldapExporter = Objects.requireNonNull(ldapExporter, "ldapExporter must not be null");
         this.mailboxExporter = Objects.requireNonNull(mailboxExporter, "mailboxExporter must not be null");
         this.storageProvider = Objects.requireNonNull(storageProvider, "storageProvider must not be null");
         this.metadataStore = Objects.requireNonNull(metadataStore, "metadataStore must not be null");
+        this.maxParallelProcesses = maxParallelProcesses;
     }
 
     /** Backs up every object of {@code type} found across the whole directory. */
@@ -95,12 +113,11 @@ public class BackupService {
         Instant sessionStart = Instant.now();
         metadataStore.save(new BackupSession(sessionId, type, SessionStatus.IN_PROGRESS, sessionStart, null, null));
 
-        boolean allSucceeded = true;
+        List<Callable<Boolean>> tasks = new ArrayList<>(resolved.size());
         for (String identifier : resolved) {
-            if (!backupOne(sessionId, type, identifier)) {
-                allSucceeded = false;
-            }
+            tasks.add(() -> backupOne(sessionId, type, identifier));
         }
+        boolean allSucceeded = !Parallel.run(maxParallelProcesses, tasks).contains(false);
 
         Instant sessionEnd = Instant.now();
         String size = storageProvider.sizeOfSession(sessionId);

--- a/core/src/main/java/io/zmbackup/core/service/Parallel.java
+++ b/core/src/main/java/io/zmbackup/core/service/Parallel.java
@@ -1,0 +1,54 @@
+package io.zmbackup.core.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Runs a batch of tasks on a bounded thread pool and collects their results, mirroring the bash
+ * tool's {@code parallel --jobs "$MAX_PARALLEL_PROCESS"} invocations: every task runs to
+ * completion regardless of whether others fail, and results are returned in the same order the
+ * tasks were given.
+ */
+final class Parallel {
+
+    private Parallel() {}
+
+    /**
+     * Runs {@code tasks} on a fixed thread pool of {@code maxParallelProcesses} threads (at least
+     * one), waiting for all of them to finish before returning.
+     *
+     * @throws IOException if the calling thread is interrupted while waiting, or if any task
+     *     throws; an {@link IOException} thrown by a task is rethrown as-is, anything else is
+     *     wrapped in one
+     */
+    static <T> List<T> run(int maxParallelProcesses, List<Callable<T>> tasks) throws IOException {
+        ExecutorService executor = Executors.newFixedThreadPool(Math.max(1, maxParallelProcesses));
+        try {
+            List<Future<T>> futures = executor.invokeAll(tasks);
+            List<T> results = new ArrayList<>(futures.size());
+            for (Future<T> future : futures) {
+                try {
+                    results.add(future.get());
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof IOException io) {
+                        throw io;
+                    }
+                    throw new IOException("Parallel task failed", cause);
+                }
+            }
+            return results;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while running parallel tasks", e);
+        } finally {
+            executor.shutdown();
+        }
+    }
+}

--- a/core/src/main/java/io/zmbackup/core/service/RestoreService.java
+++ b/core/src/main/java/io/zmbackup/core/service/RestoreService.java
@@ -1,0 +1,151 @@
+package io.zmbackup.core.service;
+
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.LdapObjectType;
+import io.zmbackup.core.domain.RestoreResult;
+import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.StorageProvider;
+import io.zmbackup.core.port.ZimbraLdapExporter;
+import io.zmbackup.core.port.ZimbraMailboxExporter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Restores previously backed-up LDAP entries and mailbox content, mirroring {@code
+ * restore_main_ldap}/{@code restore_main_mailbox}/{@code restore_main_domain} in the bash tool's
+ * {@code RestoreAction.sh}.
+ */
+public class RestoreService {
+
+    private static final String LDIFF_SUFFIX = "ldiff";
+    private static final String TGZ_SUFFIX = "tgz";
+
+    private final ZimbraLdapExporter ldapExporter;
+    private final ZimbraMailboxExporter mailboxExporter;
+    private final StorageProvider storageProvider;
+    private final MetadataStore metadataStore;
+
+    public RestoreService(
+            ZimbraLdapExporter ldapExporter,
+            ZimbraMailboxExporter mailboxExporter,
+            StorageProvider storageProvider,
+            MetadataStore metadataStore) {
+        this.ldapExporter = Objects.requireNonNull(ldapExporter, "ldapExporter must not be null");
+        this.mailboxExporter = Objects.requireNonNull(mailboxExporter, "mailboxExporter must not be null");
+        this.storageProvider = Objects.requireNonNull(storageProvider, "storageProvider must not be null");
+        this.metadataStore = Objects.requireNonNull(metadataStore, "metadataStore must not be null");
+    }
+
+    /**
+     * Restores the LDAP entry for each of {@code accounts} (or every account in {@code sessionId}
+     * when {@code accounts} is empty), mirroring {@code restore_main_ldap}.
+     */
+    public RestoreResult restoreLdap(String sessionId, List<String> accounts) throws IOException {
+        List<String> resolved = resolve(sessionId, accounts);
+        List<String> failed = new ArrayList<>();
+        for (String account : resolved) {
+            if (!restoreLdapOne(sessionId, account)) {
+                failed.add(account);
+            }
+        }
+        return new RestoreResult(resolved.size(), failed);
+    }
+
+    /**
+     * Restores the domain LDAP entry for each of {@code domains} (or every domain in {@code
+     * sessionId} when {@code domains} is empty), mirroring {@code restore_main_domain}.
+     */
+    public RestoreResult restoreDomain(String sessionId, List<String> domains) throws IOException {
+        List<String> resolved = resolve(sessionId, domains);
+        List<String> failed = new ArrayList<>();
+        for (String domain : resolved) {
+            if (!restoreDomainOne(sessionId, domain)) {
+                failed.add(domain);
+            }
+        }
+        return new RestoreResult(resolved.size(), failed);
+    }
+
+    /**
+     * Restores the mailbox content for each of {@code accounts} (or every account in {@code
+     * sessionId} when {@code accounts} is empty), mirroring {@code restore_main_mailbox}.
+     */
+    public RestoreResult restoreMailbox(String sessionId, List<String> accounts) throws IOException {
+        List<String> resolved = resolve(sessionId, accounts);
+        List<String> failed = new ArrayList<>();
+        for (String account : resolved) {
+            if (!restoreMailboxOne(sessionId, account, account)) {
+                failed.add(account);
+            }
+        }
+        return new RestoreResult(resolved.size(), failed);
+    }
+
+    /**
+     * Restores both the LDAP entry and mailbox content for each of {@code accounts} (or every
+     * account in {@code sessionId} when {@code accounts} is empty), equivalent to {@code zmbackup
+     * -r full-*} in the bash tool.
+     */
+    public RestoreResult restoreFull(String sessionId, List<String> accounts) throws IOException {
+        RestoreResult ldapResult = restoreLdap(sessionId, accounts);
+        RestoreResult mailboxResult = restoreMailbox(sessionId, accounts);
+        Set<String> failed = new LinkedHashSet<>(ldapResult.failedAccounts());
+        failed.addAll(mailboxResult.failedAccounts());
+        return new RestoreResult(ldapResult.total(), List.copyOf(failed));
+    }
+
+    private boolean restoreLdapOne(String sessionId, String account) {
+        try (InputStream source = storageProvider.openRead(sessionId, account, LDIFF_SUFFIX)) {
+            // The adapter reads the DN straight out of the LDIF content, so the object type
+            // passed here has no effect on account/alias/distlist/signature restores.
+            ldapExporter.restore(LdapObjectType.ACCOUNT, source);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private boolean restoreDomainOne(String sessionId, String domain) {
+        try (InputStream source = storageProvider.openRead(sessionId, domain, LDIFF_SUFFIX)) {
+            ldapExporter.restoreDomain(source);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private boolean restoreMailboxOne(String sessionId, String account, String destination) {
+        if (!storageProvider.exists(sessionId, account, TGZ_SUFFIX)) {
+            // Mirrors mailbox_restore's "No such file or directory" case: nothing to restore, not
+            // a failure.
+            return true;
+        }
+        try (InputStream source = storageProvider.openRead(sessionId, account, TGZ_SUFFIX)) {
+            mailboxExporter.restore(destination, source);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * {@code identifiers} when non-empty; otherwise every account (or domain) recorded for {@code
+     * sessionId}, mirroring {@code build_listRST}'s SQLite-backed session lookup.
+     */
+    private List<String> resolve(String sessionId, List<String> identifiers) throws IOException {
+        if (!identifiers.isEmpty()) {
+            return identifiers;
+        }
+        List<BackupAccountRecord> records = metadataStore.findAccountsForSession(sessionId);
+        List<String> resolved = new ArrayList<>(records.size());
+        for (BackupAccountRecord record : records) {
+            resolved.add(record.email());
+        }
+        return resolved;
+    }
+}

--- a/core/src/main/java/io/zmbackup/core/service/RestoreService.java
+++ b/core/src/main/java/io/zmbackup/core/service/RestoreService.java
@@ -76,10 +76,28 @@ public class RestoreService {
      * sessionId} when {@code accounts} is empty), mirroring {@code restore_main_mailbox}.
      */
     public RestoreResult restoreMailbox(String sessionId, List<String> accounts) throws IOException {
+        return restoreMailbox(sessionId, accounts, null);
+    }
+
+    /**
+     * Restores the mailbox content for each of {@code accounts} (or every account in {@code
+     * sessionId} when {@code accounts} is empty) into {@code destination} when given, mirroring
+     * {@code restore_main_mailbox}'s restore-on-account handling of its {@code $3} destination
+     * argument.
+     *
+     * @param destination a different account to restore the mailbox content into, or {@code null}
+     *     to restore each account into itself; when given, {@code accounts} must contain exactly
+     *     one account
+     */
+    public RestoreResult restoreMailbox(String sessionId, List<String> accounts, String destination)
+            throws IOException {
+        if (destination != null && accounts.size() != 1) {
+            throw new IllegalArgumentException("destination requires exactly one account, got " + accounts.size());
+        }
         List<String> resolved = resolve(sessionId, accounts);
         List<String> failed = new ArrayList<>();
         for (String account : resolved) {
-            if (!restoreMailboxOne(sessionId, account, account)) {
+            if (!restoreMailboxOne(sessionId, account, destination != null ? destination : account)) {
                 failed.add(account);
             }
         }

--- a/core/src/main/java/io/zmbackup/core/service/RestoreService.java
+++ b/core/src/main/java/io/zmbackup/core/service/RestoreService.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 /**
  * Restores previously backed-up LDAP entries and mailbox content, mirroring {@code
@@ -29,16 +30,31 @@ public class RestoreService {
     private final ZimbraMailboxExporter mailboxExporter;
     private final StorageProvider storageProvider;
     private final MetadataStore metadataStore;
+    private final int maxParallelProcesses;
 
     public RestoreService(
             ZimbraLdapExporter ldapExporter,
             ZimbraMailboxExporter mailboxExporter,
             StorageProvider storageProvider,
             MetadataStore metadataStore) {
+        this(ldapExporter, mailboxExporter, storageProvider, metadataStore, 1);
+    }
+
+    /**
+     * @param maxParallelProcesses how many accounts to restore concurrently, mirroring the bash
+     *     tool's {@code MAX_PARALLEL_PROCESS}; values below 1 are treated as 1
+     */
+    public RestoreService(
+            ZimbraLdapExporter ldapExporter,
+            ZimbraMailboxExporter mailboxExporter,
+            StorageProvider storageProvider,
+            MetadataStore metadataStore,
+            int maxParallelProcesses) {
         this.ldapExporter = Objects.requireNonNull(ldapExporter, "ldapExporter must not be null");
         this.mailboxExporter = Objects.requireNonNull(mailboxExporter, "mailboxExporter must not be null");
         this.storageProvider = Objects.requireNonNull(storageProvider, "storageProvider must not be null");
         this.metadataStore = Objects.requireNonNull(metadataStore, "metadataStore must not be null");
+        this.maxParallelProcesses = maxParallelProcesses;
     }
 
     /**
@@ -47,13 +63,11 @@ public class RestoreService {
      */
     public RestoreResult restoreLdap(String sessionId, List<String> accounts) throws IOException {
         List<String> resolved = resolve(sessionId, accounts);
-        List<String> failed = new ArrayList<>();
+        List<Callable<Boolean>> tasks = new ArrayList<>(resolved.size());
         for (String account : resolved) {
-            if (!restoreLdapOne(sessionId, account)) {
-                failed.add(account);
-            }
+            tasks.add(() -> restoreLdapOne(sessionId, account));
         }
-        return new RestoreResult(resolved.size(), failed);
+        return summarize(resolved, Parallel.run(maxParallelProcesses, tasks));
     }
 
     /**
@@ -62,13 +76,11 @@ public class RestoreService {
      */
     public RestoreResult restoreDomain(String sessionId, List<String> domains) throws IOException {
         List<String> resolved = resolve(sessionId, domains);
-        List<String> failed = new ArrayList<>();
+        List<Callable<Boolean>> tasks = new ArrayList<>(resolved.size());
         for (String domain : resolved) {
-            if (!restoreDomainOne(sessionId, domain)) {
-                failed.add(domain);
-            }
+            tasks.add(() -> restoreDomainOne(sessionId, domain));
         }
-        return new RestoreResult(resolved.size(), failed);
+        return summarize(resolved, Parallel.run(maxParallelProcesses, tasks));
     }
 
     /**
@@ -95,13 +107,11 @@ public class RestoreService {
             throw new IllegalArgumentException("destination requires exactly one account, got " + accounts.size());
         }
         List<String> resolved = resolve(sessionId, accounts);
-        List<String> failed = new ArrayList<>();
+        List<Callable<Boolean>> tasks = new ArrayList<>(resolved.size());
         for (String account : resolved) {
-            if (!restoreMailboxOne(sessionId, account, destination != null ? destination : account)) {
-                failed.add(account);
-            }
+            tasks.add(() -> restoreMailboxOne(sessionId, account, destination != null ? destination : account));
         }
-        return new RestoreResult(resolved.size(), failed);
+        return summarize(resolved, Parallel.run(maxParallelProcesses, tasks));
     }
 
     /**
@@ -149,6 +159,17 @@ public class RestoreService {
         } catch (IOException e) {
             return false;
         }
+    }
+
+    /** Pairs {@code resolved} with the matching per-account {@code outcomes} from {@link Parallel#run}. */
+    private static RestoreResult summarize(List<String> resolved, List<Boolean> outcomes) {
+        List<String> failed = new ArrayList<>();
+        for (int i = 0; i < resolved.size(); i++) {
+            if (!outcomes.get(i)) {
+                failed.add(resolved.get(i));
+            }
+        }
+        return new RestoreResult(resolved.size(), failed);
     }
 
     /**

--- a/core/src/test/java/io/zmbackup/core/domain/RestoreResultTest.java
+++ b/core/src/test/java/io/zmbackup/core/domain/RestoreResultTest.java
@@ -1,0 +1,40 @@
+package io.zmbackup.core.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RestoreResultTest {
+
+    @Test
+    void allSucceededIsTrueWhenNoFailures() {
+        RestoreResult result = new RestoreResult(2, List.of());
+
+        assertTrue(result.allSucceeded());
+        assertEquals(2, result.succeededCount());
+    }
+
+    @Test
+    void allSucceededIsFalseWhenSomeFailed() {
+        RestoreResult result = new RestoreResult(2, List.of("bad@example.com"));
+
+        assertFalse(result.allSucceeded());
+        assertEquals(1, result.succeededCount());
+    }
+
+    @Test
+    void rejectsMoreFailuresThanTotal() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new RestoreResult(1, List.of("a@example.com", "b@example.com")));
+    }
+
+    @Test
+    void rejectsNullFailedAccounts() {
+        assertThrows(NullPointerException.class, () -> new RestoreResult(1, null));
+    }
+}

--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -103,6 +103,42 @@ class BackupServiceTest {
     }
 
     @Test
+    void discoveredAccountOnBlocklistIsSkipped() throws IOException {
+        accountDiscovery.wholeDirectory.put(LdapObjectType.ACCOUNT, List.of("alice@example.com", "bob@example.com"));
+        BackupService blocklisted = new BackupService(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                identifier -> identifier.equals("bob@example.com"),
+                1);
+
+        Optional<BackupSession> result = blocklisted.backup(BackupType.LDAP);
+
+        assertTrue(result.isPresent());
+        assertEquals(
+                Set.of("alice@example.com"), namesOf(metadataStore.findAccountsForSession(result.get().sessionId())));
+    }
+
+    @Test
+    void explicitAccountBypassesBlocklist() throws IOException {
+        BackupService blocklisted = new BackupService(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                identifier -> true,
+                1);
+
+        Optional<BackupSession> result = blocklisted.backup(BackupType.LDAP, List.of("alice@example.com"));
+
+        assertTrue(result.isPresent());
+        assertEquals(SessionStatus.FINISHED, result.get().status());
+    }
+
+    @Test
     void returnsEmptyAndSkipsSessionWhenNothingToBackUp() throws IOException {
         Optional<BackupSession> result = backupService.backup(BackupType.SIGNATURE);
 

--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -283,6 +283,11 @@ class BackupServiceTest {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public void restoreDomain(InputStream source) {
+            throw new UnsupportedOperationException();
+        }
+
         Set<LdapObjectType> exportedTypesFor(String... identifiers) {
             Set<LdapObjectType> types = new HashSet<>();
             for (String identifier : identifiers) {

--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -123,6 +123,58 @@ class BackupServiceTest {
     }
 
     @Test
+    void discoveredDomainOnBlocklistIsSkipped() throws IOException {
+        accountDiscovery.wholeDirectory.put(LdapObjectType.DOMAIN, List.of("example.com", "blocked.example.com"));
+        BackupService blocklisted = new BackupService(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                identifier -> identifier.equals("blocked.example.com"),
+                1);
+
+        Optional<BackupSession> result = blocklisted.backup(BackupType.DOMAIN);
+
+        assertTrue(result.isPresent());
+        assertEquals(
+                Set.of("example.com"), namesOf(metadataStore.findAccountsForSession(result.get().sessionId())));
+    }
+
+    @Test
+    void domainScopedDiscoveryRespectsBlocklist() throws IOException {
+        accountDiscovery.byDomain.put(
+                Map.entry(LdapObjectType.ACCOUNT, "example.com"),
+                List.of("alice@example.com", "bob@example.com"));
+        BackupService blocklisted = new BackupService(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                identifier -> identifier.equals("bob@example.com"),
+                1);
+
+        Optional<BackupSession> result = blocklisted.backup(BackupType.LDAP, List.of(), "example.com");
+
+        assertTrue(result.isPresent());
+        assertEquals(
+                Set.of("alice@example.com"), namesOf(metadataStore.findAccountsForSession(result.get().sessionId())));
+    }
+
+    @Test
+    void backupIsSkippedEntirelyWhenEveryDiscoveredAccountIsBlocked() throws IOException {
+        accountDiscovery.wholeDirectory.put(LdapObjectType.ACCOUNT, List.of("alice@example.com"));
+        BackupService blocklisted = new BackupService(
+                accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore, identifier -> true, 1);
+
+        Optional<BackupSession> result = blocklisted.backup(BackupType.LDAP);
+
+        assertTrue(result.isEmpty());
+        assertTrue(metadataStore.listSessions().isEmpty());
+    }
+
+    @Test
     void explicitAccountBypassesBlocklist() throws IOException {
         BackupService blocklisted = new BackupService(
                 accountDiscovery,

--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -192,6 +192,54 @@ class BackupServiceTest {
     }
 
     @Test
+    void backupNeverRunsMoreThanMaxParallelProcessesAccountsConcurrently() throws IOException {
+        List<String> accounts = List.of(
+                "a@example.com", "b@example.com", "c@example.com", "d@example.com", "e@example.com",
+                "f@example.com");
+        accountDiscovery.wholeDirectory.put(LdapObjectType.ACCOUNT, accounts);
+        java.util.concurrent.atomic.AtomicInteger inFlight = new java.util.concurrent.atomic.AtomicInteger();
+        java.util.concurrent.atomic.AtomicInteger maxInFlight = new java.util.concurrent.atomic.AtomicInteger();
+        ZimbraLdapExporter trackingExporter = new ZimbraLdapExporter() {
+            @Override
+            public void export(String identifier, LdapObjectType type, OutputStream destination) throws IOException {
+                int current = inFlight.incrementAndGet();
+                maxInFlight.updateAndGet(prev -> Math.max(prev, current));
+                try {
+                    Thread.sleep(20);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    inFlight.decrementAndGet();
+                }
+            }
+
+            @Override
+            public void exportDomain(String domain, OutputStream destination) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void restore(LdapObjectType type, InputStream source) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void restoreDomain(InputStream source) {
+                throw new UnsupportedOperationException();
+            }
+        };
+        BackupService parallelBackup = new BackupService(
+                accountDiscovery, trackingExporter, mailboxExporter, storageProvider, metadataStore, 2);
+
+        Optional<BackupSession> result = parallelBackup.backup(BackupType.LDAP);
+
+        assertTrue(result.isPresent());
+        assertEquals(SessionStatus.FINISHED, result.get().status());
+        assertTrue(maxInFlight.get() <= 2, "observed " + maxInFlight.get() + " concurrent exports, expected at most 2");
+        assertEquals(2, maxInFlight.get());
+    }
+
+    @Test
     void notifiesBeginAndFinishForASession() throws IOException {
         RecordingNotifier notifier = new RecordingNotifier();
         BackupService notified = new BackupService(
@@ -450,9 +498,13 @@ class BackupServiceTest {
         }
     }
 
-    /** In-memory {@link StorageProvider} fake backed by a byte-array map. */
+    /**
+     * In-memory {@link StorageProvider} fake backed by a byte-array map. Uses a {@link
+     * ConcurrentHashMap} since {@link #backupNeverRunsMoreThanMaxParallelProcessesAccountsConcurrently}
+     * exercises it from multiple threads at once.
+     */
     private static final class InMemoryStorageProvider implements StorageProvider {
-        final Map<String, byte[]> content = new LinkedHashMap<>();
+        final Map<String, byte[]> content = new java.util.concurrent.ConcurrentHashMap<>();
 
         @Override
         public OutputStream openWrite(String sessionId, String account, String suffix) {
@@ -560,7 +612,7 @@ class BackupServiceTest {
         }
 
         @Override
-        public void recordAccountBackup(BackupAccountRecord record) {
+        public synchronized void recordAccountBackup(BackupAccountRecord record) {
             accounts.computeIfAbsent(record.sessionId(), k -> new ArrayList<>()).add(record);
         }
 

--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -11,6 +11,7 @@ import io.zmbackup.core.domain.LdapObjectType;
 import io.zmbackup.core.domain.SessionStatus;
 import io.zmbackup.core.port.AccountDiscovery;
 import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.Notifier;
 import io.zmbackup.core.port.StorageProvider;
 import io.zmbackup.core.port.ZimbraLdapExporter;
 import io.zmbackup.core.port.ZimbraMailboxExporter;
@@ -136,6 +137,45 @@ class BackupServiceTest {
 
         assertTrue(result.isPresent());
         assertEquals(SessionStatus.FINISHED, result.get().status());
+    }
+
+    @Test
+    void notifiesBeginAndFinishForASession() throws IOException {
+        RecordingNotifier notifier = new RecordingNotifier();
+        BackupService notified = new BackupService(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                identifier -> false,
+                notifier,
+                1);
+
+        Optional<BackupSession> result = notified.backup(BackupType.LDAP, List.of("alice@example.com"));
+
+        assertEquals(2, notifier.calls.size());
+        assertTrue(notifier.calls.get(0).startsWith("begin:"));
+        assertEquals(
+                "finish:" + result.get().sessionId() + ":LDAP:" + result.get().status(), notifier.calls.get(1));
+    }
+
+    @Test
+    void doesNotNotifyWhenNothingToBackUp() throws IOException {
+        RecordingNotifier notifier = new RecordingNotifier();
+        BackupService notified = new BackupService(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                identifier -> false,
+                notifier,
+                1);
+
+        notified.backup(BackupType.SIGNATURE);
+
+        assertTrue(notifier.calls.isEmpty());
     }
 
     @Test
@@ -419,6 +459,21 @@ class BackupServiceTest {
     }
 
     /** In-memory {@link MetadataStore} fake backed by simple maps. */
+    /** {@link Notifier} fake that records every call it receives. */
+    private static final class RecordingNotifier implements Notifier {
+        final List<String> calls = new ArrayList<>();
+
+        @Override
+        public void notifyBegin(String sessionId, BackupType type) {
+            calls.add("begin:" + sessionId + ":" + type);
+        }
+
+        @Override
+        public void notifyFinish(String sessionId, BackupType type, SessionStatus status) {
+            calls.add("finish:" + sessionId + ":" + type + ":" + status);
+        }
+    }
+
     private static final class InMemoryMetadataStore implements MetadataStore {
         final Map<String, BackupSession> sessions = new LinkedHashMap<>();
         final Map<String, List<BackupAccountRecord>> accounts = new LinkedHashMap<>();

--- a/core/src/test/java/io/zmbackup/core/service/ParallelTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/ParallelTest.java
@@ -1,0 +1,139 @@
+package io.zmbackup.core.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link Parallel#run} bounds concurrency by {@code maxParallelProcesses}, runs every
+ * task to completion regardless of individual failures, and surfaces results/exceptions correctly.
+ */
+class ParallelTest {
+
+    @Test
+    void neverRunsMoreThanMaxParallelProcessesConcurrently() throws IOException {
+        int maxParallelProcesses = 3;
+        int taskCount = 12;
+        AtomicInteger inFlight = new AtomicInteger();
+        AtomicInteger maxObservedInFlight = new AtomicInteger();
+        CountDownLatch releaseGate = new CountDownLatch(1);
+
+        List<Callable<Integer>> tasks = new java.util.ArrayList<>();
+        for (int i = 0; i < taskCount; i++) {
+            tasks.add(() -> {
+                int current = inFlight.incrementAndGet();
+                maxObservedInFlight.updateAndGet(previousMax -> Math.max(previousMax, current));
+                releaseGate.await(5, TimeUnit.SECONDS);
+                inFlight.decrementAndGet();
+                return current;
+            });
+        }
+
+        // Every task blocks on releaseGate until at least maxParallelProcesses are running, which
+        // proves the pool doesn't run more than that many concurrently; then everything is
+        // released together so the batch actually completes.
+        Thread releaser = new Thread(() -> {
+            try {
+                while (inFlight.get() < maxParallelProcesses) {
+                    Thread.sleep(10);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                releaseGate.countDown();
+            }
+        });
+        releaser.start();
+
+        List<Integer> results = Parallel.run(maxParallelProcesses, tasks);
+
+        assertEquals(taskCount, results.size());
+        assertTrue(
+                maxObservedInFlight.get() <= maxParallelProcesses,
+                "observed " + maxObservedInFlight.get() + " concurrent tasks, expected at most "
+                        + maxParallelProcesses);
+        assertEquals(maxParallelProcesses, maxObservedInFlight.get());
+    }
+
+    @Test
+    void treatsValuesBelowOneAsOneThread() throws IOException {
+        AtomicInteger inFlight = new AtomicInteger();
+        AtomicInteger maxObservedInFlight = new AtomicInteger();
+        List<Callable<Void>> tasks = List.of(
+                () -> {
+                    maxObservedInFlight.updateAndGet(prev -> Math.max(prev, inFlight.incrementAndGet()));
+                    Thread.sleep(20);
+                    inFlight.decrementAndGet();
+                    return null;
+                },
+                () -> {
+                    maxObservedInFlight.updateAndGet(prev -> Math.max(prev, inFlight.incrementAndGet()));
+                    Thread.sleep(20);
+                    inFlight.decrementAndGet();
+                    return null;
+                });
+
+        Parallel.run(0, tasks);
+
+        assertEquals(1, maxObservedInFlight.get());
+    }
+
+    @Test
+    void runsEveryTaskToCompletionRegardlessOfOthersFailing() throws IOException {
+        AtomicInteger completed = new AtomicInteger();
+        List<Callable<Integer>> tasks = List.of(
+                () -> {
+                    completed.incrementAndGet();
+                    return 1;
+                },
+                () -> {
+                    completed.incrementAndGet();
+                    throw new IOException("simulated failure");
+                },
+                () -> {
+                    completed.incrementAndGet();
+                    return 3;
+                });
+
+        assertThrows(IOException.class, () -> Parallel.run(2, tasks));
+        assertEquals(3, completed.get());
+    }
+
+    @Test
+    void returnsResultsInTheSameOrderAsTasks() throws IOException {
+        List<Callable<Integer>> tasks =
+                List.of(() -> 1, () -> 2, () -> 3, () -> 4, () -> 5);
+
+        List<Integer> results = Parallel.run(4, tasks);
+
+        assertEquals(List.of(1, 2, 3, 4, 5), results);
+    }
+
+    @Test
+    void rethrowsIOExceptionThrownByATaskAsIs() {
+        List<Callable<Void>> tasks = List.of(() -> {
+            throw new IOException("boom");
+        });
+
+        IOException exception = assertThrows(IOException.class, () -> Parallel.run(1, tasks));
+        assertEquals("boom", exception.getMessage());
+    }
+
+    @Test
+    void wrapsNonIOExceptionThrownByATaskInIOException() {
+        List<Callable<Void>> tasks = List.of(() -> {
+            throw new RuntimeException("boom");
+        });
+
+        IOException exception = assertThrows(IOException.class, () -> Parallel.run(1, tasks));
+        assertEquals(RuntimeException.class, exception.getCause().getClass());
+    }
+}

--- a/core/src/test/java/io/zmbackup/core/service/RestoreServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/RestoreServiceTest.java
@@ -1,0 +1,301 @@
+package io.zmbackup.core.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.LdapObjectType;
+import io.zmbackup.core.domain.RestoreResult;
+import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.StorageProvider;
+import io.zmbackup.core.port.ZimbraLdapExporter;
+import io.zmbackup.core.port.ZimbraMailboxExporter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link RestoreService} against hand-rolled fakes of its ports, mirroring the
+ * style of {@link BackupServiceTest}.
+ */
+class RestoreServiceTest {
+
+    private final FakeZimbraLdapExporter ldapExporter = new FakeZimbraLdapExporter();
+    private final FakeZimbraMailboxExporter mailboxExporter = new FakeZimbraMailboxExporter();
+    private final InMemoryStorageProvider storageProvider = new InMemoryStorageProvider();
+    private final InMemoryMetadataStore metadataStore = new InMemoryMetadataStore();
+    private final RestoreService restoreService =
+            new RestoreService(ldapExporter, mailboxExporter, storageProvider, metadataStore);
+
+    @Test
+    void restoreLdapRestoresExplicitAccounts() throws IOException {
+        storageProvider.put("full-1", "alice@example.com", "ldiff", "ldiff:alice@example.com");
+
+        RestoreResult result = restoreService.restoreLdap("full-1", List.of("alice@example.com"));
+
+        assertTrue(result.allSucceeded());
+        assertEquals(1, result.total());
+        assertEquals(List.of("ldiff:alice@example.com"), ldapExporter.restored.get("alice@example.com"));
+    }
+
+    @Test
+    void restoreLdapResolvesEveryAccountInSessionWhenNoneGiven() throws IOException {
+        storageProvider.put("full-1", "alice@example.com", "ldiff", "ldiff:alice@example.com");
+        storageProvider.put("full-1", "bob@example.com", "ldiff", "ldiff:bob@example.com");
+        metadataStore.recordAccountBackup(recordFor("full-1", "alice@example.com"));
+        metadataStore.recordAccountBackup(recordFor("full-1", "bob@example.com"));
+
+        RestoreResult result = restoreService.restoreLdap("full-1", List.of());
+
+        assertEquals(2, result.total());
+        assertTrue(result.allSucceeded());
+        assertEquals(Set.of("alice@example.com", "bob@example.com"), ldapExporter.restored.keySet());
+    }
+
+    @Test
+    void restoreLdapRecordsFailureWhenLdifIsMissing() throws IOException {
+        RestoreResult result = restoreService.restoreLdap("full-1", List.of("missing@example.com"));
+
+        assertEquals(1, result.total());
+        assertEquals(List.of("missing@example.com"), result.failedAccounts());
+    }
+
+    @Test
+    void restoreLdapRecordsFailureWhenAdapterThrows() throws IOException {
+        storageProvider.put("full-1", "bad@example.com", "ldiff", "ldiff:bad@example.com");
+        ldapExporter.failing.add("bad@example.com");
+
+        RestoreResult result = restoreService.restoreLdap("full-1", List.of("bad@example.com"));
+
+        assertEquals(List.of("bad@example.com"), result.failedAccounts());
+    }
+
+    @Test
+    void restoreDomainRestoresViaRestoreDomainMethod() throws IOException {
+        storageProvider.put("domain-1", "example.com", "ldiff", "ldiff:example.com");
+
+        RestoreResult result = restoreService.restoreDomain("domain-1", List.of("example.com"));
+
+        assertTrue(result.allSucceeded());
+        assertEquals(List.of("ldiff:example.com"), ldapExporter.restoredDomains.get("example.com"));
+        assertTrue(ldapExporter.restored.isEmpty());
+    }
+
+    @Test
+    void restoreMailboxRestoresIntoTheSameAccountByDefault() throws IOException {
+        storageProvider.put("mbox-1", "alice@example.com", "tgz", "tgz:alice");
+
+        RestoreResult result = restoreService.restoreMailbox("mbox-1", List.of("alice@example.com"));
+
+        assertTrue(result.allSucceeded());
+        assertEquals(List.of("tgz:alice"), mailboxExporter.restoredInto.get("alice@example.com"));
+    }
+
+    @Test
+    void restoreMailboxTreatsMissingArchiveAsSuccessNotFailure() throws IOException {
+        RestoreResult result = restoreService.restoreMailbox("mbox-1", List.of("alice@example.com"));
+
+        assertTrue(result.allSucceeded());
+        assertTrue(mailboxExporter.restoredInto.isEmpty());
+    }
+
+    @Test
+    void restoreMailboxRecordsFailureWhenAdapterThrows() throws IOException {
+        storageProvider.put("mbox-1", "bad@example.com", "tgz", "tgz:bad");
+        mailboxExporter.failing.add("bad@example.com");
+
+        RestoreResult result = restoreService.restoreMailbox("mbox-1", List.of("bad@example.com"));
+
+        assertEquals(List.of("bad@example.com"), result.failedAccounts());
+    }
+
+    @Test
+    void restoreFullRestoresLdapThenMailboxAndUnionsFailures() throws IOException {
+        storageProvider.put("full-1", "alice@example.com", "ldiff", "ldiff:alice@example.com");
+        storageProvider.put("full-1", "alice@example.com", "tgz", "tgz:alice");
+        storageProvider.put("full-1", "bad@example.com", "ldiff", "ldiff:bad@example.com");
+        storageProvider.put("full-1", "bad@example.com", "tgz", "tgz:bad");
+        ldapExporter.failing.add("bad@example.com");
+        mailboxExporter.failing.add("bad@example.com");
+
+        RestoreResult result = restoreService.restoreFull("full-1", List.of("alice@example.com", "bad@example.com"));
+
+        assertEquals(2, result.total());
+        assertEquals(List.of("bad@example.com"), result.failedAccounts());
+        assertEquals(List.of("tgz:alice"), mailboxExporter.restoredInto.get("alice@example.com"));
+        assertEquals(List.of("ldiff:alice@example.com"), ldapExporter.restored.get("alice@example.com"));
+    }
+
+    private static BackupAccountRecord recordFor(String sessionId, String email) {
+        Instant now = Instant.now();
+        return new BackupAccountRecord(null, sessionId, email, "1K", now, now);
+    }
+
+    /** In-memory {@link ZimbraLdapExporter} fake that records what was restored. */
+    private static final class FakeZimbraLdapExporter implements ZimbraLdapExporter {
+        final Map<String, List<String>> restored = new LinkedHashMap<>();
+        final Map<String, List<String>> restoredDomains = new LinkedHashMap<>();
+        final Set<String> failing = new HashSet<>();
+
+        @Override
+        public void export(String identifier, LdapObjectType type, OutputStream destination) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void exportDomain(String domain, OutputStream destination) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void restore(LdapObjectType type, InputStream source) throws IOException {
+            String content = new String(source.readAllBytes());
+            String identifier = content.substring(content.lastIndexOf(':') + 1);
+            if (failing.contains(identifier)) {
+                throw new IOException("simulated restore failure for " + identifier);
+            }
+            restored.computeIfAbsent(identifier, k -> new ArrayList<>()).add(content);
+        }
+
+        @Override
+        public void restoreDomain(InputStream source) throws IOException {
+            String content = new String(source.readAllBytes());
+            String identifier = content.substring(content.lastIndexOf(':') + 1);
+            if (failing.contains(identifier)) {
+                throw new IOException("simulated restore failure for " + identifier);
+            }
+            restoredDomains.computeIfAbsent(identifier, k -> new ArrayList<>()).add(content);
+        }
+    }
+
+    /** In-memory {@link ZimbraMailboxExporter} fake that records the destination each restore went to. */
+    private static final class FakeZimbraMailboxExporter implements ZimbraMailboxExporter {
+        final Map<String, List<String>> restoredInto = new LinkedHashMap<>();
+        final Set<String> failing = new HashSet<>();
+
+        @Override
+        public boolean export(String account, OutputStream destination, Instant since) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void restore(String account, InputStream source) throws IOException {
+            if (failing.contains(account)) {
+                throw new IOException("simulated restore failure for " + account);
+            }
+            String content = new String(source.readAllBytes());
+            restoredInto.computeIfAbsent(account, k -> new ArrayList<>()).add(content);
+        }
+    }
+
+    /** In-memory {@link StorageProvider} fake backed by a byte-array map. */
+    private static final class InMemoryStorageProvider implements StorageProvider {
+        final Map<String, byte[]> content = new LinkedHashMap<>();
+
+        void put(String sessionId, String account, String suffix, String value) {
+            content.put(key(sessionId, account, suffix), value.getBytes());
+        }
+
+        @Override
+        public OutputStream openWrite(String sessionId, String account, String suffix) {
+            String key = key(sessionId, account, suffix);
+            return new ByteArrayOutputStream() {
+                @Override
+                public void close() throws IOException {
+                    super.close();
+                    content.put(key, toByteArray());
+                }
+            };
+        }
+
+        @Override
+        public InputStream openRead(String sessionId, String account, String suffix) throws IOException {
+            byte[] bytes = content.get(key(sessionId, account, suffix));
+            if (bytes == null) {
+                throw new IOException("no content for " + key(sessionId, account, suffix));
+            }
+            return new ByteArrayInputStream(bytes);
+        }
+
+        @Override
+        public boolean exists(String sessionId, String account, String suffix) {
+            return content.containsKey(key(sessionId, account, suffix));
+        }
+
+        @Override
+        public String sizeOfAccount(String sessionId, String account) {
+            return "1B";
+        }
+
+        @Override
+        public String sizeOfSession(String sessionId) {
+            return "1B";
+        }
+
+        @Override
+        public void deleteSession(String sessionId) {
+            content.keySet().removeIf(key -> key.startsWith(sessionId + "/"));
+        }
+
+        private static String key(String sessionId, String account, String suffix) {
+            return sessionId + "/" + account + "." + suffix;
+        }
+    }
+
+    /** In-memory {@link MetadataStore} fake backed by simple maps. */
+    private static final class InMemoryMetadataStore implements MetadataStore {
+        final Map<String, List<BackupAccountRecord>> accounts = new LinkedHashMap<>();
+
+        @Override
+        public void save(BackupSession session) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<BackupSession> findSession(String sessionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<BackupSession> listSessions() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<BackupSession> findSessionsCompletedBefore(Instant cutoff) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void deleteSession(String sessionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void recordAccountBackup(BackupAccountRecord record) {
+            accounts.computeIfAbsent(record.sessionId(), k -> new ArrayList<>()).add(record);
+        }
+
+        @Override
+        public List<BackupAccountRecord> findAccountsForSession(String sessionId) {
+            return accounts.getOrDefault(sessionId, List.of());
+        }
+
+        @Override
+        public Optional<Instant> lastSuccessfulBackupTime(String email) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/core/src/test/java/io/zmbackup/core/service/RestoreServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/RestoreServiceTest.java
@@ -1,6 +1,7 @@
 package io.zmbackup.core.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.zmbackup.core.domain.BackupAccountRecord;
@@ -109,6 +110,33 @@ class RestoreServiceTest {
 
         assertTrue(result.allSucceeded());
         assertTrue(mailboxExporter.restoredInto.isEmpty());
+    }
+
+    @Test
+    void restoreMailboxRestoresIntoDestinationAccountWhenGiven() throws IOException {
+        storageProvider.put("mbox-1", "alice@example.com", "tgz", "tgz:alice");
+
+        RestoreResult result =
+                restoreService.restoreMailbox("mbox-1", List.of("alice@example.com"), "bob@example.com");
+
+        assertTrue(result.allSucceeded());
+        assertEquals(List.of("tgz:alice"), mailboxExporter.restoredInto.get("bob@example.com"));
+        assertTrue(mailboxExporter.restoredInto.get("alice@example.com") == null);
+    }
+
+    @Test
+    void restoreMailboxRejectsDestinationWithMultipleAccounts() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> restoreService.restoreMailbox(
+                        "mbox-1", List.of("alice@example.com", "bob@example.com"), "carol@example.com"));
+    }
+
+    @Test
+    void restoreMailboxRejectsDestinationWithNoExplicitAccount() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> restoreService.restoreMailbox("mbox-1", List.of(), "carol@example.com"));
     }
 
     @Test

--- a/core/src/test/java/io/zmbackup/core/service/RestoreServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/RestoreServiceTest.java
@@ -95,6 +95,37 @@ class RestoreServiceTest {
     }
 
     @Test
+    void restoreDomainResolvesEveryDomainInSessionWhenNoneGiven() throws IOException {
+        storageProvider.put("domain-1", "example.com", "ldiff", "ldiff:example.com");
+        storageProvider.put("domain-1", "other.com", "ldiff", "ldiff:other.com");
+        metadataStore.recordAccountBackup(recordFor("domain-1", "example.com"));
+        metadataStore.recordAccountBackup(recordFor("domain-1", "other.com"));
+
+        RestoreResult result = restoreService.restoreDomain("domain-1", List.of());
+
+        assertEquals(2, result.total());
+        assertTrue(result.allSucceeded());
+        assertEquals(Set.of("example.com", "other.com"), ldapExporter.restoredDomains.keySet());
+    }
+
+    @Test
+    void restoreDomainRecordsFailureWhenLdifIsMissing() throws IOException {
+        RestoreResult result = restoreService.restoreDomain("domain-1", List.of("missing.com"));
+
+        assertEquals(List.of("missing.com"), result.failedAccounts());
+    }
+
+    @Test
+    void restoreDomainRecordsFailureWhenAdapterThrows() throws IOException {
+        storageProvider.put("domain-1", "bad.com", "ldiff", "ldiff:bad.com");
+        ldapExporter.failing.add("bad.com");
+
+        RestoreResult result = restoreService.restoreDomain("domain-1", List.of("bad.com"));
+
+        assertEquals(List.of("bad.com"), result.failedAccounts());
+    }
+
+    @Test
     void restoreMailboxRestoresIntoTheSameAccountByDefault() throws IOException {
         storageProvider.put("mbox-1", "alice@example.com", "tgz", "tgz:alice");
 
@@ -164,6 +195,22 @@ class RestoreServiceTest {
         assertEquals(List.of("bad@example.com"), result.failedAccounts());
         assertEquals(List.of("tgz:alice"), mailboxExporter.restoredInto.get("alice@example.com"));
         assertEquals(List.of("ldiff:alice@example.com"), ldapExporter.restored.get("alice@example.com"));
+    }
+
+    @Test
+    void constructorRejectsNullPorts() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new RestoreService(null, mailboxExporter, storageProvider, metadataStore));
+        assertThrows(
+                NullPointerException.class,
+                () -> new RestoreService(ldapExporter, null, storageProvider, metadataStore));
+        assertThrows(
+                NullPointerException.class,
+                () -> new RestoreService(ldapExporter, mailboxExporter, null, metadataStore));
+        assertThrows(
+                NullPointerException.class,
+                () -> new RestoreService(ldapExporter, mailboxExporter, storageProvider, null));
     }
 
     private static BackupAccountRecord recordFor(String sessionId, String email) {

--- a/local/src/main/java/io/zmbackup/local/EmailNotifier.java
+++ b/local/src/main/java/io/zmbackup/local/EmailNotifier.java
@@ -1,0 +1,124 @@
+package io.zmbackup.local;
+
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import io.zmbackup.core.port.Notifier;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Sends plain-text e-mail notifications by speaking SMTP directly over a socket to a local relay,
+ * mirroring {@code notify_begin}/{@code notify_finish} in the bash tool's {@code NotifyAction.sh},
+ * which submits through the {@code sendmail} command to the same local MTA.
+ */
+public class EmailNotifier implements Notifier {
+
+    private final String smtpHost;
+    private final int smtpPort;
+    private final String sender;
+    private final String recipient;
+    private final boolean notifyOnBegin;
+    private final boolean notifyOnFinishSuccess;
+    private final boolean notifyOnFinishError;
+
+    /**
+     * @param smtpHost              host of the local SMTP relay to submit through
+     * @param smtpPort              port of the local SMTP relay
+     * @param sender                the {@code From} address, mirroring {@code EMAIL_SENDER}
+     * @param recipient             the {@code To} address, mirroring {@code EMAIL_NOTIFY}
+     * @param notifyOnBegin         whether to send a notification when a session starts
+     * @param notifyOnFinishSuccess whether to send a notification when a session finishes successfully
+     * @param notifyOnFinishError   whether to send a notification when a session fails
+     */
+    public EmailNotifier(
+            String smtpHost,
+            int smtpPort,
+            String sender,
+            String recipient,
+            boolean notifyOnBegin,
+            boolean notifyOnFinishSuccess,
+            boolean notifyOnFinishError) {
+        this.smtpHost = Objects.requireNonNull(smtpHost, "smtpHost must not be null");
+        this.smtpPort = smtpPort;
+        this.sender = Objects.requireNonNull(sender, "sender must not be null");
+        this.recipient = Objects.requireNonNull(recipient, "recipient must not be null");
+        this.notifyOnBegin = notifyOnBegin;
+        this.notifyOnFinishSuccess = notifyOnFinishSuccess;
+        this.notifyOnFinishError = notifyOnFinishError;
+    }
+
+    @Override
+    public void notifyBegin(String sessionId, BackupType type) throws IOException {
+        if (!notifyOnBegin) {
+            return;
+        }
+        String subject = "Zmbackup - Backup routine for " + type.sessionPrefix() + " started";
+        String body = "This is an automatic message to inform you that the " + type.sessionPrefix()
+                + " backup session " + sessionId + " started at " + Instant.now() + ".\n";
+        send(subject, body);
+    }
+
+    @Override
+    public void notifyFinish(String sessionId, BackupType type, SessionStatus status) throws IOException {
+        boolean shouldNotify = status == SessionStatus.FINISHED ? notifyOnFinishSuccess : notifyOnFinishError;
+        if (!shouldNotify) {
+            return;
+        }
+        String subject = "Zmbackup - Backup routine for " + type.sessionPrefix() + " " + status.dbValue();
+        String body = "This is an automatic message to inform you that the " + type.sessionPrefix()
+                + " backup session " + sessionId + " completed at " + Instant.now() + " with status "
+                + status.dbValue() + ".\n";
+        send(subject, body);
+    }
+
+    private void send(String subject, String body) throws IOException {
+        try (Socket socket = new Socket(smtpHost, smtpPort);
+                BufferedReader in = new BufferedReader(
+                        new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII));
+                OutputStream out = socket.getOutputStream()) {
+            readResponse(in, 220);
+            command(out, in, "EHLO localhost", 250);
+            command(out, in, "MAIL FROM:<" + sender + ">", 250);
+            command(out, in, "RCPT TO:<" + recipient + ">", 250);
+            command(out, in, "DATA", 354);
+
+            String message = "From: " + sender + "\r\n"
+                    + "To: " + recipient + "\r\n"
+                    + "Subject: " + subject + "\r\n"
+                    + "\r\n"
+                    + body
+                    + "\r\n.\r\n";
+            out.write(message.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            readResponse(in, 250);
+
+            command(out, in, "QUIT", 221);
+        }
+    }
+
+    private static void command(OutputStream out, BufferedReader in, String line, int expectedCode)
+            throws IOException {
+        out.write((line + "\r\n").getBytes(StandardCharsets.US_ASCII));
+        out.flush();
+        readResponse(in, expectedCode);
+    }
+
+    private static void readResponse(BufferedReader in, int expectedCode) throws IOException {
+        String line;
+        do {
+            line = in.readLine();
+            if (line == null) {
+                throw new IOException("SMTP server closed the connection unexpectedly");
+            }
+        } while (line.length() > 3 && line.charAt(3) == '-'); // keep reading a multi-line response
+        if (!line.startsWith(Integer.toString(expectedCode))) {
+            throw new IOException("Unexpected SMTP response: " + line);
+        }
+    }
+}

--- a/local/src/main/java/io/zmbackup/local/FileBlocklist.java
+++ b/local/src/main/java/io/zmbackup/local/FileBlocklist.java
@@ -1,0 +1,39 @@
+package io.zmbackup.local;
+
+import io.zmbackup.core.port.Blocklist;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Reads a one-identifier-per-line blocklist file into memory, mirroring {@code grep -Fxq "$1"
+ * "$blockedlist"} in the bash tool's {@code ldap_filter}. A missing file is treated as an empty
+ * blocklist, the same as {@code grep} against a nonexistent file failing to match.
+ */
+public class FileBlocklist implements Blocklist {
+
+    private final Set<String> blocked;
+
+    public FileBlocklist(Path blockedListFile) throws IOException {
+        Set<String> loaded = new HashSet<>();
+        try {
+            for (String line : Files.readAllLines(blockedListFile)) {
+                String trimmed = line.strip();
+                if (!trimmed.isEmpty()) {
+                    loaded.add(trimmed);
+                }
+            }
+        } catch (NoSuchFileException e) {
+            // Nothing is blocked, mirroring grep against a missing blockedlist.conf.
+        }
+        this.blocked = Set.copyOf(loaded);
+    }
+
+    @Override
+    public boolean isBlocked(String identifier) {
+        return blocked.contains(identifier);
+    }
+}

--- a/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
+++ b/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
@@ -215,7 +215,15 @@ public class SqliteMetadataStore implements MetadataStore {
     }
 
     private Connection connect() throws SQLException {
-        return DriverManager.getConnection(jdbcUrl);
+        Connection connection = DriverManager.getConnection(jdbcUrl);
+        // Backup and restore sessions now run accounts through a thread pool (see
+        // io.zmbackup.core.service.Parallel), so concurrent connections from the same process can
+        // momentarily contend for SQLite's file lock; retry instead of failing immediately with
+        // SQLITE_BUSY.
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("PRAGMA busy_timeout = 5000");
+        }
+        return connection;
     }
 
     private static BackupSession mapSession(ResultSet rs) throws SQLException {

--- a/local/src/test/java/io/zmbackup/local/EmailNotifierTest.java
+++ b/local/src/test/java/io/zmbackup/local/EmailNotifierTest.java
@@ -1,0 +1,190 @@
+package io.zmbackup.local;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/** Exercises {@link EmailNotifier} against a minimal hand-rolled fake SMTP server. */
+class EmailNotifierTest {
+
+    private FakeSmtpServer smtpServer;
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (smtpServer != null) {
+            smtpServer.close();
+        }
+    }
+
+    @Test
+    void notifyBeginSendsMessageWhenLevelEnablesBegin() throws Exception {
+        smtpServer = FakeSmtpServer.start();
+        EmailNotifier notifier = new EmailNotifier(
+                "127.0.0.1", smtpServer.port(), "root@example.com", "admin@example.com", true, true, true);
+
+        notifier.notifyBegin("full-1", BackupType.FULL);
+
+        FakeSmtpServer.Message message = smtpServer.awaitMessage();
+        assertEquals("root@example.com", message.from());
+        assertEquals("admin@example.com", message.to());
+        assertTrue(message.data().contains("Subject: Zmbackup - Backup routine for full started"));
+        assertTrue(message.data().contains("full-1"));
+    }
+
+    @Test
+    void notifyBeginSendsNothingWhenLevelDisablesBegin() throws Exception {
+        smtpServer = FakeSmtpServer.start();
+        EmailNotifier notifier = new EmailNotifier(
+                "127.0.0.1", smtpServer.port(), "root@example.com", "admin@example.com", false, true, true);
+
+        notifier.notifyBegin("full-1", BackupType.FULL);
+
+        assertFalse(smtpServer.receivedAnyMessage());
+    }
+
+    @Test
+    void notifyFinishSendsMessageOnSuccessWhenEnabled() throws Exception {
+        smtpServer = FakeSmtpServer.start();
+        EmailNotifier notifier = new EmailNotifier(
+                "127.0.0.1", smtpServer.port(), "root@example.com", "admin@example.com", true, true, false);
+
+        notifier.notifyFinish("full-1", BackupType.FULL, SessionStatus.FINISHED);
+
+        FakeSmtpServer.Message message = smtpServer.awaitMessage();
+        assertTrue(message.data().contains("FINISHED"));
+    }
+
+    @Test
+    void notifyFinishSendsNothingOnSuccessWhenOnlyErrorEnabled() throws Exception {
+        smtpServer = FakeSmtpServer.start();
+        EmailNotifier notifier = new EmailNotifier(
+                "127.0.0.1", smtpServer.port(), "root@example.com", "admin@example.com", true, false, true);
+
+        notifier.notifyFinish("full-1", BackupType.FULL, SessionStatus.FINISHED);
+
+        assertFalse(smtpServer.receivedAnyMessage());
+    }
+
+    @Test
+    void notifyFinishSendsMessageOnFailureWhenErrorEnabled() throws Exception {
+        smtpServer = FakeSmtpServer.start();
+        EmailNotifier notifier = new EmailNotifier(
+                "127.0.0.1", smtpServer.port(), "root@example.com", "admin@example.com", true, false, true);
+
+        notifier.notifyFinish("full-1", BackupType.FULL, SessionStatus.FAILED);
+
+        FakeSmtpServer.Message message = smtpServer.awaitMessage();
+        assertTrue(message.data().contains("FAILED"));
+    }
+
+    @Test
+    void throwsIOExceptionWhenRelayIsUnreachable() {
+        EmailNotifier notifier =
+                new EmailNotifier("127.0.0.1", 1, "root@example.com", "admin@example.com", true, true, true);
+
+        assertThrows(IOException.class, () -> notifier.notifyBegin("full-1", BackupType.FULL));
+    }
+
+    /** A minimal single-connection SMTP server that accepts one submission and records it. */
+    private static final class FakeSmtpServer implements AutoCloseable {
+        private final ServerSocket serverSocket;
+        private final CompletableFuture<Message> received = new CompletableFuture<>();
+
+        private FakeSmtpServer(ServerSocket serverSocket) {
+            this.serverSocket = serverSocket;
+        }
+
+        static FakeSmtpServer start() throws IOException {
+            ServerSocket serverSocket = new ServerSocket(0, 0, java.net.InetAddress.getLoopbackAddress());
+            FakeSmtpServer server = new FakeSmtpServer(serverSocket);
+            Thread thread = new Thread(server::acceptOnce, "fake-smtp-server");
+            thread.setDaemon(true);
+            thread.start();
+            return server;
+        }
+
+        int port() {
+            return serverSocket.getLocalPort();
+        }
+
+        Message awaitMessage() throws Exception {
+            return received.get(5, java.util.concurrent.TimeUnit.SECONDS);
+        }
+
+        boolean receivedAnyMessage() {
+            try {
+                received.get(300, java.util.concurrent.TimeUnit.MILLISECONDS);
+                return true;
+            } catch (java.util.concurrent.TimeoutException e) {
+                return false;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+
+        private void acceptOnce() {
+            try (Socket socket = serverSocket.accept();
+                    BufferedReader in = new BufferedReader(
+                            new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII));
+                    OutputStream out = socket.getOutputStream()) {
+                write(out, "220 fake-smtp ready\r\n");
+                String from = null;
+                String to = null;
+                List<String> dataLines = new ArrayList<>();
+                String line;
+                while ((line = in.readLine()) != null) {
+                    if (line.startsWith("EHLO")) {
+                        write(out, "250 ok\r\n");
+                    } else if (line.startsWith("MAIL FROM:")) {
+                        from = line.substring(line.indexOf('<') + 1, line.indexOf('>'));
+                        write(out, "250 ok\r\n");
+                    } else if (line.startsWith("RCPT TO:")) {
+                        to = line.substring(line.indexOf('<') + 1, line.indexOf('>'));
+                        write(out, "250 ok\r\n");
+                    } else if (line.startsWith("DATA")) {
+                        write(out, "354 send it\r\n");
+                        String dataLine;
+                        while ((dataLine = in.readLine()) != null && !dataLine.equals(".")) {
+                            dataLines.add(dataLine);
+                        }
+                        write(out, "250 ok\r\n");
+                        received.complete(new Message(from, to, String.join("\n", dataLines)));
+                    } else if (line.startsWith("QUIT")) {
+                        write(out, "221 bye\r\n");
+                        break;
+                    }
+                }
+            } catch (IOException ignored) {
+                // Best-effort fake server; test assertions will fail on their own if nothing arrived.
+            }
+        }
+
+        private static void write(OutputStream out, String line) throws IOException {
+            out.write(line.getBytes(StandardCharsets.US_ASCII));
+            out.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            serverSocket.close();
+        }
+
+        record Message(String from, String to, String data) {}
+    }
+}

--- a/local/src/test/java/io/zmbackup/local/FileBlocklistTest.java
+++ b/local/src/test/java/io/zmbackup/local/FileBlocklistTest.java
@@ -1,0 +1,57 @@
+package io.zmbackup.local;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FileBlocklistTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void isBlockedMatchesExactLinesFromTheFile() throws IOException {
+        Path blockedListFile = tempDir.resolve("blockedlist.conf");
+        Files.writeString(blockedListFile, "alice@example.com\nbob@example.com\n");
+
+        FileBlocklist blocklist = new FileBlocklist(blockedListFile);
+
+        assertTrue(blocklist.isBlocked("alice@example.com"));
+        assertTrue(blocklist.isBlocked("bob@example.com"));
+        assertFalse(blocklist.isBlocked("carol@example.com"));
+    }
+
+    @Test
+    void ignoresBlankLines() throws IOException {
+        Path blockedListFile = tempDir.resolve("blockedlist.conf");
+        Files.writeString(blockedListFile, "alice@example.com\n\n   \n");
+
+        FileBlocklist blocklist = new FileBlocklist(blockedListFile);
+
+        assertTrue(blocklist.isBlocked("alice@example.com"));
+        assertFalse(blocklist.isBlocked(""));
+    }
+
+    @Test
+    void missingFileBlocksNothing() throws IOException {
+        FileBlocklist blocklist = new FileBlocklist(tempDir.resolve("nonexistent.conf"));
+
+        assertFalse(blocklist.isBlocked("alice@example.com"));
+    }
+
+    @Test
+    void doesNotMatchPartialLines() throws IOException {
+        Path blockedListFile = tempDir.resolve("blockedlist.conf");
+        Files.writeString(blockedListFile, "alice@example.com\n");
+
+        FileBlocklist blocklist = new FileBlocklist(blockedListFile);
+
+        assertFalse(blocklist.isBlocked("alice@example.co"));
+        assertFalse(blocklist.isBlocked("alice"));
+    }
+}

--- a/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
@@ -9,8 +9,11 @@ import com.unboundid.ldap.sdk.LDAPURL;
 import com.unboundid.ldap.sdk.ResultCode;
 import com.unboundid.ldap.sdk.SearchRequest;
 import com.unboundid.ldap.sdk.SearchResult;
+import com.unboundid.ldap.sdk.SearchResultEntry;
 import com.unboundid.ldap.sdk.SearchScope;
 import com.unboundid.ldap.sdk.extensions.StartTLSExtendedRequest;
+import com.unboundid.ldif.LDIFException;
+import com.unboundid.ldif.LDIFReader;
 import com.unboundid.ldif.LDIFWriter;
 import com.unboundid.util.ssl.SSLUtil;
 import com.unboundid.util.ssl.TrustAllTrustManager;
@@ -147,11 +150,52 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
     /**
      * {@inheritDoc}
      *
-     * <p>Not yet implemented.
+     * <p>Mirrors {@code ldap_restore} in the bash tool's {@code ParallelAction.sh}: {@code
+     * ldapdelete -Z -r ...} on the entry's DN (result discarded, exactly as the bash tool does),
+     * followed by {@code ldapadd -Z ...} to re-add it from the LDIF. The DN is read from the LDIF
+     * itself, so {@code type} is not otherwise used here.
      */
     @Override
     public void restore(LdapObjectType type, InputStream source) throws IOException {
-        throw new UnsupportedOperationException("UnboundIdLdapAdapter.restore() is not yet implemented");
+        Entry entry = readEntry(source);
+        try (LDAPConnection connection = connect()) {
+            deleteRecursively(connection, entry.getDN());
+            connection.add(entry);
+        } catch (LDAPException e) {
+            throw new IOException(
+                    "Failed to restore " + entry.getDN() + " to Zimbra LDAP at " + host + ":" + port, e);
+        }
+    }
+
+    private static Entry readEntry(InputStream source) throws IOException {
+        try (LDIFReader ldifReader = new LDIFReader(source)) {
+            Entry entry = ldifReader.readEntry();
+            if (entry == null) {
+                throw new IOException("No LDAP entry found in restore source");
+            }
+            return entry;
+        } catch (LDIFException e) {
+            throw new IOException("Invalid LDIF content in restore source", e);
+        }
+    }
+
+    /**
+     * Best-effort recursive delete of {@code dn} and its children, mirroring {@code ldapdelete
+     * -r}: the bash tool discards this command's result entirely (redirected to {@code
+     * /dev/null}), relying on the following {@code ldapadd} to report any real failure, so
+     * failures here are swallowed the same way.
+     */
+    private static void deleteRecursively(LDAPConnection connection, String dn) {
+        try {
+            SearchResult children =
+                    connection.search(dn, SearchScope.ONE, Filter.createPresenceFilter("objectClass"));
+            for (SearchResultEntry child : children.getSearchEntries()) {
+                deleteRecursively(connection, child.getDN());
+            }
+            connection.delete(dn);
+        } catch (LDAPException ignored) {
+            // Best-effort, exactly like the bash tool's `ldapdelete -r ... > /dev/null 2>&1`.
+        }
     }
 
     private static String domainBaseDn(String domain) {

--- a/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
@@ -167,6 +167,27 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Mirrors {@code domain_restore} in the bash tool's {@code ParallelAction.sh}: {@code
+     * ldapadd -Z ...} only (no preceding delete), treating a {@code ldapadd} "Already exists"
+     * failure as success.
+     */
+    @Override
+    public void restoreDomain(InputStream source) throws IOException {
+        Entry entry = readEntry(source);
+        try (LDAPConnection connection = connect()) {
+            connection.add(entry);
+        } catch (LDAPException e) {
+            if (e.getResultCode() == ResultCode.ENTRY_ALREADY_EXISTS) {
+                return;
+            }
+            throw new IOException(
+                    "Failed to restore domain " + entry.getDN() + " to Zimbra LDAP at " + host + ":" + port, e);
+        }
+    }
+
     private static Entry readEntry(InputStream source) throws IOException {
         try (LDIFReader ldifReader = new LDIFReader(source)) {
             Entry entry = ldifReader.readEntry();

--- a/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
@@ -50,7 +51,10 @@ public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
         this.baseUri = URI.create(baseUrl);
         this.adminUser = Objects.requireNonNull(adminUser, "adminUser must not be null");
         this.adminPassword = Objects.requireNonNull(adminPassword, "adminPassword must not be null");
-        this.httpClient = HttpClient.newHttpClient();
+        // WireMock (used in tests) and most Zimbra REST deployments only speak HTTP/1.1; pinning
+        // the version avoids the client's default h2 upgrade attempt hitting an RST_STREAM/EOF on
+        // unknown-length POST bodies (see restore()).
+        this.httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
     }
 
     /**
@@ -92,19 +96,46 @@ public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
     /**
      * {@inheritDoc}
      *
-     * <p>Not yet implemented.
+     * <p>Issues an HTTP POST of {@code source} against {@code
+     * {baseUrl}/home/{account}/?fmt=tgz&resolve=skip}, mirroring {@code mailbox_restore} in the
+     * bash tool's {@code ParallelAction.sh}: {@code postRestURL '//?fmt=tgz&resolve=skip'
+     * <file>.tgz}. {@code account} is whichever account the caller wants the content restored
+     * into, which may differ from the account it was originally exported from (restore-on-account).
      */
     @Override
     public void restore(String account, InputStream source) throws IOException {
-        throw new UnsupportedOperationException("ZimbraRestMailboxExporter.restore() is not yet implemented");
+        HttpRequest request = HttpRequest.newBuilder(restoreUri(account))
+                .header("Authorization", basicAuthHeader())
+                .POST(BodyPublishers.ofInputStream(() -> source))
+                .build();
+
+        HttpResponse<Void> response;
+        try {
+            response = httpClient.send(request, BodyHandlers.discarding());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while restoring mailbox for " + account, e);
+        }
+
+        if (response.statusCode() / 100 != 2) {
+            throw new IOException("Failed to restore mailbox for " + account + ": HTTP " + response.statusCode());
+        }
     }
 
     private URI exportUri(String account, Instant since) throws IOException {
-        String path = (baseUri.getRawPath() == null ? "" : baseUri.getRawPath()) + "/home/" + account + "/";
         String query = "fmt=tgz&resolve=skip";
         if (since != null) {
             query += "&query=after:\"" + AFTER_DATE_FORMAT.format(since) + "\"";
         }
+        return restUri(account, query);
+    }
+
+    private URI restoreUri(String account) throws IOException {
+        return restUri(account, "fmt=tgz&resolve=skip");
+    }
+
+    private URI restUri(String account, String query) throws IOException {
+        String path = (baseUri.getRawPath() == null ? "" : baseUri.getRawPath()) + "/home/" + account + "/";
         try {
             return new URI(baseUri.getScheme(), baseUri.getAuthority(), path, query, null);
         } catch (URISyntaxException e) {

--- a/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
@@ -364,6 +364,54 @@ class UnboundIdLdapAdapterTest {
     }
 
     @Test
+    void restoreDomainAddsEntryThatDidNotPreviouslyExist() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+        String ldif =
+                "dn: dc=other,dc=com\n"
+                        + "objectClass: zimbraDomain\n"
+                        + "dc: other\n"
+                        + "zimbraDomainName: other.com\n";
+
+        adapter.restoreDomain(new ByteArrayInputStream(ldif.getBytes(StandardCharsets.UTF_8)));
+
+        Entry added = directoryServer.getEntry("dc=other,dc=com");
+        assertEquals("other.com", added.getAttributeValue("zimbraDomainName"));
+    }
+
+    @Test
+    void restoreDomainTreatsAlreadyExistingEntryAsSuccess() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        directoryServer.add(
+                "dc=other,dc=com",
+                new Attribute("objectClass", "zimbraDomain"),
+                new Attribute("dc", "other"),
+                new Attribute("zimbraDomainName", "other.com"));
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+        String ldif =
+                "dn: dc=other,dc=com\n"
+                        + "objectClass: zimbraDomain\n"
+                        + "dc: other\n"
+                        + "zimbraDomainName: other.com\n";
+
+        adapter.restoreDomain(new ByteArrayInputStream(ldif.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void restoreDomainThrowsIOExceptionOnOtherFailures() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+        String ldif = "dn: dc=other,dc=nowhere,dc=missing\nobjectClass: zimbraDomain\ndc: other\n";
+
+        assertThrows(
+                IOException.class,
+                () -> adapter.restoreDomain(new ByteArrayInputStream(ldif.getBytes(StandardCharsets.UTF_8))));
+    }
+
+    @Test
     void restoreWrapsUnreachableServerInIOException() {
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false);
         String ldif = "dn: uid=alice,dc=example,dc=com\nobjectClass: zimbraAccount\nuid: alice\n";

--- a/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
@@ -9,6 +9,7 @@ import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
 import com.unboundid.ldap.listener.InMemoryListenerConfig;
 import com.unboundid.ldap.sdk.Attribute;
 import com.unboundid.ldap.sdk.DN;
+import com.unboundid.ldap.sdk.Entry;
 import com.unboundid.ldap.sdk.LDAPConnection;
 import com.unboundid.util.ObjectPair;
 import com.unboundid.util.ssl.KeyStoreKeyManager;
@@ -18,9 +19,11 @@ import com.unboundid.util.ssl.cert.PublicKeyAlgorithmIdentifier;
 import com.unboundid.util.ssl.cert.SignatureAlgorithmIdentifier;
 import com.unboundid.util.ssl.cert.X509Certificate;
 import io.zmbackup.core.domain.LdapObjectType;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyPair;
@@ -307,14 +310,68 @@ class UnboundIdLdapAdapterTest {
     }
 
     @Test
-    void restoreIsNotYetImplemented() throws Exception {
+    void restoreDeletesExistingEntryAndReAddsFromLdif() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"),
+                new Attribute("description", "stale"));
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+        String ldif =
+                "dn: uid=alice,dc=example,dc=com\n"
+                        + "objectClass: zimbraAccount\n"
+                        + "uid: alice\n"
+                        + "zimbraMailDeliveryAddress: alice@example.com\n"
+                        + "mail: alice@example.com\n"
+                        + "description: restored\n";
+
+        adapter.restore(LdapObjectType.ACCOUNT, new ByteArrayInputStream(ldif.getBytes(StandardCharsets.UTF_8)));
+
+        Entry restored = directoryServer.getEntry("uid=alice,dc=example,dc=com");
+        assertEquals("restored", restored.getAttributeValue("description"));
+    }
+
+    @Test
+    void restoreAddsEntryThatDidNotPreviouslyExist() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+        String ldif =
+                "dn: uid=alice,dc=example,dc=com\n"
+                        + "objectClass: zimbraAccount\n"
+                        + "uid: alice\n"
+                        + "zimbraMailDeliveryAddress: alice@example.com\n";
+
+        adapter.restore(LdapObjectType.ACCOUNT, new ByteArrayInputStream(ldif.getBytes(StandardCharsets.UTF_8)));
+
+        Entry added = directoryServer.getEntry("uid=alice,dc=example,dc=com");
+        assertEquals("alice@example.com", added.getAttributeValue("zimbraMailDeliveryAddress"));
+    }
+
+    @Test
+    void restoreThrowsIOExceptionWhenLdifHasNoEntry() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
                 "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
 
         assertThrows(
-                UnsupportedOperationException.class,
-                () -> adapter.restore(LdapObjectType.ACCOUNT, java.io.InputStream.nullInputStream()));
+                IOException.class,
+                () -> adapter.restore(LdapObjectType.ACCOUNT, new ByteArrayInputStream(new byte[0])));
+    }
+
+    @Test
+    void restoreWrapsUnreachableServerInIOException() {
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false);
+        String ldif = "dn: uid=alice,dc=example,dc=com\nobjectClass: zimbraAccount\nuid: alice\n";
+
+        assertThrows(
+                IOException.class,
+                () -> adapter.restore(
+                        LdapObjectType.ACCOUNT, new ByteArrayInputStream(ldif.getBytes(StandardCharsets.UTF_8))));
     }
 
     private InMemoryDirectoryServer startDirectoryServer(SSLSocketFactory startTlsSocketFactory) throws Exception {

--- a/zimbra/src/test/java/io/zmbackup/zimbra/ZimbraRestMailboxExporterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/ZimbraRestMailboxExporterTest.java
@@ -4,6 +4,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -14,10 +16,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -116,13 +119,49 @@ class ZimbraRestMailboxExporterTest {
     }
 
     @Test
-    void restoreIsNotYetImplemented() {
+    void restorePostsContentToRestoreEndpoint() throws Exception {
+        wireMockServer.stubFor(post(urlEqualTo(EXPORT_PATH + "?fmt=tgz&resolve=skip"))
+                .willReturn(aResponse().withStatus(200)));
+        ZimbraRestMailboxExporter exporter = exporter();
+
+        exporter.restore(ACCOUNT, new ByteArrayInputStream("tgz-content".getBytes(StandardCharsets.UTF_8)));
+
+        wireMockServer.verify(postRequestedFor(urlEqualTo(EXPORT_PATH + "?fmt=tgz&resolve=skip"))
+                .withHeader("Authorization", equalTo(basicAuthHeader()))
+                .withRequestBody(equalTo("tgz-content")));
+    }
+
+    @Test
+    void restorePostsIntoDestinationAccountForRestoreOnAccount() throws Exception {
+        String destination = "bob@example.com";
+        wireMockServer.stubFor(post(urlPathEqualTo("/home/" + destination + "/"))
+                .willReturn(aResponse().withStatus(200)));
+        ZimbraRestMailboxExporter exporter = exporter();
+
+        exporter.restore(destination, new ByteArrayInputStream("tgz-content".getBytes(StandardCharsets.UTF_8)));
+
+        wireMockServer.verify(postRequestedFor(urlPathEqualTo("/home/" + destination + "/")));
+    }
+
+    @Test
+    void restoreThrowsIOExceptionOnNonSuccessStatus() {
+        wireMockServer.stubFor(post(urlPathEqualTo(EXPORT_PATH)).willReturn(aResponse().withStatus(500)));
+        ZimbraRestMailboxExporter exporter = exporter();
+
+        IOException exception = assertThrows(
+                IOException.class,
+                () -> exporter.restore(ACCOUNT, new ByteArrayInputStream("tgz-content".getBytes())));
+        assertTrue(exception.getMessage().contains("500"));
+    }
+
+    @Test
+    void restoreWrapsUnreachableServerInIOException() {
         ZimbraRestMailboxExporter exporter =
                 new ZimbraRestMailboxExporter("http://127.0.0.1:1", ADMIN_USER, ADMIN_PASSWORD);
 
         assertThrows(
-                UnsupportedOperationException.class,
-                () -> exporter.restore(ACCOUNT, InputStream.nullInputStream()));
+                IOException.class,
+                () -> exporter.restore(ACCOUNT, new ByteArrayInputStream("tgz-content".getBytes())));
     }
 
     private ZimbraRestMailboxExporter exporter() {


### PR DESCRIPTION
## Summary

Implements the [Phase 1.6] restore/parallelism/blocklist/notifications delivery from #260, closing #311 through #322:

- **#311** LDAP delete + re-add in `UnboundIdLdapAdapter.restore()`
- **#312** `restoreDomain()`: add-only, treats "Already exists" as success
- **#313** `RestoreService`: `restoreLdap`, `restoreMailbox`, `restoreFull`, `restoreDomain`
- **#314** Restore-on-account: `restoreMailbox(sessionId, accounts, destination)`
- **#315** `BackupService`/`RestoreService` switched to a bounded `ExecutorService` (`Parallel` helper), sized by `backup.maxParallelProcesses`
- **#316** `Blocklist` port + `FileBlocklist`, wired into `BackupService` discovery
- **#317** `Notifier` port + `EmailNotifier` (raw SMTP), wired into `BackupService` begin/finish
- **#318** `zmbackup restore` / `restore ldap` / `restore domain` / `restore mailbox` commands
- **#319** Unit tests for `RestoreService`
- **#320** Integration tests: in-memory LDAP restore + WireMock mailbox POST
- **#321** Unit tests for blocklist filtering
- **#322** Unit tests for parallel execution (`maxParallelProcesses` respected)

Each behavior mirrors its bash-tool counterpart (`RestoreAction.sh`, `NotifyAction.sh`, `ldap_filter`'s blocklist check, `parallel --jobs`), per the existing convention in this codebase.

Per user direction, this is one combined branch/PR for all 12 sub-issues rather than 12 stacked ones, since they're tightly interdependent and each would otherwise need to branch off the previous one's unmerged state.

## Test plan

- [x] `./gradlew build` (all modules, including the cucumber integration suite and shadowJar smoke tests) passes locally
- [x] New unit tests for LDAP restore/domain-restore, `RestoreService`, `Parallel`, `FileBlocklist`, `EmailNotifier`, and the new CLI commands
- [x] New `restore_integration.feature` cucumber scenarios against real (in-memory) LDAP + WireMock adapters
- [ ] Manual validation of a full backup → restore round-trip against a real Zimbra instance (tracked separately as #310/#323, outside this PR's scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zNgbqzB8UFge981tWdQoG