### PR TITLE
Add PID lock to prevent concurrent zmbackup instances

### DIFF
--- a/app/src/main/java/io/zmbackup/app/PidLock.java
+++ b/app/src/main/java/io/zmbackup/app/PidLock.java
@@ -1,0 +1,82 @@
+package io.zmbackup.app;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * An OS-level advisory lock on a {@code zmbackup.pid} file inside the backup work directory,
+ * preventing two zmbackup processes from mutating the same backup store at once.
+ *
+ * <p>This holds a {@link FileLock} for the lifetime of the process rather than writing a bare PID
+ * and grepping {@code ps} for it (the bash tool's {@code checkpid}, which was never actually
+ * wired up): the OS releases a {@link FileLock} automatically if the process dies, so there is no
+ * stale-lock case to detect or clean up.
+ */
+public final class PidLock implements AutoCloseable {
+
+    private static final String LOCK_FILENAME = "zmbackup.pid";
+
+    private final FileChannel channel;
+    private final FileLock lock;
+
+    private PidLock(FileChannel channel, FileLock lock) {
+        this.channel = channel;
+        this.lock = lock;
+    }
+
+    /**
+     * Acquires the lock inside {@code workDir}, writing this process's PID into the lock file.
+     *
+     * @throws AlreadyRunningException if another zmbackup process currently holds the lock
+     */
+    public static PidLock acquire(Path workDir) throws IOException {
+        Path lockFile = workDir.resolve(LOCK_FILENAME);
+        FileChannel channel = FileChannel.open(
+                lockFile, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+        FileLock lock;
+        try {
+            lock = channel.tryLock();
+        } catch (OverlappingFileLockException e) {
+            lock = null;
+        }
+        if (lock == null) {
+            String heldBy = readPid(channel);
+            channel.close();
+            throw new AlreadyRunningException(
+                    "Another zmbackup process (pid " + heldBy + ") is already running against " + workDir);
+        }
+        channel.truncate(0);
+        channel.write(ByteBuffer.wrap(Long.toString(ProcessHandle.current().pid()).getBytes(StandardCharsets.UTF_8)));
+        return new PidLock(channel, lock);
+    }
+
+    private static String readPid(FileChannel channel) throws IOException {
+        channel.position(0);
+        ByteBuffer buffer = ByteBuffer.allocate((int) Math.min(channel.size(), 64));
+        channel.read(buffer);
+        String text = new String(buffer.array(), 0, buffer.position(), StandardCharsets.UTF_8).strip();
+        return text.isEmpty() ? "unknown" : text;
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            lock.release();
+        } finally {
+            channel.close();
+        }
+    }
+
+    /** Thrown by {@link #acquire} when another zmbackup process already holds the lock. */
+    public static final class AlreadyRunningException extends IOException {
+        private AlreadyRunningException(String message) {
+            super(message);
+        }
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/BackupAliasCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupAliasCommand.java
@@ -27,6 +27,9 @@ public final class BackupAliasCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.ALIAS, accounts, null);
+        return LockedExecution.run(
+                context,
+                spec.commandLine().getErr(),
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.ALIAS, accounts, null));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupDistlistCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupDistlistCommand.java
@@ -29,6 +29,10 @@ public final class BackupDistlistCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.DISTRIBUTION_LIST, accounts, null);
+        return LockedExecution.run(
+                context,
+                spec.commandLine().getErr(),
+                () -> BackupRunner.run(
+                        context, spec.commandLine().getOut(), BackupType.DISTRIBUTION_LIST, accounts, null));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupDomainCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupDomainCommand.java
@@ -27,6 +27,9 @@ public final class BackupDomainCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.DOMAIN, domains, null);
+        return LockedExecution.run(
+                context,
+                spec.commandLine().getErr(),
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.DOMAIN, domains, null));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupFullCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupFullCommand.java
@@ -33,6 +33,9 @@ public final class BackupFullCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.FULL, accounts, domain);
+        return LockedExecution.run(
+                context,
+                spec.commandLine().getErr(),
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.FULL, accounts, domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupIncrementalCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupIncrementalCommand.java
@@ -33,6 +33,10 @@ public final class BackupIncrementalCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.INCREMENTAL, accounts, domain);
+        return LockedExecution.run(
+                context,
+                spec.commandLine().getErr(),
+                () -> BackupRunner.run(
+                        context, spec.commandLine().getOut(), BackupType.INCREMENTAL, accounts, domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupLdapCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupLdapCommand.java
@@ -30,6 +30,9 @@ public final class BackupLdapCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.LDAP, accounts, domain);
+        return LockedExecution.run(
+                context,
+                spec.commandLine().getErr(),
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.LDAP, accounts, domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupMailboxCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupMailboxCommand.java
@@ -33,6 +33,9 @@ public final class BackupMailboxCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.MAILBOX, accounts, domain);
+        return LockedExecution.run(
+                context,
+                spec.commandLine().getErr(),
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.MAILBOX, accounts, domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupSignatureCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupSignatureCommand.java
@@ -29,6 +29,9 @@ public final class BackupSignatureCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return BackupRunner.run(context, spec.commandLine().getOut(), BackupType.SIGNATURE, accounts, null);
+        return LockedExecution.run(
+                context,
+                spec.commandLine().getErr(),
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.SIGNATURE, accounts, null));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/DeleteCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/DeleteCommand.java
@@ -26,13 +26,16 @@ public final class DeleteCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         AppContext context = AppContext.fromConfigFile(parent.configFile());
         PrintWriter out = spec.commandLine().getOut();
+        PrintWriter err = spec.commandLine().getErr();
 
-        out.println("Removing session " + sessionId + " - please wait.");
-        if (context.sessionService().deleteSession(sessionId)) {
-            out.println("Backup session " + sessionId + " removed.");
-            return 0;
-        }
-        spec.commandLine().getErr().println("Session " + sessionId + " not found in database - ignoring.");
-        return 1;
+        return LockedExecution.run(context, err, () -> {
+            out.println("Removing session " + sessionId + " - please wait.");
+            if (context.sessionService().deleteSession(sessionId)) {
+                out.println("Backup session " + sessionId + " removed.");
+                return 0;
+            }
+            err.println("Session " + sessionId + " not found in database - ignoring.");
+            return 1;
+        });
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/HousekeepCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/HousekeepCommand.java
@@ -30,19 +30,21 @@ public final class HousekeepCommand implements Callable<Integer> {
         PrintWriter out = spec.commandLine().getOut();
         HousekeepService housekeepService = context.housekeepService();
 
-        out.println("Removing old backup sessions - please wait.");
-        List<BackupSession> rotated =
-                housekeepService.rotateOldSessions(context.config().backup().rotateDays());
-        for (BackupSession session : rotated) {
-            out.println("Backup session " + session.sessionId() + " removed.");
-        }
+        return LockedExecution.run(context, spec.commandLine().getErr(), () -> {
+            out.println("Removing old backup sessions - please wait.");
+            List<BackupSession> rotated =
+                    housekeepService.rotateOldSessions(context.config().backup().rotateDays());
+            for (BackupSession session : rotated) {
+                out.println("Backup session " + session.sessionId() + " removed.");
+            }
 
-        out.println("Removing empty backup sessions - please wait.");
-        List<BackupSession> emptied = housekeepService.cleanEmpty();
-        for (BackupSession session : emptied) {
-            out.println("Backup session " + session.sessionId() + " removed.");
-        }
+            out.println("Removing empty backup sessions - please wait.");
+            List<BackupSession> emptied = housekeepService.cleanEmpty();
+            for (BackupSession session : emptied) {
+                out.println("Backup session " + session.sessionId() + " removed.");
+            }
 
-        return 0;
+            return 0;
+        });
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/LockedExecution.java
+++ b/app/src/main/java/io/zmbackup/app/cli/LockedExecution.java
@@ -1,0 +1,26 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.app.PidLock;
+import java.io.PrintWriter;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+/**
+ * Wraps a mutating subcommand's body in a {@link PidLock} on the backup work directory, so two
+ * zmbackup processes can never back up, restore, delete, or housekeep the same store at once.
+ */
+final class LockedExecution {
+
+    private LockedExecution() {}
+
+    /** Runs {@code body} while holding the lock, or prints an error and returns exit code 4 if it's already held. */
+    static Integer run(AppContext context, PrintWriter err, Callable<Integer> body) throws Exception {
+        try (PidLock lock = PidLock.acquire(context.config().backup().workDir())) {
+            return body.call();
+        } catch (PidLock.AlreadyRunningException e) {
+            err.println(e.getMessage());
+            return CommandLine.ExitCode.SOFTWARE;
+        }
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
@@ -62,9 +62,11 @@ public final class RestoreCommand implements Callable<Integer> {
 
         AppContext context = AppContext.fromConfigFile(parent.configFile());
         PrintWriter out = spec.commandLine().getOut();
-        RestoreResult result = destination != null
-                ? context.restoreService().restoreMailbox(sessionId, accounts, destination)
-                : context.restoreService().restoreFull(sessionId, accounts);
-        return RestoreRunner.printResult(out, sessionId, result);
+        return LockedExecution.run(context, err, () -> {
+            RestoreResult result = destination != null
+                    ? context.restoreService().restoreMailbox(sessionId, accounts, destination)
+                    : context.restoreService().restoreFull(sessionId, accounts);
+            return RestoreRunner.printResult(out, sessionId, result);
+        });
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreDomainCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreDomainCommand.java
@@ -30,7 +30,9 @@ public final class RestoreDomainCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        RestoreResult result = context.restoreService().restoreDomain(sessionId, domains);
-        return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
+        return LockedExecution.run(context, spec.commandLine().getErr(), () -> {
+            RestoreResult result = context.restoreService().restoreDomain(sessionId, domains);
+            return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
+        });
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreLdapCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreLdapCommand.java
@@ -30,7 +30,9 @@ public final class RestoreLdapCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        RestoreResult result = context.restoreService().restoreLdap(sessionId, accounts);
-        return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
+        return LockedExecution.run(context, spec.commandLine().getErr(), () -> {
+            RestoreResult result = context.restoreService().restoreLdap(sessionId, accounts);
+            return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
+        });
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreMailboxCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreMailboxCommand.java
@@ -43,7 +43,9 @@ public final class RestoreMailboxCommand implements Callable<Integer> {
         }
 
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        RestoreResult result = context.restoreService().restoreMailbox(sessionId, accounts, destination);
-        return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
+        return LockedExecution.run(context, err, () -> {
+            RestoreResult result = context.restoreService().restoreMailbox(sessionId, accounts, destination);
+            return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
+        });
     }
 }

--- a/app/src/test/java/io/zmbackup/app/PidLockTest.java
+++ b/app/src/test/java/io/zmbackup/app/PidLockTest.java
@@ -1,0 +1,45 @@
+package io.zmbackup.app;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PidLockTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void acquireWritesTheCurrentProcessPidToTheLockFile() throws Exception {
+        try (PidLock lock = PidLock.acquire(tempDir)) {
+            String content = Files.readString(tempDir.resolve("zmbackup.pid")).strip();
+            assertEquals(Long.toString(ProcessHandle.current().pid()), content);
+        }
+    }
+
+    @Test
+    void secondAcquireWhileTheFirstIsHeldFailsWithTheHoldingPid() throws Exception {
+        try (PidLock first = PidLock.acquire(tempDir)) {
+            PidLock.AlreadyRunningException e =
+                    assertThrows(PidLock.AlreadyRunningException.class, () -> PidLock.acquire(tempDir));
+            assertTrue(e.getMessage().contains(Long.toString(ProcessHandle.current().pid())));
+        }
+    }
+
+    @Test
+    void acquireSucceedsAgainAfterTheFirstLockIsClosed() throws Exception {
+        try (PidLock first = PidLock.acquire(tempDir)) {
+            // held
+        }
+
+        try (PidLock second = PidLock.acquire(tempDir)) {
+            String content = Files.readString(tempDir.resolve("zmbackup.pid")).strip();
+            assertEquals(Long.toString(ProcessHandle.current().pid()), content);
+        }
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cli/HousekeepCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/HousekeepCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.zmbackup.app.AppContext;
+import io.zmbackup.app.PidLock;
 import io.zmbackup.core.domain.BackupAccountRecord;
 import io.zmbackup.core.domain.BackupSession;
 import io.zmbackup.core.domain.BackupType;
@@ -62,6 +63,23 @@ class HousekeepCommandTest {
         assertTrue(context.metadataStore().findSession("ldap-old").isEmpty());
         assertTrue(context.metadataStore().findSession("ldap-empty").isEmpty());
         assertTrue(context.metadataStore().findSession("ldap-recent").isPresent());
+    }
+
+    @Test
+    void failsWithoutRunningWhenAnotherProcessHoldsTheLock() throws Exception {
+        Path configFile = writeConfig(7);
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        CommandLine cmd = new CommandLine(new Main());
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(err));
+
+        try (PidLock lock = PidLock.acquire(tempDir)) {
+            int exitCode = cmd.execute("--config", configFile.toString(), "housekeep");
+
+            assertEquals(CommandLine.ExitCode.SOFTWARE, exitCode);
+            assertTrue(err.toString().contains("already running"));
+        }
     }
 
     private static BackupSession session(String sessionId, Instant completedAt) {


### PR DESCRIPTION
## Summary
- The bash tool's `checkpid` function existed in `MiscAction.sh` but was never actually called anywhere, so nothing stopped two `zmbackup` invocations from mutating the same work directory at the same time.
- Adds `PidLock`: an OS-level `FileLock` on `<workDir>/zmbackup.pid`, held for the process's lifetime. Unlike the old PID-in-a-file-plus-`ps`-grep approach, the OS releases the lock automatically if the process dies, so there's no stale-lock case to special-case.
- Wired into every mutating subcommand — `backup <full/incremental/mailbox/ldap/alias/distlist/signature/domain>`, `restore` (+ its `ldap`/`mailbox`/`domain` subcommands), `delete`, and `housekeep` — via a small `LockedExecution.run()` helper. `list` and `accounts list` stay unlocked since they're read-only.
- If the lock is already held, the command prints `Another zmbackup process (pid <n>) is already running against <workDir>` and exits 1 instead of touching anything.

## Test plan
- [x] `./gradlew test` (all modules) passes
- [x] New `PidLockTest`: acquire writes the PID, a second acquire while held fails with the holder's PID in the message, a lock is reusable after being closed
- [x] New `HousekeepCommandTest` case: running `housekeep` while another process holds the lock fails with exit code 1 and the expected error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zNgbqzB8UFge981tWdQoG