### PR TITLE
Add a zmbackup migrate command and run it automatically on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ jar, a thin `zmbackup` launcher, `zmbackup.yaml`, the blocked list and a cron fi
 require GNU Parallel, ldap-utils or the sqlite3 CLI - the Java tool talks to LDAP and SQLite
 directly, so those are only needed for the bash tool.
 
+Unlike the bash tool, the Java build only ever reads session metadata from SQLite - there's no
+TXT mode. If you're moving to it from the bash tool and its `WORKDIR` still has a `sessions.txt`,
+`install-java.sh` migrates it into the SQLite metadata store automatically at the end of the
+install (or upgrade), via the `zmbackup migrate` command. That command is also safe to run by
+hand at any time - `$ zmbackup migrate` - and is a no-op once there's nothing left to import (it
+renames `sessions.txt` to `sessions.txt.migrated` after a successful import, so re-running it,
+e.g. after `install-java.sh --force-upgrade`, doesn't import the same sessions twice).
+
 ```
 # cd zmbackup
 # ./install-java.sh

--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -12,6 +12,7 @@ import io.zmbackup.core.port.ZimbraLdapExporter;
 import io.zmbackup.core.port.ZimbraMailboxExporter;
 import io.zmbackup.core.service.BackupService;
 import io.zmbackup.core.service.HousekeepService;
+import io.zmbackup.core.service.MigrationService;
 import io.zmbackup.core.service.RestoreService;
 import io.zmbackup.core.service.SessionService;
 import io.zmbackup.local.EmailNotifier;
@@ -61,6 +62,7 @@ public final class AppContext {
     private final BackupService backupService;
     private final RestoreService restoreService;
     private final HousekeepService housekeepService;
+    private final MigrationService migrationService;
 
     public AppContext(AppConfig config) throws IOException {
         this.config = config;
@@ -93,6 +95,7 @@ public final class AppContext {
         this.restoreService = new RestoreService(
                 ldapExporter, mailboxExporter, storageProvider, metadataStore, config.backup().maxParallelProcesses());
         this.housekeepService = new HousekeepService(storageProvider, metadataStore);
+        this.migrationService = new MigrationService(storageProvider, metadataStore);
     }
 
     /**
@@ -199,5 +202,9 @@ public final class AppContext {
 
     public HousekeepService housekeepService() {
         return housekeepService;
+    }
+
+    public MigrationService migrationService() {
+        return migrationService;
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/Main.java
+++ b/app/src/main/java/io/zmbackup/app/cli/Main.java
@@ -22,7 +22,8 @@ import picocli.CommandLine.Spec;
             ListCommand.class,
             DeleteCommand.class,
             HousekeepCommand.class,
-            AccountsCommand.class
+            AccountsCommand.class,
+            MigrateCommand.class
         })
 public final class Main implements Callable<Integer> {
 

--- a/app/src/main/java/io/zmbackup/app/cli/MigrateCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/MigrateCommand.java
@@ -1,0 +1,64 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/**
+ * Imports a bash-tool {@code sessions.txt} into the SQLite metadata store this build reads
+ * exclusively, for servers moving from the bash tool - which may have stored its sessions as TXT
+ * - to this Java build. Delegates the parsing to {@link io.zmbackup.core.service.MigrationService};
+ * mirrors the bash tool's {@code -mg}/{@code --migrate} option in spirit, but only ever migrates
+ * TXT into SQLite, since that is the only format this build understands.
+ *
+ * <p>Safe to run more than once, including unattended from the installer: once a {@code
+ * sessions.txt} is imported it is renamed to {@code sessions.txt.migrated}, so a repeat run finds
+ * nothing left to import instead of re-inserting duplicate account records.
+ */
+@Command(name = "migrate", description = "Import a bash-tool sessions.txt into the SQLite metadata store.")
+public final class MigrateCommand implements Callable<Integer> {
+
+    private static final String SESSIONS_TXT = "sessions.txt";
+    private static final String MIGRATED_SUFFIX = ".migrated";
+
+    @ParentCommand
+    private Main parent;
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.configFile());
+        PrintWriter out = spec.commandLine().getOut();
+        PrintWriter err = spec.commandLine().getErr();
+        Path workDir = context.config().backup().workDir();
+        Path sessionsTxt = workDir.resolve(SESSIONS_TXT);
+
+        return LockedExecution.run(context, err, () -> {
+            if (!Files.exists(sessionsTxt)) {
+                out.println("No " + SESSIONS_TXT + " found in " + workDir + " - nothing to migrate.");
+                return 0;
+            }
+
+            List<String> lines = Files.readAllLines(sessionsTxt);
+            int imported = context.migrationService().importSessionsText(lines);
+
+            Path migrated = workDir.resolve(SESSIONS_TXT + MIGRATED_SUFFIX);
+            Files.move(sessionsTxt, migrated, StandardCopyOption.REPLACE_EXISTING);
+
+            out.println("Imported " + imported + " backup session(s) from " + SESSIONS_TXT
+                    + " into the SQLite metadata store.");
+            out.println(SESSIONS_TXT + " renamed to " + migrated.getFileName() + ".");
+            return 0;
+        });
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cli/MigrateCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MigrateCommandTest.java
@@ -1,0 +1,133 @@
+package io.zmbackup.app.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.app.PidLock;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+class MigrateCommandTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void importsSessionsTxtAndRenamesItOnceMigrated() throws Exception {
+        Path configFile = writeConfig();
+        Files.writeString(
+                tempDir.resolve("sessions.txt"),
+                """
+                SESSION: full-20260101120000 started on Thu Jan  1 12:00:00 UTC 2026
+                full-20260101120000:alice@example.com:01/01/26
+                SESSION: full-20260101120000 completed in Thu Jan  1 12:05:00 UTC 2026
+                """);
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out);
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "migrate");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("Imported 1 backup session(s)"));
+        assertFalse(Files.exists(tempDir.resolve("sessions.txt")));
+        assertTrue(Files.exists(tempDir.resolve("sessions.txt.migrated")));
+
+        AppContext context = AppContext.fromConfigFile(configFile);
+        var session = context.metadataStore().findSession("full-20260101120000").orElseThrow();
+        assertEquals(BackupType.FULL, session.type());
+        assertEquals(SessionStatus.FINISHED, session.status());
+        assertEquals(1, context.metadataStore().findAccountsForSession("full-20260101120000").size());
+    }
+
+    @Test
+    void doesNothingWhenNoSessionsTxtExists() throws Exception {
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out);
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "migrate");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("nothing to migrate"));
+    }
+
+    @Test
+    void runningTwiceOnlyImportsOnce() throws Exception {
+        Path configFile = writeConfig();
+        Files.writeString(
+                tempDir.resolve("sessions.txt"),
+                "SESSION: ldap-20260101120000 started on Thu Jan  1 12:00:00 UTC 2026\n"
+                        + "SESSION: ldap-20260101120000 completed in Thu Jan  1 12:05:00 UTC 2026\n");
+        commandLine(new StringWriter()).execute("--config", configFile.toString(), "migrate");
+
+        StringWriter out = new StringWriter();
+        int exitCode = commandLine(out).execute("--config", configFile.toString(), "migrate");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("nothing to migrate"));
+        AppContext context = AppContext.fromConfigFile(configFile);
+        assertEquals(1, context.metadataStore().listSessions().size());
+    }
+
+    @Test
+    void failsWithoutRunningWhenAnotherProcessHoldsTheLock() throws Exception {
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        CommandLine cmd = new CommandLine(new Main());
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(err));
+
+        try (PidLock lock = PidLock.acquire(tempDir)) {
+            int exitCode = cmd.execute("--config", configFile.toString(), "migrate");
+
+            assertEquals(CommandLine.ExitCode.SOFTWARE, exitCode);
+            assertTrue(err.toString().contains("already running"));
+        }
+    }
+
+    private Path writeConfig() throws IOException {
+        Path configFile = tempDir.resolve("zmbackup.yaml");
+        Files.writeString(
+                configFile,
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:389
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                zimbraMailbox:
+                  backupUser: zimbra
+                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
+                backup:
+                  workDir: %s
+                  logFile: %s
+                  blockedListFile: %s
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """
+                        .formatted(
+                                tempDir, tempDir.resolve("zmbackup.log"), tempDir.resolve("blockedlist.conf")));
+        return configFile;
+    }
+
+    private static CommandLine commandLine(StringWriter out) {
+        CommandLine cmd = new CommandLine(new Main());
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(new StringWriter()));
+        return cmd;
+    }
+}

--- a/core/src/main/java/io/zmbackup/core/service/MigrationService.java
+++ b/core/src/main/java/io/zmbackup/core/service/MigrationService.java
@@ -1,0 +1,147 @@
+package io.zmbackup.core.service;
+
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.StorageProvider;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Imports the bash tool's {@code sessions.txt} format into the {@link MetadataStore}, for
+ * servers moving from the bash tool (which may store its sessions as TXT) to this Java build,
+ * which only ever reads session metadata from SQLite. Mirrors {@code importsessionSQL} and
+ * {@code importaccountsSQL} in the bash tool's {@code MigrationAction.sh}, except that it writes
+ * {@code backup_session.type} as the raw prefix ({@link BackupType#sessionPrefix()}) that {@link
+ * io.zmbackup.core.port.MetadataStore} implementations parse back with {@link
+ * BackupType#fromSessionPrefix(String)}, rather than the bash tool's human-readable text.
+ *
+ * <p>{@code sessions.txt} only records a session's start/finish text (not a reliably parseable
+ * timestamp) and, per account line, a date without a time. So - like the bash tool's own
+ * migration - a session's completion time is taken to be the same instant as its start (itself
+ * read precisely from the {@code {prefix}-yyyyMMddHHmmss} session ID), and an account record's
+ * start/completion time is taken to be midnight of the date on its line.
+ */
+public final class MigrationService {
+
+    private static final Logger LOG = Logger.getLogger(MigrationService.class.getName());
+
+    private static final Pattern SESSION_LINE =
+            Pattern.compile("^SESSION: (\\S+) (started on|completed in|failed to move staged data on) .*$");
+    private static final Pattern ACCOUNT_LINE = Pattern.compile("^([^:]+):([^:]+):(\\d{2}/\\d{2}/\\d{2})$");
+    private static final DateTimeFormatter SESSION_ID_TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+    private static final DateTimeFormatter ACCOUNT_LINE_DATE = DateTimeFormatter.ofPattern("MM/dd/yy");
+
+    private final StorageProvider storageProvider;
+    private final MetadataStore metadataStore;
+
+    public MigrationService(StorageProvider storageProvider, MetadataStore metadataStore) {
+        this.storageProvider = Objects.requireNonNull(storageProvider, "storageProvider must not be null");
+        this.metadataStore = Objects.requireNonNull(metadataStore, "metadataStore must not be null");
+    }
+
+    /**
+     * Parses {@code sessionsTxtLines} (the content of a bash-tool {@code sessions.txt}) and
+     * writes every session, and every account backup within it, into the metadata store.
+     *
+     * @return the number of sessions imported
+     */
+    public int importSessionsText(List<String> sessionsTxtLines) throws IOException {
+        TreeSet<String> started = new TreeSet<>();
+        TreeSet<String> completed = new TreeSet<>();
+        TreeSet<String> failed = new TreeSet<>();
+        Map<String, List<String[]>> accountLinesBySession = new LinkedHashMap<>();
+
+        for (String line : sessionsTxtLines) {
+            Matcher sessionMatch = SESSION_LINE.matcher(line);
+            if (sessionMatch.matches()) {
+                String sessionId = sessionMatch.group(1);
+                switch (sessionMatch.group(2)) {
+                    case "started on" -> started.add(sessionId);
+                    case "completed in" -> completed.add(sessionId);
+                    case "failed to move staged data on" -> failed.add(sessionId);
+                    default -> throw new AssertionError("Unreachable: unmatched group " + sessionMatch.group(2));
+                }
+                continue;
+            }
+            Matcher accountMatch = ACCOUNT_LINE.matcher(line);
+            if (accountMatch.matches()) {
+                accountLinesBySession
+                        .computeIfAbsent(accountMatch.group(1), key -> new ArrayList<>())
+                        .add(new String[] {accountMatch.group(2), accountMatch.group(3)});
+            }
+        }
+
+        int imported = 0;
+        for (String sessionId : started) {
+            BackupType type;
+            Instant startedAt;
+            try {
+                type = BackupType.fromSessionPrefix(sessionId.substring(0, sessionId.indexOf('-')));
+                startedAt = parseSessionTimestamp(sessionId);
+            } catch (RuntimeException e) {
+                LOG.log(Level.WARNING, "Skipping unparsable session ID '" + sessionId + "' from sessions.txt", e);
+                continue;
+            }
+
+            SessionStatus status;
+            Instant completedAt;
+            if (completed.contains(sessionId)) {
+                status = SessionStatus.FINISHED;
+                completedAt = startedAt;
+            } else if (failed.contains(sessionId)) {
+                status = SessionStatus.FAILED;
+                completedAt = startedAt;
+            } else {
+                status = SessionStatus.IN_PROGRESS;
+                completedAt = null;
+            }
+
+            String size = storageProvider.sizeOfSession(sessionId);
+            metadataStore.save(new BackupSession(sessionId, type, status, startedAt, completedAt, size));
+            imported++;
+
+            for (String[] accountLine : accountLinesBySession.getOrDefault(sessionId, List.of())) {
+                String email = accountLine[0];
+                Instant accountAt = parseAccountDate(accountLine[1], startedAt);
+                String accountSize = storageProvider.sizeOfAccount(sessionId, email);
+                metadataStore.recordAccountBackup(
+                        new BackupAccountRecord(null, sessionId, email, accountSize, accountAt, accountAt));
+            }
+        }
+        return imported;
+    }
+
+    private static Instant parseSessionTimestamp(String sessionId) {
+        String timestamp = sessionId.substring(sessionId.indexOf('-') + 1);
+        return LocalDateTime.parse(timestamp, SESSION_ID_TIMESTAMP)
+                .atZone(ZoneId.systemDefault())
+                .toInstant();
+    }
+
+    private static Instant parseAccountDate(String date, Instant fallback) {
+        try {
+            return LocalDate.parse(date, ACCOUNT_LINE_DATE)
+                    .atStartOfDay(ZoneId.systemDefault())
+                    .toInstant();
+        } catch (RuntimeException e) {
+            return fallback;
+        }
+    }
+}

--- a/core/src/test/java/io/zmbackup/core/service/MigrationServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/MigrationServiceTest.java
@@ -1,0 +1,180 @@
+package io.zmbackup.core.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.StorageProvider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class MigrationServiceTest {
+
+    private final InMemoryStorageProvider storageProvider = new InMemoryStorageProvider();
+    private final InMemoryMetadataStore metadataStore = new InMemoryMetadataStore();
+    private final MigrationService migrationService = new MigrationService(storageProvider, metadataStore);
+
+    @Test
+    void importsFinishedSessionWithAccounts() throws IOException {
+        storageProvider.sessionSizes.put("full-20260101120000", "10M");
+        storageProvider.accountSizes.put("full-20260101120000/alice@example.com", "6M");
+        storageProvider.accountSizes.put("full-20260101120000/bob@example.com", "4M");
+
+        int imported = migrationService.importSessionsText(
+                List.of(
+                        "SESSION: full-20260101120000 started on Thu Jan  1 12:00:00 UTC 2026",
+                        "full-20260101120000:alice@example.com:01/01/26",
+                        "full-20260101120000:bob@example.com:01/01/26",
+                        "SESSION: full-20260101120000 completed in Thu Jan  1 12:05:00 UTC 2026"));
+
+        assertEquals(1, imported);
+        BackupSession session = metadataStore.sessions.get("full-20260101120000");
+        assertEquals(BackupType.FULL, session.type());
+        assertEquals(SessionStatus.FINISHED, session.status());
+        assertEquals("10M", session.size());
+        assertEquals(Instant.parse("2026-01-01T12:00:00Z"), session.startedAt());
+        assertEquals(session.startedAt(), session.completedAt());
+
+        List<BackupAccountRecord> accounts = metadataStore.accounts.get("full-20260101120000");
+        assertEquals(2, accounts.size());
+        assertEquals("alice@example.com", accounts.get(0).email());
+        assertEquals("6M", accounts.get(0).size());
+        assertEquals(
+                LocalDate.of(2026, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant(),
+                accounts.get(0).startedAt());
+        assertEquals("bob@example.com", accounts.get(1).email());
+        assertEquals("4M", accounts.get(1).size());
+    }
+
+    @Test
+    void importsFailedSessionAsFailed() throws IOException {
+        migrationService.importSessionsText(
+                List.of(
+                        "SESSION: ldap-20260101120000 started on Thu Jan  1 12:00:00 UTC 2026",
+                        "SESSION: ldap-20260101120000 failed to move staged data on Thu Jan  1 12:05:00 UTC 2026"));
+
+        assertEquals(SessionStatus.FAILED, metadataStore.sessions.get("ldap-20260101120000").status());
+    }
+
+    @Test
+    void importsStillRunningSessionAsInProgressWithNoCompletionTime() throws IOException {
+        migrationService.importSessionsText(
+                List.of("SESSION: inc-20260101120000 started on Thu Jan  1 12:00:00 UTC 2026"));
+
+        BackupSession session = metadataStore.sessions.get("inc-20260101120000");
+        assertEquals(SessionStatus.IN_PROGRESS, session.status());
+        assertEquals(null, session.completedAt());
+    }
+
+    @Test
+    void skipsUnparsableSessionIds() throws IOException {
+        int imported = migrationService.importSessionsText(
+                List.of("SESSION: not-a-valid-session-id started on Thu Jan  1 12:00:00 UTC 2026"));
+
+        assertEquals(0, imported);
+        assertTrue(metadataStore.sessions.isEmpty());
+    }
+
+    @Test
+    void ignoresUnrelatedLines() throws IOException {
+        int imported = migrationService.importSessionsText(List.of("", "some unrelated log line", "not:enough"));
+
+        assertEquals(0, imported);
+    }
+
+    /** In-memory {@link StorageProvider} fake returning canned sizes, keyed like the real dir layout. */
+    private static final class InMemoryStorageProvider implements StorageProvider {
+        final Map<String, String> sessionSizes = new LinkedHashMap<>();
+        final Map<String, String> accountSizes = new LinkedHashMap<>();
+
+        @Override
+        public OutputStream openWrite(String sessionId, String account, String suffix) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public InputStream openRead(String sessionId, String account, String suffix) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean exists(String sessionId, String account, String suffix) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String sizeOfAccount(String sessionId, String account) {
+            return accountSizes.getOrDefault(sessionId + "/" + account, "0B");
+        }
+
+        @Override
+        public String sizeOfSession(String sessionId) {
+            return sessionSizes.getOrDefault(sessionId, "0B");
+        }
+
+        @Override
+        public void deleteSession(String sessionId) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /** In-memory {@link MetadataStore} fake backed by simple maps. */
+    private static final class InMemoryMetadataStore implements MetadataStore {
+        final Map<String, BackupSession> sessions = new LinkedHashMap<>();
+        final Map<String, List<BackupAccountRecord>> accounts = new LinkedHashMap<>();
+
+        @Override
+        public void save(BackupSession session) {
+            sessions.put(session.sessionId(), session);
+        }
+
+        @Override
+        public Optional<BackupSession> findSession(String sessionId) {
+            return Optional.ofNullable(sessions.get(sessionId));
+        }
+
+        @Override
+        public List<BackupSession> listSessions() {
+            return List.copyOf(sessions.values());
+        }
+
+        @Override
+        public List<BackupSession> findSessionsCompletedBefore(Instant cutoff) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void deleteSession(String sessionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void recordAccountBackup(BackupAccountRecord record) {
+            accounts.computeIfAbsent(record.sessionId(), key -> new ArrayList<>()).add(record);
+        }
+
+        @Override
+        public List<BackupAccountRecord> findAccountsForSession(String sessionId) {
+            return accounts.getOrDefault(sessionId, List.of());
+        }
+
+        @Override
+        public Optional<Instant> lastSuccessfulBackupTime(String email) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/installScriptJava/deploy.sh
+++ b/installScriptJava/deploy.sh
@@ -6,6 +6,22 @@
 ################################################################################
 
 ################################################################################
+# migrate_legacy_sessions: The Java build only ever reads session metadata from
+# SQLite, but a server moving to it from the bash tool may have been using the
+# bash tool's TXT sessions instead. If a sessions.txt is sitting in the backup
+# directory, import it into the SQLite metadata store via "zmbackup migrate"
+# (io.zmbackup.app.cli.MigrateCommand) so that history isn't silently lost.
+# Safe to call unconditionally: the command itself is a no-op once there is no
+# sessions.txt left to import (it renames it to sessions.txt.migrated).
+################################################################################
+function migrate_legacy_sessions() {
+  if [[ -f "$OSE_DEFAULT_BKP_DIR/sessions.txt" ]]; then
+    echo "Found an existing sessions.txt - migrating it into the SQLite metadata store..."
+    sudo -H -u "$OSE_USER" bash -c "zmbackup migrate"
+  fi
+}
+
+################################################################################
 # deploy_new_java: Deploy a new install of the Java build of Zmbackup
 ################################################################################
 function deploy_new_java() {
@@ -66,6 +82,10 @@ function deploy_new_java() {
 
   # Generate Zmbackup's blocked list (shared logic with the bash installer)
   blocklist_gen
+
+  # zmbackup.yaml/the jar are fully in place now, so "zmbackup migrate" can load
+  # config and open the SQLite metadata store if there's a legacy sessions.txt.
+  migrate_legacy_sessions
 }
 
 ################################################################################
@@ -79,6 +99,11 @@ function deploy_upgrade_java() {
   test -d "$ZMBKP_LIB" || mkdir -p "$ZMBKP_LIB"
   install -o "$OSE_USER" -m 755 "$MYDIR"/app/src/main/scripts/zmbackup "$ZMBKP_SRC"
   install -o "$OSE_USER" -m 750 "$MYDIR"/app/build/libs/"$ZMBKP_JAR_NAME" "$ZMBKP_LIB"
+
+  # Covers a server that switched to the Java build without ever having its
+  # sessions.txt migrated (e.g. a bash-to-Java move immediately followed by
+  # --force-upgrade); a no-op otherwise.
+  migrate_legacy_sessions
 
   echo "Upgrade completed."
 }

--- a/tests/mocks/sudo
+++ b/tests/mocks/sudo
@@ -1,5 +1,11 @@
 #!/bin/bash
-# sudo mock - simulates blocklist_gen's "sudo -H -u $OSE_USER bash -c ..." call
+# sudo mock - simulates blocklist_gen's and migrate_legacy_sessions's
+# "sudo -H -u $OSE_USER bash -c ..." calls. Records each invocation's
+# arguments to $MOCK_SUDO_LOG when set, so tests can assert which command was
+# actually run under sudo.
+if [ -n "${MOCK_SUDO_LOG:-}" ]; then
+  echo "$*" >> "$MOCK_SUDO_LOG"
+fi
 if [ "${MOCK_SU_FAIL:-0}" = "1" ]; then
   exit 1
 fi

--- a/tests/unit/test_installer_java_deploy.bats
+++ b/tests/unit/test_installer_java_deploy.bats
@@ -133,6 +133,24 @@ user@example.com"
   grep -q "galsync@example.com" "${ZMBKP_CONF}/blockedlist.conf"
 }
 
+@test "deploy_new_java: migrates an existing sessions.txt via zmbackup migrate" {
+  mkdir -p "$OSE_DEFAULT_BKP_DIR"
+  touch "${OSE_DEFAULT_BKP_DIR}/sessions.txt"
+  MOCK_SUDO_LOG="$(mktemp)"
+  MOCK_SU_OUTPUT=""
+  export MOCK_SUDO_LOG
+  deploy_new_java
+  grep -q "zmbackup migrate" "$MOCK_SUDO_LOG"
+}
+
+@test "deploy_new_java: does not invoke migrate when there is no sessions.txt" {
+  MOCK_SUDO_LOG="$(mktemp)"
+  MOCK_SU_OUTPUT=""
+  export MOCK_SUDO_LOG
+  deploy_new_java
+  ! grep -q "zmbackup migrate" "$MOCK_SUDO_LOG"
+}
+
 # ---------------------------------------------------------------------------
 # deploy_upgrade_java
 # ---------------------------------------------------------------------------
@@ -145,6 +163,22 @@ user@example.com"
 @test "deploy_upgrade_java: reinstalls the jar" {
   run deploy_upgrade_java
   [ -f "${ZMBKP_LIB}/${ZMBKP_JAR_NAME}" ]
+}
+
+@test "deploy_upgrade_java: migrates an existing sessions.txt via zmbackup migrate" {
+  mkdir -p "$OSE_DEFAULT_BKP_DIR"
+  touch "${OSE_DEFAULT_BKP_DIR}/sessions.txt"
+  MOCK_SUDO_LOG="$(mktemp)"
+  export MOCK_SUDO_LOG
+  deploy_upgrade_java
+  grep -q "zmbackup migrate" "$MOCK_SUDO_LOG"
+}
+
+@test "deploy_upgrade_java: does not invoke migrate when there is no sessions.txt" {
+  MOCK_SUDO_LOG="$(mktemp)"
+  export MOCK_SUDO_LOG
+  deploy_upgrade_java
+  ! grep -q "zmbackup migrate" "$MOCK_SUDO_LOG"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Java build (zmbackup 2.0) only ever reads session metadata from SQLite (`io.zmbackup.local.SqliteMetadataStore`) — unlike the bash tool, it has no TXT mode. That means a server moving from the bash tool to the Java build would silently lose its backup history if the bash tool had been configured with `SESSION_TYPE=TXT` (the bash tool's own default).

- Added `MigrationService` (`core`), which parses a bash-tool `sessions.txt` and writes every session and account backup it describes into the `MetadataStore`. It's careful to write `backup_session.type` as the raw prefix (`BackupType.sessionPrefix()`, e.g. `"full"`) that `SqliteMetadataStore` expects, rather than the human-readable text the bash tool's own SQLite writer uses.
- Added a `zmbackup migrate` CLI subcommand (`app`) that reads `sessions.txt` from the configured `workDir`, delegates to `MigrationService`, and renames the file to `sessions.txt.migrated` on success — so re-running it (e.g. after `install-java.sh --force-upgrade`) is a no-op instead of re-inserting duplicate account records.
- Wired `installScriptJava/deploy.sh` (`deploy_new_java`/`deploy_upgrade_java`) to run `zmbackup migrate` automatically whenever a `sessions.txt` is found in the backup directory, so the migration happens without the operator needing to know about it.
- Documented the new command and automatic behavior in the README's "Installation (Java version)" section.

## Test plan

- [x] `./gradlew build` (all modules compile, existing test suites pass)
- [x] New unit tests: `core/src/test/java/io/zmbackup/core/service/MigrationServiceTest.java` (parsing/import logic: finished/failed/in-progress sessions, account records, malformed input)
- [x] New unit tests: `app/src/test/java/io/zmbackup/app/cli/MigrateCommandTest.java` (CLI wiring: import + rename, no-op when no `sessions.txt`, idempotent re-run, PID lock)
- [x] New bats tests in `tests/unit/test_installer_java_deploy.bats` verifying `deploy_new_java`/`deploy_upgrade_java` invoke `zmbackup migrate` only when a `sessions.txt` exists
- [x] `npx bats --verbose-run tests/unit/` — no regressions (all pre-existing failures are unrelated `sqlite3: command not found` from this sandbox lacking the CLI, not from these changes)


---
_Generated by [Claude Code](https://claude.ai/code/session_012ZQtnUVYVMMRBBp8dwm8NA)_