### PR TITLE
Add a zmbackup truncate command to empty the metadata database

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ hand at any time - `$ zmbackup migrate` - and is a no-op once there's nothing le
 renames `sessions.txt` to `sessions.txt.migrated` after a successful import, so re-running it,
 e.g. after `install-java.sh --force-upgrade`, doesn't import the same sessions twice).
 
+The Java build also has `zmbackup truncate`, mirroring the bash tool's `-t`/`--truncate` in
+spirit but scoped to the database only - it does not delete any backup files. It permanently
+empties `sessions.sqlite3` (every session and account record) and, like the bash tool's own
+`--force-clean` guard, refuses to do anything unless run as `zmbackup truncate --force-clean`.
+**This is for test/development installs only - never run it against production**, since the
+deleted session/account history cannot be recovered afterward. `install-java.sh --remove` offers
+to run it for you (with the same warning) before it removes the rest of the install.
+
 ```
 # cd zmbackup
 # ./install-java.sh

--- a/app/src/main/java/io/zmbackup/app/cli/Main.java
+++ b/app/src/main/java/io/zmbackup/app/cli/Main.java
@@ -23,7 +23,8 @@ import picocli.CommandLine.Spec;
             DeleteCommand.class,
             HousekeepCommand.class,
             AccountsCommand.class,
-            MigrateCommand.class
+            MigrateCommand.class,
+            TruncateCommand.class
         })
 public final class Main implements Callable<Integer> {
 

--- a/app/src/main/java/io/zmbackup/app/cli/TruncateCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/TruncateCommand.java
@@ -1,0 +1,64 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import java.io.PrintWriter;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/**
+ * Empties the SQLite metadata store, mirroring the bash tool's {@code -t}/{@code --truncate}
+ * ({@code leeroy_jenkins} in {@code DeleteAction.sh}) in spirit - including its confirmation
+ * guard - but scoped to the database only: unlike the bash tool, this does not delete the backup
+ * files on disk (use {@code zmbackup delete}/{@code housekeep}, or clear the work directory by
+ * hand, for that).
+ *
+ * <p>This is destructive and irreversible: it permanently deletes every backup session and
+ * account record, with no way to recover them afterward. It is intended only for resetting a
+ * test/development installation - never run it against a production zmbackup deployment. Like
+ * the bash tool's own {@code --force-clean} guard, it refuses to do anything unless
+ * {@code --force-clean} is passed explicitly.
+ */
+@Command(
+        name = "truncate",
+        description = "Empty the backup metadata database. TEST/DEV USE ONLY - never run this against production.")
+public final class TruncateCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private Main parent;
+
+    @Option(
+            names = "--force-clean",
+            description = "Confirm the truncate - required, since this action is irreversible.")
+    private boolean forceClean;
+
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        PrintWriter out = spec.commandLine().getOut();
+        PrintWriter err = spec.commandLine().getErr();
+
+        if (!forceClean) {
+            err.println("This action is irreversible: it permanently deletes every backup session and "
+                    + "account record from the database (the backup files on disk are left untouched). "
+                    + "Only ever use it against a test/development installation - never production, "
+                    + "since the deleted history cannot be recovered. Re-run with --force-clean to confirm.");
+            return CommandLine.ExitCode.USAGE;
+        }
+
+        AppContext context = AppContext.fromConfigFile(parent.configFile());
+        return LockedExecution.run(context, err, () -> {
+            out.println("TEST/DEV USE ONLY - truncating the backup metadata database. "
+                    + "The backup files on disk are not affected.");
+            int removed = context.sessionService().truncateDatabase();
+            out.println(removed + " backup session(s) removed from the database.");
+            return 0;
+        });
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cli/TruncateCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/TruncateCommandTest.java
@@ -1,0 +1,111 @@
+package io.zmbackup.app.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.app.PidLock;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+class TruncateCommandTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void refusesToRunWithoutForceCleanAndLeavesTheDatabaseUntouched() throws Exception {
+        Path configFile = writeConfig();
+        AppContext.fromConfigFile(configFile).metadataStore().save(session("ldap-1"));
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        CommandLine cmd = commandLine(out, err);
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "truncate");
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(err.toString().contains("--force-clean"));
+        assertEquals(1, AppContext.fromConfigFile(configFile).metadataStore().listSessions().size());
+    }
+
+    @Test
+    void forceCleanEmptiesTheDatabase() throws Exception {
+        Path configFile = writeConfig();
+        AppContext.fromConfigFile(configFile).metadataStore().save(session("ldap-1"));
+        AppContext.fromConfigFile(configFile).metadataStore().save(session("ldap-2"));
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "truncate", "--force-clean");
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("2 backup session(s) removed from the database."));
+        assertTrue(out.toString().contains("TEST/DEV USE ONLY"));
+        assertEquals(0, AppContext.fromConfigFile(configFile).metadataStore().listSessions().size());
+    }
+
+    @Test
+    void failsWithoutRunningWhenAnotherProcessHoldsTheLock() throws Exception {
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        CommandLine cmd = commandLine(out, err);
+
+        try (PidLock lock = PidLock.acquire(tempDir)) {
+            int exitCode = cmd.execute("--config", configFile.toString(), "truncate", "--force-clean");
+
+            assertEquals(CommandLine.ExitCode.SOFTWARE, exitCode);
+            assertTrue(err.toString().contains("already running"));
+        }
+    }
+
+    private static BackupSession session(String sessionId) {
+        Instant now = Instant.now();
+        return new BackupSession(sessionId, BackupType.LDAP, SessionStatus.FINISHED, now, now, "1K");
+    }
+
+    private Path writeConfig() throws IOException {
+        Path configFile = tempDir.resolve("zmbackup.yaml");
+        Files.writeString(
+                configFile,
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:389
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                zimbraMailbox:
+                  backupUser: zimbra
+                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
+                backup:
+                  workDir: %s
+                  logFile: %s
+                  blockedListFile: %s
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """
+                        .formatted(
+                                tempDir, tempDir.resolve("zmbackup.log"), tempDir.resolve("blockedlist.conf")));
+        return configFile;
+    }
+
+    private static CommandLine commandLine(StringWriter out, StringWriter err) {
+        CommandLine cmd = new CommandLine(new Main());
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(err));
+        return cmd;
+    }
+}

--- a/core/src/main/java/io/zmbackup/core/port/MetadataStore.java
+++ b/core/src/main/java/io/zmbackup/core/port/MetadataStore.java
@@ -29,6 +29,15 @@ public interface MetadataStore {
     /** Removes a session and its associated account records. */
     void deleteSession(String sessionId) throws IOException;
 
+    /**
+     * Deletes every session and account record, emptying the store completely. Unlike {@link
+     * #deleteSession}, this cannot be scoped or undone - callers are responsible for confirming
+     * intent first (see {@code zmbackup truncate}).
+     *
+     * @return the number of sessions removed
+     */
+    int truncate() throws IOException;
+
     /** Records that the account in {@code record} was backed up as part of its session. */
     void recordAccountBackup(BackupAccountRecord record) throws IOException;
 

--- a/core/src/main/java/io/zmbackup/core/service/SessionService.java
+++ b/core/src/main/java/io/zmbackup/core/service/SessionService.java
@@ -45,4 +45,16 @@ public class SessionService {
         metadataStore.deleteSession(sessionId);
         return true;
     }
+
+    /**
+     * Empties the metadata store of every session and account record, mirroring the bash tool's
+     * {@code -t}/{@code --truncate} ({@code leeroy_jenkins}) in spirit, but scoped to the database
+     * only - the backup files on disk are left untouched. Irreversible, so intended only for
+     * resetting a test/non-production installation; driven by {@code zmbackup truncate}.
+     *
+     * @return the number of sessions removed
+     */
+    public int truncateDatabase() throws IOException {
+        return metadataStore.truncate();
+    }
 }

--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -612,6 +612,11 @@ class BackupServiceTest {
         }
 
         @Override
+        public int truncate() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public synchronized void recordAccountBackup(BackupAccountRecord record) {
             accounts.computeIfAbsent(record.sessionId(), k -> new ArrayList<>()).add(record);
         }

--- a/core/src/test/java/io/zmbackup/core/service/HousekeepServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/HousekeepServiceTest.java
@@ -159,6 +159,11 @@ class HousekeepServiceTest {
         }
 
         @Override
+        public int truncate() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public void recordAccountBackup(BackupAccountRecord record) {
             accounts.computeIfAbsent(record.sessionId(), k -> new ArrayList<>()).add(record);
         }

--- a/core/src/test/java/io/zmbackup/core/service/MigrationServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/MigrationServiceTest.java
@@ -163,6 +163,11 @@ class MigrationServiceTest {
         }
 
         @Override
+        public int truncate() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public void recordAccountBackup(BackupAccountRecord record) {
             accounts.computeIfAbsent(record.sessionId(), key -> new ArrayList<>()).add(record);
         }

--- a/core/src/test/java/io/zmbackup/core/service/RestoreServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/RestoreServiceTest.java
@@ -359,6 +359,11 @@ class RestoreServiceTest {
         }
 
         @Override
+        public int truncate() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public void recordAccountBackup(BackupAccountRecord record) {
             accounts.computeIfAbsent(record.sessionId(), k -> new ArrayList<>()).add(record);
         }

--- a/core/src/test/java/io/zmbackup/core/service/SessionServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/SessionServiceTest.java
@@ -70,6 +70,26 @@ class SessionServiceTest {
         assertTrue(storageProvider.deletedSessions.isEmpty());
     }
 
+    @Test
+    void truncateDatabaseRemovesEverySessionAndAccountRecordButLeavesStorageAlone() throws IOException {
+        metadataStore.save(session("ldap-1", Instant.now()));
+        metadataStore.save(session("ldap-2", Instant.now()));
+        metadataStore.recordAccountBackup(
+                new BackupAccountRecord(null, "ldap-1", "alice@example.com", "1K", Instant.now(), Instant.now()));
+
+        int removed = sessionService.truncateDatabase();
+
+        assertEquals(2, removed);
+        assertEquals(List.of(), sessionService.listSessions());
+        assertEquals(List.of(), metadataStore.findAccountsForSession("ldap-1"));
+        assertTrue(storageProvider.deletedSessions.isEmpty());
+    }
+
+    @Test
+    void truncateDatabaseReturnsZeroWhenStoreAlreadyEmpty() throws IOException {
+        assertEquals(0, sessionService.truncateDatabase());
+    }
+
     private static BackupSession session(String sessionId, Instant startedAt) {
         return new BackupSession(sessionId, BackupType.LDAP, SessionStatus.FINISHED, startedAt, startedAt, "1K");
     }
@@ -142,6 +162,14 @@ class SessionServiceTest {
         public void deleteSession(String sessionId) {
             sessions.remove(sessionId);
             accounts.remove(sessionId);
+        }
+
+        @Override
+        public int truncate() {
+            int removed = sessions.size();
+            sessions.clear();
+            accounts.clear();
+            return removed;
         }
 
         @Override

--- a/installScriptJava/deploy.sh
+++ b/installScriptJava/deploy.sh
@@ -109,20 +109,46 @@ function deploy_upgrade_java() {
 }
 
 ################################################################################
+# truncate_database: Ask whether to also empty the SQLite metadata store (via
+# "zmbackup truncate --force-clean") before it's torn down along with the rest
+# of the install. Irreversible and, per "zmbackup truncate" itself, meant only
+# for a test/development install being decommissioned - never run it against
+# a production server, since the deleted session/account history cannot be
+# recovered. Must run before the jar/config are removed below, since the
+# command needs both to load.
+################################################################################
+function truncate_database() {
+  printf "Also empty the backup metadata database (sessions.sqlite3)? This only makes sense for a "
+  printf "\ntest/development install being torn down - it is irreversible and must NEVER be used on "
+  printf "\na production server. [y/N]"
+  read -r OPT
+  if [[ $OPT == 'y' || $OPT == 'Y' ]]; then
+    echo "Truncating the backup metadata database..."
+    sudo -H -u "$OSE_USER" bash -c "zmbackup truncate --force-clean"
+  fi
+}
+
+################################################################################
 # uninstall_java: Remove the Java build of Zmbackup and all files related
 ################################################################################
 function uninstall_java() {
   echo "Removing... Please wait while we make some changes."
-
-  rm -f "$ZMBKP_SRC"/zmbackup
-  rm -rf "$ZMBKP_LIB"
-  rm -f "$ZMBKP_CRON_FILE"
 
   WORKDIR=""
   if [[ -f "$ZMBKP_CONF"/zmbackup.yaml ]]; then
     WORKDIR=$(grep "workDir:" "$ZMBKP_CONF"/zmbackup.yaml | head -1 | awk '{print $2}')
   fi
 
+  # Ask about the database while the jar/config are still in place to run
+  # "zmbackup truncate" against - only offer it when there is actually an
+  # install left to run it with.
+  if [[ -f "$ZMBKP_LIB/$ZMBKP_JAR_NAME" ]] && [[ -f "$ZMBKP_CONF"/zmbackup.yaml ]]; then
+    truncate_database
+  fi
+
+  rm -f "$ZMBKP_SRC"/zmbackup
+  rm -rf "$ZMBKP_LIB"
+  rm -f "$ZMBKP_CRON_FILE"
   rm -rf "$ZMBKP_CONF"
 
   printf "Preserve Backup Storage?[n/Y]"

--- a/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
+++ b/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
@@ -154,6 +154,23 @@ public class SqliteMetadataStore implements MetadataStore {
     }
 
     @Override
+    public int truncate() throws IOException {
+        try (Connection connection = connect();
+                Statement statement = connection.createStatement()) {
+            int removed;
+            try (ResultSet rs = statement.executeQuery("select count(*) from backup_session")) {
+                rs.next();
+                removed = rs.getInt(1);
+            }
+            statement.execute("delete from backup_account");
+            statement.execute("delete from backup_session");
+            return removed;
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
     public void recordAccountBackup(BackupAccountRecord record) throws IOException {
         String sql =
                 "insert into backup_account (sessionID, account_size, email, initial_date, conclusion_date) "

--- a/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
+++ b/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
@@ -116,6 +116,24 @@ class SqliteMetadataStoreTest {
     }
 
     @Test
+    void truncateRemovesEverySessionAndAccountRecordAndReturnsCount() throws IOException {
+        store.save(session("full-1", SessionStatus.FINISHED, "10M"));
+        store.save(session("full-2", SessionStatus.IN_PROGRESS, null));
+        store.recordAccountBackup(accountRecord("full-1", "user@example.com"));
+
+        int removed = store.truncate();
+
+        assertEquals(2, removed);
+        assertEquals(List.of(), store.listSessions());
+        assertEquals(List.of(), store.findAccountsForSession("full-1"));
+    }
+
+    @Test
+    void truncateOnEmptyStoreReturnsZero() throws IOException {
+        assertEquals(0, store.truncate());
+    }
+
+    @Test
     void recordedAccountBackupCanBeFoundBySession() throws IOException {
         store.save(session("full-1", SessionStatus.FINISHED, "10M"));
         BackupAccountRecord record = accountRecord("full-1", "user@example.com");

--- a/tests/unit/test_installer_java_deploy.bats
+++ b/tests/unit/test_installer_java_deploy.bats
@@ -236,6 +236,41 @@ user@example.com"
   MOCK_SU_OUTPUT=""
   deploy_new_java
   touch "${OSE_DEFAULT_BKP_DIR}/sessions.sqlite3"
-  echo "N" | uninstall_java
+  printf 'N\nN\n' | uninstall_java
   [ ! -f "${OSE_DEFAULT_BKP_DIR}/sessions.sqlite3" ]
+}
+
+# ---------------------------------------------------------------------------
+# uninstall_java: truncate_database prompt
+# ---------------------------------------------------------------------------
+
+@test "uninstall_java: does not offer to truncate the database when there is no jar/config to run it against" {
+  mkdir -p "$ZMBKP_SRC" "$ZMBKP_CONF" "$ZMBKP_LIB"
+  echo "backup:" > "${ZMBKP_CONF}/zmbackup.yaml"
+  echo "  workDir: ${DEPLOY_ROOT}/backup" >> "${ZMBKP_CONF}/zmbackup.yaml"
+  mkdir -p "${DEPLOY_ROOT}/backup"
+  MOCK_SUDO_LOG="$(mktemp)"
+  export MOCK_SUDO_LOG
+  # Only one answer is needed ("Preserve Backup Storage?") since the truncate
+  # prompt must not run without an installed jar/config to invoke it against.
+  echo "N" | uninstall_java
+  [ ! -s "$MOCK_SUDO_LOG" ]
+}
+
+@test "uninstall_java: invokes zmbackup truncate --force-clean when the user opts in" {
+  MOCK_SU_OUTPUT=""
+  deploy_new_java
+  MOCK_SUDO_LOG="$(mktemp)"
+  export MOCK_SUDO_LOG
+  printf 'Y\nY\n' | uninstall_java
+  grep -q "zmbackup truncate --force-clean" "$MOCK_SUDO_LOG"
+}
+
+@test "uninstall_java: does not invoke zmbackup truncate when the user declines" {
+  MOCK_SU_OUTPUT=""
+  deploy_new_java
+  MOCK_SUDO_LOG="$(mktemp)"
+  export MOCK_SUDO_LOG
+  printf 'N\nN\n' | uninstall_java
+  ! grep -q "zmbackup truncate" "$MOCK_SUDO_LOG"
 }


### PR DESCRIPTION
## Summary
- Adds `zmbackup truncate` (Java CLI), mirroring the bash tool's `-t`/`--truncate` (`leeroy_jenkins`) in spirit — including its `--force-clean` confirmation gate — but scoped to the SQLite metadata database only: it never deletes backup files on disk.
- Without `--force-clean`, the command refuses to run, printing an irreversibility warning and returning the usage exit code without even loading config. With it, it acquires the `PidLock`, empties `backup_account`/`backup_session`, and reports how many sessions were removed.
- The command, its Javadoc, and the README all repeat the same warning: **this is for test/development installs only — never run it against production**, since the deleted session/account history cannot be recovered.
- Wires an opt-in prompt into `install-java.sh --remove`: while tearing down an install (and before the jar/config are removed), it now asks whether to also truncate the database, with the same test-only warning, before falling through to the pre-existing "Preserve Backup Storage?" prompt.

## Implementation
- `MetadataStore.truncate()` (new port method) → `SqliteMetadataStore.truncate()` (deletes both tables in one connection, returns the pre-delete session count).
- `SessionService.truncateDatabase()` delegates to it.
- `TruncateCommand` wires it up behind `--force-clean`, wrapped in `LockedExecution` like the other mutating commands.
- `installScriptJava/deploy.sh`: new `truncate_database()` function, called from `uninstall_java()` only when a jar/config are actually present to run `zmbackup truncate` against.

## Test plan
- [x] `./gradlew test` — full suite green, including new tests: `TruncateCommandTest` (refuses without `--force-clean` and leaves the DB untouched; empties it with `--force-clean`; respects `PidLock` contention), `SessionServiceTest#truncateDatabase*`, `SqliteMetadataStoreTest#truncate*`.
- [x] `npx bats tests/unit/` — full suite passes except pre-existing, unrelated `SQLITE3`-mode bash-tool failures caused by `sqlite3` not being installable in this sandbox (confirmed pre-existing/environmental, not caused by this change).
- [x] Updated and added `tests/unit/test_installer_java_deploy.bats` coverage for the new `uninstall_java` prompt (skipped when there's nothing to truncate against; invokes `zmbackup truncate --force-clean` on opt-in; doesn't on decline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEamQDmHL3NQuRXj85UJgh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEamQDmHL3NQuRXj85UJgh)_