### PR TITLE
Add install-java.sh to set up the environment for zmbackup 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,28 @@ $ zmbackup -v
   zmbackup version: 1.2.9
 ```
 
+### Installation (Java version)
+
+Zmbackup 2.0, the Java rewrite, has its own installer, **install-java.sh**, that prepares the
+environment the same way **install.sh** does for the bash tool: it checks for (and, if missing,
+installs) a Java 21 JDK, builds `zmbackup.jar` with the bundled Gradle wrapper, then installs the
+jar, a thin `zmbackup` launcher, `zmbackup.yaml`, the blocked list and a cron file. It does not
+require GNU Parallel, ldap-utils or the sqlite3 CLI - the Java tool talks to LDAP and SQLite
+directly, so those are only needed for the bash tool.
+
+```
+# cd zmbackup
+# ./install-java.sh
+# su - zimbra
+$ zmbackup --version
+  zmbackup version: 1.2.9
+```
+
+Building the jar needs internet access on first run (to download Gradle and the project's Maven
+dependencies). Run `./install-java.sh --remove` to uninstall, or `./install-java.sh --force-upgrade`
+to rebuild and redeploy the jar without touching your existing configuration. See
+`./install-java.sh --help` for details.
+
 ## Usage
 
 To check all the options available to Zmbackup, just execute **zmbackup -h** or **zmbackup --help**. This will return for you a list with all the options, what each one of them does, and the syntax.

--- a/install-java.sh
+++ b/install-java.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+################################################################################
+# install-java - Install script to help you install the Java build of zmbackup
+#                (zmbackup 2.0) in your server, the same way install.sh does
+#                for the bash build: it prepares the whole environment (Java
+#                runtime, jar, launcher, config, blocked list, cron) for you.
+#
+################################################################################
+# INSTALL MAIN CODE
+################################################################################
+
+#
+#  Help code
+################################################################################
+if [[ $1 == "--help" ]] || [[ $1 == "-h" ]]; then
+  source installScriptJava/vars.sh
+  source installScriptJava/help.sh
+  show_help_java
+  exit "$ERR_OK"
+fi
+
+################################################################################
+# LOADING INSTALL LIBRARIES
+################################################################################
+echo "Loading installer - PLEASE WAIT"
+# Reused as-is from the bash installer: root/OS/upgrade detection (check_env)
+# and the license banner (contract) and blocked-list generator (blocklist_gen)
+# don't depend on which language zmbackup itself is written in.
+source installScript/check.sh
+source installScript/menu.sh
+source installScript/deploy.sh
+# Java-specific: paths, Java runtime check, dependency install, jar build,
+# prompts/summary and deploy/uninstall for the Java build.
+source installScriptJava/vars.sh
+source installScriptJava/check.sh
+source installScriptJava/depDownload.sh
+source installScriptJava/build.sh
+source installScriptJava/deploy.sh
+source installScriptJava/menu.sh
+source installScriptJava/help.sh
+
+#
+#  Checking your environment
+################################################################################
+check_env "$1"
+check_java_runtime
+
+#
+#  Uninstall code
+################################################################################
+if [[ $1 == "--remove" ]] || [[ $1 == "-r" ]]; then
+  if [[ $UNINSTALL = "Y" ]]; then
+    uninstall_java
+    echo "Uninstall completed. Thanks for using Zmbackup. Have a nice day!"
+    exit "$ERR_OK"
+  else
+    echo "Zmbackup (Java) is not installed - nothing to do"
+    exit "$ERR_OK"
+  fi
+fi
+
+#
+# Install & Upgrade code
+################################################################################
+contract
+if [[ $NEED_JAVA == "Y" ]]; then
+  if [[ $SO = "ubuntu" ]]; then
+    install_java_ubuntu
+  else
+    install_java_redhat
+  fi
+fi
+
+if [[ $UPGRADE = "Y" ]]; then
+  build_jar
+  deploy_upgrade_java
+else
+  set_values_java
+  check_config_java
+  build_jar
+  deploy_new_java
+fi
+
+# We're done!
+read -r -p "Install completed. Do you want to display the README file? (Y/n)" tmp
+case "$tmp" in
+	y|Y|Yes|"") less "$MYDIR"/README.md;;
+	*) echo "Done!";;
+esac
+
+clear
+exit "$ERR_OK"

--- a/installScriptJava/build.sh
+++ b/installScriptJava/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+################################################################################
+
+################################################################################
+# build_jar: Build the self-contained zmbackup.jar with the Gradle wrapper.
+# Requires a Java JDK on PATH (see check_java_runtime/depDownload.sh) and, on
+# first run, internet access to download Gradle and the project's Maven
+# dependencies.
+################################################################################
+function build_jar() {
+  echo "Building ${ZMBKP_JAR_NAME} - this can take a few minutes on first run."
+  ( cd "$MYDIR" && ./gradlew :app:shadowJar -q )
+  BASHERRCODE=$?
+
+  JAR_PATH="$MYDIR/app/build/libs/$ZMBKP_JAR_NAME"
+
+  if [[ $BASHERRCODE -ne 0 ]]; then
+    echo "[FAIL] - Gradle build failed"
+    echo "Please check the output above, fix the issue, and run the installer again."
+    echo "You can also try building it manually with: ./gradlew :app:shadowJar"
+    exit "$ERR_BUILD_FAILED"
+  fi
+
+  if [[ ! -f "$JAR_PATH" ]]; then
+    echo "[FAIL] - Build succeeded but $JAR_PATH was not produced"
+    exit "$ERR_BUILD_FAILED"
+  fi
+
+  echo "Build completed: $JAR_PATH"
+}

--- a/installScriptJava/check.sh
+++ b/installScriptJava/check.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+################################################################################
+# check_env_java, check_config_java live in check.sh/menu.sh of the bash
+# installer and are reused as-is (see install-java.sh) - root privileges, OS
+# detection, and upgrade/uninstall detection do not depend on which language
+# zmbackup itself is written in.
+################################################################################
+
+################################################################################
+# check_java_runtime: Check if a Java 21+ runtime is available. Sets NEED_JAVA
+# to Y or N so depDownload.sh knows whether to install one.
+################################################################################
+function check_java_runtime() {
+  printf "  Java %s Runtime...	          " "$JAVA_MIN_VERSION"
+  if ! command -v java > /dev/null 2>&1; then
+    printf "[NOT FOUND]\n"
+    NEED_JAVA="Y"
+    return
+  fi
+
+  JAVA_VER_OUTPUT=$(java -version 2>&1)
+  JAVA_MAJOR=$(echo "$JAVA_VER_OUTPUT" | grep -oE '"[0-9]+' | head -1 | tr -d '"')
+
+  if [[ -z "$JAVA_MAJOR" ]]; then
+    printf "[UNKNOWN VERSION]\n"
+    NEED_JAVA="Y"
+  elif [[ "$JAVA_MAJOR" -lt "$JAVA_MIN_VERSION" ]]; then
+    printf "[TOO OLD - %s]\n" "$JAVA_MAJOR"
+    NEED_JAVA="Y"
+  else
+    printf "[OK - %s]\n" "$JAVA_MAJOR"
+    NEED_JAVA="N"
+  fi
+}

--- a/installScriptJava/depDownload.sh
+++ b/installScriptJava/depDownload.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+################################################################################
+
+################################################################################
+# install_java_ubuntu: Install a Java 21 JDK on Ubuntu/Debian
+################################################################################
+function install_java_ubuntu() {
+  echo "Installing Java $JAVA_MIN_VERSION JDK. Please wait..."
+  apt update > /dev/null 2>&1
+  apt install -y "openjdk-${JAVA_MIN_VERSION}-jdk" > /dev/null 2>&1
+  BASHERRCODE=$?
+  if [[ $BASHERRCODE -eq 0 ]]; then
+    echo "Java $JAVA_MIN_VERSION JDK installed with success!"
+  else
+    echo "Java $JAVA_MIN_VERSION JDK wasn't installed in your server"
+    echo "Please check if you have connection with the internet and apt is"
+    echo "working and try again."
+    echo "Or you can try manual execute the command:"
+    echo "apt update && apt install -y openjdk-${JAVA_MIN_VERSION}-jdk"
+    exit "$ERR_DEPNOTFOUND"
+  fi
+}
+
+################################################################################
+# install_java_redhat: Install a Java 21 JDK on Red Hat, CentOS and Rocky
+################################################################################
+function install_java_redhat() {
+  echo "Installing Java $JAVA_MIN_VERSION JDK. Please wait..."
+  yum install -y "java-${JAVA_MIN_VERSION}-openjdk-devel" > /dev/null 2>&1
+  BASHERRCODE=$?
+  if [[ $BASHERRCODE -eq 0 ]]; then
+    echo "Java $JAVA_MIN_VERSION JDK installed with success!"
+  else
+    echo "Java $JAVA_MIN_VERSION JDK wasn't installed in your server"
+    echo "Please check if you have connection with the internet and yum is"
+    echo "working and try again."
+    echo "Or you can try manual execute the command:"
+    echo "yum install -y java-${JAVA_MIN_VERSION}-openjdk-devel"
+    exit "$ERR_DEPNOTFOUND"
+  fi
+}

--- a/installScriptJava/deploy.sh
+++ b/installScriptJava/deploy.sh
@@ -28,13 +28,17 @@ function deploy_new_java() {
 
   # Thin launcher + jar - paths are fixed by app/src/main/scripts/zmbackup and
   # YamlConfigLoader.DEFAULT_CONFIG_PATH, so they must land exactly here.
-  install -o root -m 755 "$MYDIR"/app/src/main/scripts/zmbackup "$ZMBKP_SRC"
-  install -o root -g "$OSE_USER" -m 750 "$MYDIR"/app/build/libs/"$ZMBKP_JAR_NAME" "$ZMBKP_LIB"
+  # Owned by OSE_USER rather than root, matching the bash tool's own
+  # project/zmbackup and project/lib install (install.sh always runs as
+  # root, so this is just about who owns the files afterward, not who can
+  # deploy them).
+  install -o "$OSE_USER" -m 755 "$MYDIR"/app/src/main/scripts/zmbackup "$ZMBKP_SRC"
+  install -o "$OSE_USER" -m 750 "$MYDIR"/app/build/libs/"$ZMBKP_JAR_NAME" "$ZMBKP_LIB"
 
   # Config + blocked list + cron
   install --backup=numbered -o "$OSE_USER" -m 600 "$MYDIR"/project/config/zmbackup.yaml "$ZMBKP_CONF"
   install --backup=numbered -o "$OSE_USER" -m 600 "$MYDIR"/project/config/blockedlist.conf "$ZMBKP_CONF"
-  install --backup=numbered -o root -m 600 "$MYDIR"/project/config/zmbackup-java.cron "$ZMBKP_CRON_FILE"
+  install --backup=numbered -o "$OSE_USER" -m 600 "$MYDIR"/project/config/zmbackup-java.cron "$ZMBKP_CRON_FILE"
 
   # Including custom settings
   sed -i "s|{OSE_DEFAULT_BKP_DIR}|${OSE_DEFAULT_BKP_DIR}|g" "$ZMBKP_CONF"/zmbackup.yaml
@@ -73,8 +77,8 @@ function deploy_upgrade_java() {
 
   test -d "$ZMBKP_SRC" || mkdir -p "$ZMBKP_SRC"
   test -d "$ZMBKP_LIB" || mkdir -p "$ZMBKP_LIB"
-  install -o root -m 755 "$MYDIR"/app/src/main/scripts/zmbackup "$ZMBKP_SRC"
-  install -o root -g "$OSE_USER" -m 750 "$MYDIR"/app/build/libs/"$ZMBKP_JAR_NAME" "$ZMBKP_LIB"
+  install -o "$OSE_USER" -m 755 "$MYDIR"/app/src/main/scripts/zmbackup "$ZMBKP_SRC"
+  install -o "$OSE_USER" -m 750 "$MYDIR"/app/build/libs/"$ZMBKP_JAR_NAME" "$ZMBKP_LIB"
 
   echo "Upgrade completed."
 }

--- a/installScriptJava/deploy.sh
+++ b/installScriptJava/deploy.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+################################################################################
+# blocklist_gen (shared with the bash tool - same accounts, same file format)
+# is reused as-is from installScript/deploy.sh; see install-java.sh, which
+# sources both files.
+################################################################################
+
+################################################################################
+# deploy_new_java: Deploy a new install of the Java build of Zmbackup
+################################################################################
+function deploy_new_java() {
+  echo "Installing... Please wait while we make some changes."
+
+  mkdir -p "$OSE_DEFAULT_BKP_DIR" > /dev/null 2>&1
+  BASHERRCODE=$?
+  if [[ $BASHERRCODE -ne 0 ]]; then
+    echo "[FAIL] - Can't create the directory"
+    echo "For some reason Zmbackup can't create the folder $OSE_DEFAULT_BKP_DIR."
+    echo "Maybe you are using a NFS and the permissions are wrong?"
+    echo "Please check what happened and try again."
+    exit "$ERR_DEPNOTFOUND"
+  fi
+  chown -R "$OSE_USER"."$OSE_USER" "$OSE_DEFAULT_BKP_DIR" > /dev/null 2>&1
+
+  test -d "$ZMBKP_CONF" || mkdir -p "$ZMBKP_CONF"
+  test -d "$ZMBKP_SRC" || mkdir -p "$ZMBKP_SRC"
+  test -d "$ZMBKP_LIB" || mkdir -p "$ZMBKP_LIB"
+
+  # Thin launcher + jar - paths are fixed by app/src/main/scripts/zmbackup and
+  # YamlConfigLoader.DEFAULT_CONFIG_PATH, so they must land exactly here.
+  install -o root -m 755 "$MYDIR"/app/src/main/scripts/zmbackup "$ZMBKP_SRC"
+  install -o root -g "$OSE_USER" -m 750 "$MYDIR"/app/build/libs/"$ZMBKP_JAR_NAME" "$ZMBKP_LIB"
+
+  # Config + blocked list + cron
+  install --backup=numbered -o "$OSE_USER" -m 600 "$MYDIR"/project/config/zmbackup.yaml "$ZMBKP_CONF"
+  install --backup=numbered -o "$OSE_USER" -m 600 "$MYDIR"/project/config/blockedlist.conf "$ZMBKP_CONF"
+  install --backup=numbered -o root -m 600 "$MYDIR"/project/config/zmbackup-java.cron "$ZMBKP_CRON_FILE"
+
+  # Including custom settings
+  sed -i "s|{OSE_DEFAULT_BKP_DIR}|${OSE_DEFAULT_BKP_DIR}|g" "$ZMBKP_CONF"/zmbackup.yaml
+  sed -i "s|{ZMBKP_MAIL_ALERT}|${ZMBKP_MAIL_ALERT}|g" "$ZMBKP_CONF"/zmbackup.yaml
+  sed -i "s|{ZMBKP_MAIL_SENDER}|${ZMBKP_MAIL_SENDER}|g" "$ZMBKP_CONF"/zmbackup.yaml
+  # IPv6 addresses must be wrapped in brackets in URLs (RFC 3986)
+  if [[ "$OSE_INSTALL_ADDRESS" == *:* ]]; then
+    LDAP_ADDRESS="[$OSE_INSTALL_ADDRESS]"
+  else
+    LDAP_ADDRESS="$OSE_INSTALL_ADDRESS"
+  fi
+  sed -i "s|{OSE_INSTALL_ADDRESS}|${LDAP_ADDRESS}|g" "$ZMBKP_CONF"/zmbackup.yaml
+  sed -i "s|{OSE_INSTALL_LDAPPASS}|${OSE_INSTALL_LDAPPASS}|g" "$ZMBKP_CONF"/zmbackup.yaml
+  sed -i "s|{OSE_USER}|${OSE_USER}|g" "$ZMBKP_CONF"/zmbackup.yaml
+  sed -i "s|{OSE_INSTALL_DIR}|${OSE_INSTALL_DIR}|g" "$ZMBKP_CONF"/zmbackup.yaml
+  sed -i "s|{ZMBKP_CONF}|${ZMBKP_CONF}|g" "$ZMBKP_CONF"/zmbackup.yaml
+  sed -i "s|{MAX_PARALLEL_PROCESS}|${MAX_PARALLEL_PROCESS}|g" "$ZMBKP_CONF"/zmbackup.yaml
+  sed -i "s|{ROTATE_TIME}|${ROTATE_TIME}|g" "$ZMBKP_CONF"/zmbackup.yaml
+  sed -i "s|{LOCK_BACKUP}|${LOCK_BACKUP}|g" "$ZMBKP_CONF"/zmbackup.yaml
+
+  sed -i "s|{OSE_USER}|${OSE_USER}|g" "$ZMBKP_CRON_FILE"
+
+  chown -R "$OSE_USER". "$ZMBKP_CONF"
+  chmod 600 "$ZMBKP_CONF"/zmbackup.yaml
+
+  # Generate Zmbackup's blocked list (shared logic with the bash installer)
+  blocklist_gen
+}
+
+################################################################################
+# deploy_upgrade_java: Rebuild and redeploy the jar + launcher, keeping the
+# existing zmbackup.yaml/blockedlist.conf/cron untouched.
+################################################################################
+function deploy_upgrade_java() {
+  echo "Upgrading... Please wait while we make some changes."
+
+  test -d "$ZMBKP_SRC" || mkdir -p "$ZMBKP_SRC"
+  test -d "$ZMBKP_LIB" || mkdir -p "$ZMBKP_LIB"
+  install -o root -m 755 "$MYDIR"/app/src/main/scripts/zmbackup "$ZMBKP_SRC"
+  install -o root -g "$OSE_USER" -m 750 "$MYDIR"/app/build/libs/"$ZMBKP_JAR_NAME" "$ZMBKP_LIB"
+
+  echo "Upgrade completed."
+}
+
+################################################################################
+# uninstall_java: Remove the Java build of Zmbackup and all files related
+################################################################################
+function uninstall_java() {
+  echo "Removing... Please wait while we make some changes."
+
+  rm -f "$ZMBKP_SRC"/zmbackup
+  rm -rf "$ZMBKP_LIB"
+  rm -f "$ZMBKP_CRON_FILE"
+
+  WORKDIR=""
+  if [[ -f "$ZMBKP_CONF"/zmbackup.yaml ]]; then
+    WORKDIR=$(grep "workDir:" "$ZMBKP_CONF"/zmbackup.yaml | head -1 | awk '{print $2}')
+  fi
+
+  rm -rf "$ZMBKP_CONF"
+
+  printf "Preserve Backup Storage?[n/Y]"
+  read -r OPT
+  if [[ $OPT == 'N' || $OPT == 'n' ]] && [[ -n "$WORKDIR" ]]; then
+    echo "Removing backup storage..."
+    rm -rf "${WORKDIR:?}"/*
+  fi
+}

--- a/installScriptJava/help.sh
+++ b/installScriptJava/help.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+################################################################################
+# Command Help Option - Java installer
+################################################################################
+
+################################################################################
+# show_help_java: It will show a quick help about each command from
+# install-java.sh
+################################################################################
+function show_help_java (){
+  printf "usage: install-java.sh [options]"
+
+  printf "\n\nThis installs the Java build of zmbackup (2.0). It builds zmbackup.jar with"
+  printf "\nthe bundled Gradle wrapper (needs a Java %s JDK - installed automatically if" "$JAVA_MIN_VERSION"
+  printf "\nmissing - and internet access on first run), then installs it and a thin"
+  printf "\nlauncher, config, blocked list and cron file the same way install.sh does"
+  printf "\nfor the bash build."
+
+  printf "\n\nOptions:\n"
+
+  printf "\n -r,  --remove       : Uninstall the Java build of Zmbackup and remove all the files"
+  printf "\n --force-upgrade     : Force install-java.sh to rebuild and upgrade your installation - does not remove the configuration files."
+  printf "\n -h,  --help         : Show this help"
+
+  printf "\n\n\n"
+}

--- a/installScriptJava/menu.sh
+++ b/installScriptJava/menu.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+################################################################################
+# contract() (the license banner) is reused as-is from installScript/menu.sh -
+# see install-java.sh, which sources both files.
+################################################################################
+
+################################################################################
+# set_values_java: Set all the variables for the Java build of Zmbackup
+################################################################################
+function set_values_java() {
+  echo "##################################################################################"
+  echo "#                                                                                #"
+  echo "# The follow messages will ask you about some configurations for Zmbackup run in #"
+  echo "# your server. Please answer each one of then or press ENTER to assume the       #"
+  echo "# default value.                                                                 #"
+  echo "#                                                                                #"
+  echo "##################################################################################"
+  echo -e "\n"
+
+  # Inform Zimbra's default user
+  printf "Inform Zimbra's default user - DEFAULT [%s]:" "$OSE_USER"
+  read -r TMP
+  OSE_USER=${TMP:-$OSE_USER}
+
+  # Inform Zimbra's default install path
+  printf "\nInform Zimbra's default install path - DEFAULT [%s]:" "$OSE_INSTALL_DIR"
+  read -r TMP
+  OSE_INSTALL_DIR=${TMP:-$OSE_INSTALL_DIR}
+
+  # Inform Zmbackup's backup store
+  printf "\nInform the path Zmbackup will use to store - DEFAULT [%s]:" "$OSE_DEFAULT_BKP_DIR"
+  read -r TMP
+  OSE_DEFAULT_BKP_DIR=${TMP:-$OSE_DEFAULT_BKP_DIR}
+
+  # Configure mail alert recipient
+  printf "\nInform the account to receive all Zmbackup's alerts - DEFAULT [%s]:" "$ZMBKP_MAIL_ALERT"
+  read -r TMP
+  ZMBKP_MAIL_ALERT=${TMP:-$ZMBKP_MAIL_ALERT}
+
+  # Configure mail alert sender
+  printf "\nInform the account Zmbackup should send alerts from - DEFAULT [%s]:" "$ZMBKP_MAIL_SENDER"
+  read -r TMP
+  ZMBKP_MAIL_SENDER=${TMP:-$ZMBKP_MAIL_SENDER}
+
+  # Configure parallelism
+  printf "\nInform Zmbackup's number of parallel workers - DEFAULT [%s]:" "$MAX_PARALLEL_PROCESS"
+  read -r TMP
+  MAX_PARALLEL_PROCESS=${TMP:-$MAX_PARALLEL_PROCESS}
+
+  # Configure rotation
+  printf "\nInform the number of days Zmbackup should store the backups - DEFAULT [%s]:" "$ROTATE_TIME"
+  read -r TMP
+  ROTATE_TIME=${TMP:-$ROTATE_TIME}
+
+  # Configure lock
+  printf "\nZmbackup should limit backups for one per day? - DEFAULT [%s]:" "$LOCK_BACKUP"
+  read -r TMP
+  LOCK_BACKUP=${TMP:-$LOCK_BACKUP}
+
+  echo -e "\n\n"
+  echo "##################################################################################"
+  echo "#                                                                                #"
+  echo "#                            CONFIGURATION COMPLETED                             #"
+  echo "#                                                                                #"
+  echo "##################################################################################"
+}
+
+################################################################################
+# check_config_java: Check the environment for other configurations
+################################################################################
+function check_config_java() {
+  echo ""
+  echo "Here is a Summary of your settings:"
+  echo ""
+  echo "Zimbra User: $OSE_USER"
+  echo "Zimbra IP Address: $OSE_INSTALL_ADDRESS"
+  echo "Zimbra LDAP/Admin Password: $OSE_INSTALL_LDAPPASS"
+  echo "Zimbra Install Directory: $OSE_INSTALL_DIR"
+  echo "Zimbra Backup Directory: $OSE_DEFAULT_BKP_DIR"
+  echo "Zmbackup Launcher: $ZMBKP_SRC/zmbackup"
+  echo "Zmbackup Jar: $ZMBKP_LIB/$ZMBKP_JAR_NAME"
+  echo "Zmbackup Settings Directory: $ZMBKP_CONF"
+  echo "Zmbackup Backups Days Max: $ROTATE_TIME"
+  echo "Zmbackup Number of Parallel Workers: $MAX_PARALLEL_PROCESS"
+  echo "Zmbackup Backup Lock: $LOCK_BACKUP"
+  echo "Zmbackup Session Storage: SQLite3 ($OSE_DEFAULT_BKP_DIR/sessions.sqlite3)"
+  echo ""
+  echo "Press ENTER to continue or CTRL+C to cancel."
+  read -r
+}

--- a/installScriptJava/vars.sh
+++ b/installScriptJava/vars.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+################################################################################
+# SET INTERNAL VARIABLES - Java installer
+################################################################################
+
+# Exit codes - shared with the bash installer's numbering where they overlap
+ERR_OK="0"                  # No error (normal exit)
+ERR_NOROOT="2"               # Running without root privileges
+ERR_DEPNOTFOUND="3"          # Missing dependency
+ERR_NO_CONNECTION="4"        # Missing connection to install packages
+ERR_BUILD_FAILED="6"         # Gradle build of the jar failed
+
+# JAVA ZMBACKUP INSTALLATION PATH
+# These match the paths already hard coded in app/src/main/scripts/zmbackup (the thin
+# launcher) and YamlConfigLoader.DEFAULT_CONFIG_PATH - they are not free to change here.
+MYDIR=`dirname $0`                       # The directory where the install script is
+ZMBKP_SRC="/usr/local/bin"               # The thin "zmbackup" launcher goes here
+ZMBKP_CONF="/etc/zmbackup"               # The zmbackup.yaml/blockedlist directory
+ZMBKP_LIB="/usr/local/lib/zmbackup"      # Where zmbackup.jar is installed
+ZMBKP_JAR_NAME="zmbackup.jar"            # Must match app/build.gradle.kts shadowJar name
+ZMBKP_CRON_FILE="/etc/cron.d/zmbackup"   # Same schedule file the bash tool uses
+
+# JAVA RUNTIME REQUIREMENTS
+JAVA_MIN_VERSION="21"
+
+# ZIMBRA DEFAULT INSTALLATION PATH AND INTERNAL CONFIGURATION
+OSE_USER="zimbra"                                                                                                                              # Zimbra's unix user
+OSE_INSTALL_DIR="/opt/zimbra"                                                                                                                  # The Zimbra's installation path
+OSE_DEFAULT_BKP_DIR="/opt/zimbra/backup"                                                                                                       # Where you will store your backup
+OSE_INSTALL_DOMAIN=`su -s /bin/bash -c "$OSE_INSTALL_DIR/bin/zmprov gad | head -1" $OSE_USER`                                                  # Zimbra's Domain
+OSE_INSTALL_HOSTNAME=`hostname --fqdn`
+OSE_INSTALL_ADDRESS=`ping -c1 $OSE_INSTALL_HOSTNAME | head -1 | cut -d" " -f3|sed 's#(##g'|sed 's#)##g'`                                                                   # Zimbra's Server Address
+OSE_INSTALL_LDAPPASS=`su -s /bin/bash -c "$OSE_INSTALL_DIR/bin/zmlocalconfig -s zimbra_ldap_password" $OSE_USER |awk '{print $3}'`             # Zimbra's LDAP/admin Password
+ZMBKP_MAIL_ALERT="admin@"$OSE_INSTALL_DOMAIN                                                                                                   # Zmbackup's mail alert recipient
+ZMBKP_MAIL_SENDER="root@"$OSE_INSTALL_DOMAIN                                                                                                   # Zmbackup's mail alert sender
+MAX_PARALLEL_PROCESS="3"                                                                                                                       # Zmbackup's number of parallel workers
+ROTATE_TIME="30"                                                                                                                               # Zmbackup's max of days before housekeeper
+LOCK_BACKUP=true                                                                                                                               # Zmbackup's backup lock
+ZMBKP_VERSION="zmbackup version: $(cat "$MYDIR/VERSION")"                                                                                      # Zmbackup's latest version
+
+# Force a terminal type - Issue #90
+export TERM="linux"

--- a/project/config/zmbackup-java.cron
+++ b/project/config/zmbackup-java.cron
@@ -1,0 +1,31 @@
+###############################################################################
+#                          ZMBACKUP CRON FILE (JAVA)                          #
+###############################################################################
+# This file is used to manage the time and day each backup activity will be
+# executed. Please modify this file rather than create a new one.
+# Default values for each activity:
+#       Full Backup:            Every Sunday at 1:30 AM
+#       Incremental:            From Monday to Saturday at 1:30 AM
+#       Alias:                  Every day at 0:30 AM
+#       Distribution List:      Every day at 1 AM
+#       Backup Rotation:        Every day at Midnight
+###############################################################################
+#                             ZMBACKUP VARIABLES                              #
+###############################################################################
+SHELL=/bin/bash
+PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
+MAILTO=""
+30 1  * * 0     {OSE_USER}    zmbackup backup full
+0  1  * * *     {OSE_USER}    zmbackup backup distlist
+30 0  * * *     {OSE_USER}    zmbackup backup alias
+30 1  * * 1-6   {OSE_USER}    zmbackup backup incremental
+0  0  * * *     {OSE_USER}    zmbackup housekeep
+
+###############################################################################
+#                          ZMBACKUP - OTHER OPTIONS                           #
+###############################################################################
+# Mailbox Backup:     Every day at 1:30AM
+# LDAP Backup:        Every day at 1:00AM
+###############################################################################
+# 30 1 * * *      {OSE_USER}    zmbackup backup ldap
+# 30 1  * * 0     {OSE_USER}    zmbackup backup mailbox

--- a/project/config/zmbackup.yaml
+++ b/project/config/zmbackup.yaml
@@ -1,48 +1,50 @@
 # zmbackup configuration file (Java tool).
 #
 # Equivalent of zmbackup.conf for the bash tool. Installed at /etc/zmbackup/zmbackup.yaml.
+# The curly-brace tokens below are filled in by install-java.sh; if you are reading this
+# file as a template rather than an installed copy, replace them by hand.
 
 zimbraLdap:
   # LDAP server URL.
-  url: ldap://127.0.0.1:389
+  url: ldap://{OSE_INSTALL_ADDRESS}:389
   # Admin distinguished name used to bind.
   bindDn: uid=zimbra,cn=admins,cn=zimbra
   # Admin password used to bind.
-  bindPassword: changeme
+  bindPassword: {OSE_INSTALL_LDAPPASS}
   # Whether to use SSL when talking to the Zimbra server. Optional, defaults to true.
   sslEnabled: true
 
 zimbraMailbox:
   # Zimbra service account used to start/stop the service and run zmmailbox.
-  backupUser: zimbra
+  backupUser: {OSE_USER}
   # Location of the zmmailbox binary.
-  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+  zmmailboxPath: {OSE_INSTALL_DIR}/bin/zmmailbox
   # Whether to include disabled accounts. Optional, defaults to true.
   backupInactiveAccounts: true
   # Zimbra server's REST base URL, used to export mailbox content.
-  restBaseUrl: https://127.0.0.1:7071
+  restBaseUrl: https://{OSE_INSTALL_ADDRESS}:7071
   # Zimbra admin account used for REST HTTP Basic authentication.
-  adminUser: zimbra
+  adminUser: {OSE_USER}
   # The admin account's password.
-  adminPassword: changeme
+  adminPassword: {OSE_INSTALL_LDAPPASS}
 
 backup:
   # Directory backups and session metadata are stored under.
-  workDir: /opt/zimbra/backup
+  workDir: {OSE_DEFAULT_BKP_DIR}
   # Path zmbackup writes its logs to.
-  logFile: /opt/zimbra/log/zmbackup.log
+  logFile: {OSE_INSTALL_DIR}/log/zmbackup.log
   # Path to the file listing accounts that should never be backed up.
-  blockedListFile: /etc/zmbackup/blockedlist.conf
+  blockedListFile: {ZMBKP_CONF}/blockedlist.conf
   # How many accounts to back up concurrently. Optional, defaults to 3.
-  maxParallelProcesses: 3
+  maxParallelProcesses: {MAX_PARALLEL_PROCESS}
   # How many days of backups to keep before housekeeping deletes them. Optional, defaults to 30.
-  rotateDays: 30
+  rotateDays: {ROTATE_TIME}
   # Whether to allow only one backup session per type per day. Optional, defaults to true.
-  lockBackup: true
+  lockBackup: {LOCK_BACKUP}
   emailNotify:
     # Which lifecycle events to notify on: ALL, START, FINISH, ERROR, or NONE. Optional, defaults to ALL.
     level: ALL
     # Address a report is sent to after each run.
-    recipient: admin@example.com
+    recipient: {ZMBKP_MAIL_ALERT}
     # Address the report is sent from.
-    sender: root@example.com
+    sender: {ZMBKP_MAIL_SENDER}

--- a/tests/mocks/java
+++ b/tests/mocks/java
@@ -1,4 +1,8 @@
 #!/bin/bash
 # java mock
+if [ -n "${MOCK_JAVA_VERSION_OUTPUT:-}" ] && [ "$1" = "-version" ]; then
+  echo "$MOCK_JAVA_VERSION_OUTPUT" >&2
+  exit "${MOCK_JAVA_EXIT:-0}"
+fi
 echo "$@"
 exit "${MOCK_JAVA_EXIT:-0}"

--- a/tests/mocks/sudo
+++ b/tests/mocks/sudo
@@ -1,0 +1,7 @@
+#!/bin/bash
+# sudo mock - simulates blocklist_gen's "sudo -H -u $OSE_USER bash -c ..." call
+if [ "${MOCK_SU_FAIL:-0}" = "1" ]; then
+  exit 1
+fi
+echo "${MOCK_SU_OUTPUT:-}"
+exit 0

--- a/tests/unit/test_installer_java_build.bats
+++ b/tests/unit/test_installer_java_build.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# Unit tests for build_jar. These stub out ./gradlew entirely so the suite
+# stays fast and offline - a real Gradle build is exercised by the
+# `test-java` CircleCI job, not here.
+
+load '../setup'
+
+INSTALLER_JAVA_DIR="${PROJECT_ROOT}/installScriptJava"
+
+setup() {
+  setup_mock_path
+  source "${INSTALLER_JAVA_DIR}/vars.sh" 2>/dev/null || true
+  source "${INSTALLER_JAVA_DIR}/build.sh"
+
+  BUILD_ROOT="$(mktemp -d)"
+  MYDIR="$BUILD_ROOT"
+  mkdir -p "${BUILD_ROOT}/app/build/libs"
+}
+
+teardown() {
+  rm -rf "${BUILD_ROOT:-}"
+}
+
+write_gradlew() {
+  cat > "${BUILD_ROOT}/gradlew" <<EOF
+#!/bin/bash
+$1
+EOF
+  chmod +x "${BUILD_ROOT}/gradlew"
+}
+
+@test "build_jar: succeeds when gradlew produces the jar" {
+  write_gradlew "mkdir -p app/build/libs && touch app/build/libs/${ZMBKP_JAR_NAME}; exit 0"
+  run build_jar
+  [ "$status" -eq 0 ]
+  [ -f "${BUILD_ROOT}/app/build/libs/${ZMBKP_JAR_NAME}" ]
+}
+
+@test "build_jar: reports the produced jar path on success" {
+  write_gradlew "mkdir -p app/build/libs && touch app/build/libs/${ZMBKP_JAR_NAME}; exit 0"
+  run build_jar
+  [[ "$output" == *"Build completed"* ]]
+}
+
+@test "build_jar: exits ERR_BUILD_FAILED when gradlew fails" {
+  write_gradlew "exit 1"
+  run build_jar
+  [ "$status" -eq "$ERR_BUILD_FAILED" ]
+  [[ "$output" == *"Gradle build failed"* ]]
+}
+
+@test "build_jar: exits ERR_BUILD_FAILED when gradlew succeeds but the jar is missing" {
+  write_gradlew "exit 0"
+  run build_jar
+  [ "$status" -eq "$ERR_BUILD_FAILED" ]
+  [[ "$output" == *"was not produced"* ]]
+}

--- a/tests/unit/test_installer_java_check.bats
+++ b/tests/unit/test_installer_java_check.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+
+load '../setup'
+
+INSTALLER_JAVA_DIR="${PROJECT_ROOT}/installScriptJava"
+
+setup() {
+  setup_mock_path
+  source "${INSTALLER_JAVA_DIR}/vars.sh" 2>/dev/null || true
+  source "${INSTALLER_JAVA_DIR}/check.sh"
+}
+
+# ---------------------------------------------------------------------------
+# check_java_runtime
+# ---------------------------------------------------------------------------
+
+@test "check_java_runtime: sets NEED_JAVA=Y and reports NOT FOUND when java is missing" {
+  local old_path="$PATH"
+  PATH="/nonexistent"
+  run check_java_runtime
+  PATH="$old_path"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"NOT FOUND"* ]]
+}
+
+@test "check_java_runtime: sets NEED_JAVA=N when an OpenJDK 21 runtime is present" {
+  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "21.0.5" 2024-10-15
+OpenJDK Runtime Environment (build 21.0.5+11)'
+  check_java_runtime
+  [ "$NEED_JAVA" = "N" ]
+}
+
+@test "check_java_runtime: reports OK when an OpenJDK 21 runtime is present" {
+  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "21.0.5" 2024-10-15'
+  run check_java_runtime
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "check_java_runtime: sets NEED_JAVA=Y when the runtime is older than 21" {
+  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "17.0.9" 2023-10-17'
+  check_java_runtime
+  [ "$NEED_JAVA" = "Y" ]
+}
+
+@test "check_java_runtime: reports TOO OLD when the runtime is older than 21" {
+  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "17.0.9" 2023-10-17'
+  run check_java_runtime
+  [[ "$output" == *"TOO OLD"* ]]
+}
+
+@test "check_java_runtime: accepts a newer major version than the minimum" {
+  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "23.0.1" 2024-10-15'
+  check_java_runtime
+  [ "$NEED_JAVA" = "N" ]
+}
+
+@test "check_java_runtime: sets NEED_JAVA=Y when the version output cannot be parsed" {
+  export MOCK_JAVA_VERSION_OUTPUT='not a recognizable version banner'
+  check_java_runtime
+  [ "$NEED_JAVA" = "Y" ]
+}
+
+@test "check_java_runtime: reports UNKNOWN VERSION when the version output cannot be parsed" {
+  export MOCK_JAVA_VERSION_OUTPUT='not a recognizable version banner'
+  run check_java_runtime
+  [[ "$output" == *"UNKNOWN VERSION"* ]]
+}

--- a/tests/unit/test_installer_java_depDownload.bats
+++ b/tests/unit/test_installer_java_depDownload.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+load '../setup'
+
+INSTALLER_JAVA_DIR="${PROJECT_ROOT}/installScriptJava"
+
+setup() {
+  setup_mock_path
+  source "${INSTALLER_JAVA_DIR}/vars.sh" 2>/dev/null || true
+  source "${INSTALLER_JAVA_DIR}/depDownload.sh"
+}
+
+# ---------------------------------------------------------------------------
+# install_java_ubuntu
+# ---------------------------------------------------------------------------
+
+@test "install_java_ubuntu: succeeds when apt succeeds" {
+  export MOCK_APT_FAIL=0
+  run install_java_ubuntu
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"success"* ]]
+}
+
+@test "install_java_ubuntu: exits ERR_DEPNOTFOUND when apt fails" {
+  export MOCK_APT_FAIL=1
+  run install_java_ubuntu
+  [ "$status" -eq "$ERR_DEPNOTFOUND" ]
+  [[ "$output" == *"wasn't installed"* ]]
+}
+
+@test "install_java_ubuntu: prints manual command hint naming the JDK package" {
+  export MOCK_APT_FAIL=1
+  run install_java_ubuntu
+  [[ "$output" == *"openjdk-21-jdk"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# install_java_redhat
+# ---------------------------------------------------------------------------
+
+@test "install_java_redhat: succeeds when yum succeeds" {
+  export MOCK_YUM_FAIL=0
+  run install_java_redhat
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"success"* ]]
+}
+
+@test "install_java_redhat: exits ERR_DEPNOTFOUND when yum fails" {
+  export MOCK_YUM_FAIL=1
+  run install_java_redhat
+  [ "$status" -eq "$ERR_DEPNOTFOUND" ]
+  [[ "$output" == *"wasn't installed"* ]]
+}
+
+@test "install_java_redhat: prints manual command hint naming the JDK package" {
+  export MOCK_YUM_FAIL=1
+  run install_java_redhat
+  [[ "$output" == *"java-21-openjdk-devel"* ]]
+}

--- a/tests/unit/test_installer_java_deploy.bats
+++ b/tests/unit/test_installer_java_deploy.bats
@@ -1,0 +1,207 @@
+#!/usr/bin/env bats
+
+load '../setup'
+
+INSTALLER_JAVA_DIR="${PROJECT_ROOT}/installScriptJava"
+
+setup() {
+  setup_mock_path
+  source "${INSTALLER_JAVA_DIR}/vars.sh" 2>/dev/null || true
+  source "${PROJECT_ROOT}/installScript/deploy.sh"   # blocklist_gen
+  source "${INSTALLER_JAVA_DIR}/deploy.sh"
+
+  DEPLOY_ROOT="$(mktemp -d)"
+  OSE_DEFAULT_BKP_DIR="${DEPLOY_ROOT}/backup"
+  ZMBKP_CONF="${DEPLOY_ROOT}/etc/zmbackup"
+  ZMBKP_SRC="${DEPLOY_ROOT}/usr/local/bin"
+  ZMBKP_LIB="${DEPLOY_ROOT}/usr/local/lib/zmbackup"
+  ZMBKP_CRON_FILE="${DEPLOY_ROOT}/etc/cron.d/zmbackup"
+  OSE_USER="$(/usr/bin/whoami)"
+  OSE_INSTALL_ADDRESS="192.168.1.1"
+  OSE_INSTALL_LDAPPASS="testpassword"
+  OSE_INSTALL_DIR="/opt/zimbra"
+  ZMBKP_MAIL_ALERT="admin@example.com"
+  ZMBKP_MAIL_SENDER="zmbackup@example.com"
+  MAX_PARALLEL_PROCESS="3"
+  ROTATE_TIME="30"
+  LOCK_BACKUP="true"
+  export DEPLOY_ROOT OSE_DEFAULT_BKP_DIR ZMBKP_CONF ZMBKP_SRC ZMBKP_LIB ZMBKP_CRON_FILE
+  export OSE_USER OSE_INSTALL_ADDRESS OSE_INSTALL_LDAPPASS OSE_INSTALL_DIR
+  export ZMBKP_MAIL_ALERT ZMBKP_MAIL_SENDER MAX_PARALLEL_PROCESS ROTATE_TIME LOCK_BACKUP
+
+  mkdir -p "${DEPLOY_ROOT}/etc/cron.d"
+
+  # A synthetic "source tree" so deploy_new_java/deploy_upgrade_java never
+  # touch the real repo checkout or a real Gradle build.
+  MYDIR="${DEPLOY_ROOT}/src"
+  mkdir -p "${MYDIR}/app/src/main/scripts" "${MYDIR}/app/build/libs" "${MYDIR}/project/config"
+  cp "${PROJECT_ROOT}/app/src/main/scripts/zmbackup" "${MYDIR}/app/src/main/scripts/zmbackup"
+  cp "${PROJECT_ROOT}/project/config/zmbackup.yaml" "${MYDIR}/project/config/zmbackup.yaml"
+  cp "${PROJECT_ROOT}/project/config/blockedlist.conf" "${MYDIR}/project/config/blockedlist.conf"
+  cp "${PROJECT_ROOT}/project/config/zmbackup-java.cron" "${MYDIR}/project/config/zmbackup-java.cron"
+  echo "fake jar contents" > "${MYDIR}/app/build/libs/${ZMBKP_JAR_NAME}"
+  export MYDIR
+}
+
+teardown() {
+  rm -rf "${DEPLOY_ROOT:-}"
+}
+
+# ---------------------------------------------------------------------------
+# deploy_new_java
+# ---------------------------------------------------------------------------
+
+@test "deploy_new_java: creates backup directory" {
+  MOCK_SU_OUTPUT=""
+  run deploy_new_java
+  [ -d "$OSE_DEFAULT_BKP_DIR" ]
+}
+
+@test "deploy_new_java: creates zmbackup conf directory" {
+  MOCK_SU_OUTPUT=""
+  deploy_new_java
+  [ -d "$ZMBKP_CONF" ]
+}
+
+@test "deploy_new_java: installs the thin launcher" {
+  MOCK_SU_OUTPUT=""
+  deploy_new_java
+  [ -f "${ZMBKP_SRC}/zmbackup" ]
+}
+
+@test "deploy_new_java: installs the jar" {
+  MOCK_SU_OUTPUT=""
+  deploy_new_java
+  [ -f "${ZMBKP_LIB}/${ZMBKP_JAR_NAME}" ]
+}
+
+@test "deploy_new_java: installs the cron file" {
+  MOCK_SU_OUTPUT=""
+  deploy_new_java
+  [ -f "$ZMBKP_CRON_FILE" ]
+}
+
+@test "deploy_new_java: substitutes the configured user into the cron file" {
+  MOCK_SU_OUTPUT=""
+  deploy_new_java
+  ! grep -q "{OSE_USER}" "$ZMBKP_CRON_FILE"
+  grep -q "$OSE_USER" "$ZMBKP_CRON_FILE"
+}
+
+@test "deploy_new_java: installs the blocked list" {
+  MOCK_SU_OUTPUT=""
+  deploy_new_java
+  [ -f "${ZMBKP_CONF}/blockedlist.conf" ]
+}
+
+@test "deploy_new_java: substitutes OSE_DEFAULT_BKP_DIR into zmbackup.yaml" {
+  MOCK_SU_OUTPUT=""
+  deploy_new_java
+  grep -q "workDir: ${OSE_DEFAULT_BKP_DIR}" "${ZMBKP_CONF}/zmbackup.yaml"
+}
+
+@test "deploy_new_java: substitutes OSE_INSTALL_ADDRESS into zmbackup.yaml" {
+  MOCK_SU_OUTPUT=""
+  deploy_new_java
+  grep -q "192.168.1.1" "${ZMBKP_CONF}/zmbackup.yaml"
+}
+
+@test "deploy_new_java: wraps IPv6 address in brackets in zmbackup.yaml" {
+  OSE_INSTALL_ADDRESS="2001:db8::1"
+  MOCK_SU_OUTPUT=""
+  deploy_new_java
+  grep -q "\[2001:db8::1\]" "${ZMBKP_CONF}/zmbackup.yaml"
+}
+
+@test "deploy_new_java: leaves no unsubstituted {PLACEHOLDER} tokens in zmbackup.yaml" {
+  MOCK_SU_OUTPUT=""
+  deploy_new_java
+  run grep -oE '\{[A-Z_]+\}' "${ZMBKP_CONF}/zmbackup.yaml"
+  [ "$status" -ne 0 ]
+}
+
+@test "deploy_new_java: exits ERR_DEPNOTFOUND when the backup directory cannot be created" {
+  OSE_DEFAULT_BKP_DIR="/proc/invalid_dir_xyz"
+  run deploy_new_java
+  [ "$status" -eq "$ERR_DEPNOTFOUND" ]
+}
+
+@test "deploy_new_java: generates the blocked list" {
+  export MOCK_SU_OUTPUT="galsync@example.com
+user@example.com"
+  deploy_new_java
+  grep -q "galsync@example.com" "${ZMBKP_CONF}/blockedlist.conf"
+}
+
+# ---------------------------------------------------------------------------
+# deploy_upgrade_java
+# ---------------------------------------------------------------------------
+
+@test "deploy_upgrade_java: reinstalls the launcher" {
+  run deploy_upgrade_java
+  [ -f "${ZMBKP_SRC}/zmbackup" ]
+}
+
+@test "deploy_upgrade_java: reinstalls the jar" {
+  run deploy_upgrade_java
+  [ -f "${ZMBKP_LIB}/${ZMBKP_JAR_NAME}" ]
+}
+
+# ---------------------------------------------------------------------------
+# uninstall_java
+# ---------------------------------------------------------------------------
+
+@test "uninstall_java: removes the launcher" {
+  mkdir -p "$ZMBKP_SRC" "$ZMBKP_CONF" "$ZMBKP_LIB"
+  touch "${ZMBKP_SRC}/zmbackup"
+  echo "backup:" > "${ZMBKP_CONF}/zmbackup.yaml"
+  echo "  workDir: ${DEPLOY_ROOT}/backup" >> "${ZMBKP_CONF}/zmbackup.yaml"
+  mkdir -p "${DEPLOY_ROOT}/backup"
+  echo "N" | uninstall_java
+  [ ! -f "${ZMBKP_SRC}/zmbackup" ]
+}
+
+@test "uninstall_java: removes the jar directory" {
+  mkdir -p "$ZMBKP_SRC" "$ZMBKP_CONF" "$ZMBKP_LIB"
+  echo "backup:" > "${ZMBKP_CONF}/zmbackup.yaml"
+  echo "  workDir: ${DEPLOY_ROOT}/backup" >> "${ZMBKP_CONF}/zmbackup.yaml"
+  mkdir -p "${DEPLOY_ROOT}/backup"
+  echo "N" | uninstall_java
+  [ ! -d "$ZMBKP_LIB" ]
+}
+
+@test "uninstall_java: removes the cron file" {
+  mkdir -p "$ZMBKP_SRC" "$ZMBKP_CONF" "$ZMBKP_LIB"
+  touch "$ZMBKP_CRON_FILE"
+  echo "backup:" > "${ZMBKP_CONF}/zmbackup.yaml"
+  echo "  workDir: ${DEPLOY_ROOT}/backup" >> "${ZMBKP_CONF}/zmbackup.yaml"
+  mkdir -p "${DEPLOY_ROOT}/backup"
+  echo "N" | uninstall_java
+  [ ! -f "$ZMBKP_CRON_FILE" ]
+}
+
+@test "uninstall_java: removes backup storage when the user answers N" {
+  mkdir -p "$ZMBKP_CONF" "${DEPLOY_ROOT}/backup"
+  echo "backup:" > "${ZMBKP_CONF}/zmbackup.yaml"
+  echo "  workDir: ${DEPLOY_ROOT}/backup" >> "${ZMBKP_CONF}/zmbackup.yaml"
+  touch "${DEPLOY_ROOT}/backup/sessions.sqlite3"
+  echo "N" | uninstall_java
+  [ ! -f "${DEPLOY_ROOT}/backup/sessions.sqlite3" ]
+}
+
+@test "uninstall_java: preserves backup storage when the user answers Y" {
+  mkdir -p "$ZMBKP_CONF" "${DEPLOY_ROOT}/backup"
+  echo "backup:" > "${ZMBKP_CONF}/zmbackup.yaml"
+  echo "  workDir: ${DEPLOY_ROOT}/backup" >> "${ZMBKP_CONF}/zmbackup.yaml"
+  touch "${DEPLOY_ROOT}/backup/sessions.sqlite3"
+  echo "Y" | uninstall_java
+  [ -f "${DEPLOY_ROOT}/backup/sessions.sqlite3" ]
+}
+
+@test "uninstall_java: parses workDir out of the real (commented) zmbackup.yaml template" {
+  MOCK_SU_OUTPUT=""
+  deploy_new_java
+  touch "${OSE_DEFAULT_BKP_DIR}/sessions.sqlite3"
+  echo "N" | uninstall_java
+  [ ! -f "${OSE_DEFAULT_BKP_DIR}/sessions.sqlite3" ]
+}

--- a/tests/unit/test_installer_java_menu.bats
+++ b/tests/unit/test_installer_java_menu.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+
+load '../setup'
+
+INSTALLER_JAVA_DIR="${PROJECT_ROOT}/installScriptJava"
+
+setup() {
+  setup_mock_path
+  source "${INSTALLER_JAVA_DIR}/vars.sh" 2>/dev/null || true
+  source "${INSTALLER_JAVA_DIR}/menu.sh"
+}
+
+# ---------------------------------------------------------------------------
+# set_values_java
+# ---------------------------------------------------------------------------
+
+@test "set_values_java: uses defaults when all inputs are empty" {
+  run bash -c "
+    PATH='${MOCKS_DIR}:${PATH}'
+    source '${INSTALLER_JAVA_DIR}/vars.sh' 2>/dev/null || true
+    source '${INSTALLER_JAVA_DIR}/menu.sh'
+    set_values_java < <(printf '\n\n\n\n\n\n\n\n')
+    echo \"OSE_USER=\$OSE_USER\"
+    echo \"MAX_PARALLEL_PROCESS=\$MAX_PARALLEL_PROCESS\"
+  "
+  [[ "$output" == *"OSE_USER=zimbra"* ]]
+  [[ "$output" == *"MAX_PARALLEL_PROCESS=3"* ]]
+}
+
+@test "set_values_java: overrides OSE_USER when provided" {
+  run bash -c "
+    PATH='${MOCKS_DIR}:${PATH}'
+    source '${INSTALLER_JAVA_DIR}/vars.sh' 2>/dev/null || true
+    source '${INSTALLER_JAVA_DIR}/menu.sh'
+    set_values_java < <(printf 'myuser\n\n\n\n\n\n\n\n')
+    echo \"OSE_USER=\$OSE_USER\"
+  "
+  [[ "$output" == *"OSE_USER=myuser"* ]]
+}
+
+@test "set_values_java: overrides MAX_PARALLEL_PROCESS when provided" {
+  run bash -c "
+    PATH='${MOCKS_DIR}:${PATH}'
+    source '${INSTALLER_JAVA_DIR}/vars.sh' 2>/dev/null || true
+    source '${INSTALLER_JAVA_DIR}/menu.sh'
+    set_values_java < <(printf '\n\n\n\n\n8\n\n\n')
+    echo \"MAX_PARALLEL_PROCESS=\$MAX_PARALLEL_PROCESS\"
+  "
+  [[ "$output" == *"MAX_PARALLEL_PROCESS=8"* ]]
+}
+
+@test "set_values_java: displays CONFIGURATION COMPLETED message" {
+  run bash -c "
+    PATH='${MOCKS_DIR}:${PATH}'
+    source '${INSTALLER_JAVA_DIR}/vars.sh' 2>/dev/null || true
+    source '${INSTALLER_JAVA_DIR}/menu.sh'
+    set_values_java < <(printf '\n\n\n\n\n\n\n\n')
+  "
+  [[ "$output" == *"CONFIGURATION COMPLETED"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# check_config_java
+# ---------------------------------------------------------------------------
+
+@test "check_config_java: displays configuration summary" {
+  OSE_USER="zimbra"
+  OSE_INSTALL_ADDRESS="192.168.1.1"
+  OSE_INSTALL_LDAPPASS="secret"
+  OSE_INSTALL_DIR="/opt/zimbra"
+  OSE_DEFAULT_BKP_DIR="/opt/zimbra/backup"
+  ZMBKP_SRC="/usr/local/bin"
+  ZMBKP_LIB="/usr/local/lib/zmbackup"
+  ZMBKP_JAR_NAME="zmbackup.jar"
+  ZMBKP_CONF="/etc/zmbackup"
+  ROTATE_TIME="30"
+  MAX_PARALLEL_PROCESS="3"
+  LOCK_BACKUP="true"
+  output=$(echo "" | check_config_java)
+  [[ "$output" == *"Summary"* ]]
+  [[ "$output" == *"zimbra"* ]]
+  [[ "$output" == *"SQLite3"* ]]
+}

--- a/tests/unit/test_installer_java_vars.bats
+++ b/tests/unit/test_installer_java_vars.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+
+load '../setup'
+
+INSTALLER_JAVA_DIR="${PROJECT_ROOT}/installScriptJava"
+
+setup() {
+  setup_mock_path
+  source "${INSTALLER_JAVA_DIR}/vars.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Exit code constants
+# ---------------------------------------------------------------------------
+
+@test "vars: ERR_OK is 0" {
+  [ "$ERR_OK" = "0" ]
+}
+
+@test "vars: ERR_NOROOT is 2" {
+  [ "$ERR_NOROOT" = "2" ]
+}
+
+@test "vars: ERR_DEPNOTFOUND is 3" {
+  [ "$ERR_DEPNOTFOUND" = "3" ]
+}
+
+@test "vars: ERR_NO_CONNECTION is 4" {
+  [ "$ERR_NO_CONNECTION" = "4" ]
+}
+
+@test "vars: ERR_BUILD_FAILED is 6" {
+  [ "$ERR_BUILD_FAILED" = "6" ]
+}
+
+# ---------------------------------------------------------------------------
+# Installation paths - fixed by app/src/main/scripts/zmbackup and
+# YamlConfigLoader.DEFAULT_CONFIG_PATH, so these must match exactly.
+# ---------------------------------------------------------------------------
+
+@test "vars: ZMBKP_SRC is /usr/local/bin" {
+  [ "$ZMBKP_SRC" = "/usr/local/bin" ]
+}
+
+@test "vars: ZMBKP_CONF is /etc/zmbackup" {
+  [ "$ZMBKP_CONF" = "/etc/zmbackup" ]
+}
+
+@test "vars: ZMBKP_LIB is /usr/local/lib/zmbackup" {
+  [ "$ZMBKP_LIB" = "/usr/local/lib/zmbackup" ]
+}
+
+@test "vars: ZMBKP_JAR_NAME is zmbackup.jar" {
+  [ "$ZMBKP_JAR_NAME" = "zmbackup.jar" ]
+}
+
+# ---------------------------------------------------------------------------
+# Java runtime requirement
+# ---------------------------------------------------------------------------
+
+@test "vars: JAVA_MIN_VERSION is 21" {
+  [ "$JAVA_MIN_VERSION" = "21" ]
+}
+
+# ---------------------------------------------------------------------------
+# Zimbra defaults
+# ---------------------------------------------------------------------------
+
+@test "vars: OSE_USER is zimbra" {
+  [ "$OSE_USER" = "zimbra" ]
+}
+
+@test "vars: OSE_INSTALL_DIR is /opt/zimbra" {
+  [ "$OSE_INSTALL_DIR" = "/opt/zimbra" ]
+}
+
+@test "vars: OSE_DEFAULT_BKP_DIR is /opt/zimbra/backup" {
+  [ "$OSE_DEFAULT_BKP_DIR" = "/opt/zimbra/backup" ]
+}
+
+# ---------------------------------------------------------------------------
+# Backup defaults
+# ---------------------------------------------------------------------------
+
+@test "vars: MAX_PARALLEL_PROCESS is 3" {
+  [ "$MAX_PARALLEL_PROCESS" = "3" ]
+}
+
+@test "vars: ROTATE_TIME is 30" {
+  [ "$ROTATE_TIME" = "30" ]
+}
+
+@test "vars: LOCK_BACKUP is true" {
+  [ "$LOCK_BACKUP" = "true" ]
+}
+
+@test "vars: ZMBKP_VERSION has the expected prefix" {
+  # vars.sh derives MYDIR from `dirname $0`, which under the bats test runner
+  # points at bats' own internal launcher rather than the project root, so
+  # the VERSION file it tries to read isn't reachable here - only exercise
+  # what's actually under this test's control.
+  [[ "$ZMBKP_VERSION" == "zmbackup version: "* ]]
+}
+
+@test "vars: ZMBKP_VERSION reads the real VERSION file when MYDIR points at the repo" {
+  MYDIR="$PROJECT_ROOT"
+  ZMBKP_VERSION="zmbackup version: $(cat "$MYDIR/VERSION")"
+  [[ "$ZMBKP_VERSION" == *"1.2"* ]]
+}
+
+@test "vars: TERM is set to linux" {
+  [ "$TERM" = "linux" ]
+}


### PR DESCRIPTION
## Summary

- Adds `install-java.sh`, an installer for the Java rewrite (zmbackup 2.0) that mirrors what `install.sh` does for the bash tool: checks for (and installs if missing) a Java 21 JDK, builds `zmbackup.jar` with the Gradle wrapper, then installs the jar, the thin `zmbackup` launcher, `zmbackup.yaml`, the blocked list and a cron file (using the Java CLI's `zmbackup backup full`/`incremental`/`distlist`/`alias`/`housekeep` syntax instead of the bash tool's flags). Supports `--remove` and `--force-upgrade` the same way.
- Root/OS detection (`check_env`), the license banner (`contract`) and blocklist generation (`blocklist_gen`) are reused as-is from the existing `installScript/` since none of that depends on which language zmbackup itself is written in. Everything Java-specific lives in a new `installScriptJava/` (paths, Java runtime check, JDK install, jar build, prompts/summary, deploy/uninstall).
- `project/config/zmbackup.yaml` now uses the same `{PLACEHOLDER}` substitution convention as `zmbackup.conf` so the installer can fill it in; added `project/config/zmbackup-java.cron` with the Java CLI's command syntax.
- The Java tool talks to LDAP and SQLite directly (no `zmmailbox`/`ldap-utils`/`sqlite3` CLI dependency), so the installer's only real dependency to check for is the JDK itself.
- Documented the new installer in the README alongside the existing bash installation instructions.

## Test plan

- [x] `npx bats --verbose-run tests/unit/` — full suite passes except 4 pre-existing failures unrelated to this change (they depend on non-root permission checks and already failed before this PR when run as root).
- [x] New bats coverage for every function in `installScriptJava/` (vars, `check_java_runtime`, `install_java_ubuntu`/`install_java_redhat`, `build_jar`, `deploy_new_java`/`deploy_upgrade_java`/`uninstall_java`, `set_values_java`/`check_config_java`), including a round-trip test that `uninstall_java` correctly parses `workDir` out of the real (comment-laden) `zmbackup.yaml` template.
- [x] `bash -n` syntax-checked all new/modified shell scripts.
- [x] Manually ran `./install-java.sh --help` to confirm it loads and prints usage without crashing.
- [ ] Not run: a full live install against a real Zimbra host (needs root + a Zimbra install + network access for the Gradle build) — out of reach in this sandbox.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WMkVbtpDJ5gvpJfHhhxFBd)_