### PR TITLE
Close remaining bash-parity gaps before decommissioning bash

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -91,7 +91,8 @@ public final class AppContext {
                 metadataStore,
                 blocklist,
                 notifier,
-                config.backup().maxParallelProcesses());
+                config.backup().maxParallelProcesses(),
+                config.backup().lockBackup());
         this.restoreService = new RestoreService(
                 ldapExporter, mailboxExporter, storageProvider, metadataStore, config.backup().maxParallelProcesses());
         this.housekeepService = new HousekeepService(storageProvider, metadataStore);

--- a/app/src/main/java/io/zmbackup/app/cli/BackupAliasCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupAliasCommand.java
@@ -21,6 +21,9 @@ public final class BackupAliasCommand implements Callable<Integer> {
     @Option(names = "--account", description = "Back up only this alias (repeatable); default: every alias.")
     private List<String> accounts = new ArrayList<>();
 
+    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
+    private String domain;
+
     @Spec
     private CommandSpec spec;
 
@@ -30,6 +33,6 @@ public final class BackupAliasCommand implements Callable<Integer> {
         return LockedExecution.run(
                 context,
                 spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.ALIAS, accounts, null));
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.ALIAS, accounts, domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupDistlistCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupDistlistCommand.java
@@ -23,6 +23,9 @@ public final class BackupDistlistCommand implements Callable<Integer> {
             description = "Back up only this distribution list (repeatable); default: every distribution list.")
     private List<String> accounts = new ArrayList<>();
 
+    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
+    private String domain;
+
     @Spec
     private CommandSpec spec;
 
@@ -33,6 +36,6 @@ public final class BackupDistlistCommand implements Callable<Integer> {
                 context,
                 spec.commandLine().getErr(),
                 () -> BackupRunner.run(
-                        context, spec.commandLine().getOut(), BackupType.DISTRIBUTION_LIST, accounts, null));
+                        context, spec.commandLine().getOut(), BackupType.DISTRIBUTION_LIST, accounts, domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupSignatureCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupSignatureCommand.java
@@ -23,6 +23,9 @@ public final class BackupSignatureCommand implements Callable<Integer> {
             description = "Back up only this account's signatures (repeatable); default: every account.")
     private List<String> accounts = new ArrayList<>();
 
+    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
+    private String domain;
+
     @Spec
     private CommandSpec spec;
 
@@ -32,6 +35,6 @@ public final class BackupSignatureCommand implements Callable<Integer> {
         return LockedExecution.run(
                 context,
                 spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.SIGNATURE, accounts, null));
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.SIGNATURE, accounts, domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/HousekeepCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/HousekeepCommand.java
@@ -38,11 +38,9 @@ public final class HousekeepCommand implements Callable<Integer> {
                 out.println("Backup session " + session.sessionId() + " removed.");
             }
 
-            out.println("Removing empty backup sessions - please wait.");
-            List<BackupSession> emptied = housekeepService.cleanEmpty();
-            for (BackupSession session : emptied) {
-                out.println("Backup session " + session.sessionId() + " removed.");
-            }
+            out.println("Removing empty files - please wait.");
+            int emptyFilesRemoved = housekeepService.cleanEmpty();
+            out.println(emptyFilesRemoved + " empty file(s) removed.");
 
             return 0;
         });

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
@@ -59,6 +59,13 @@ public final class RestoreCommand implements Callable<Integer> {
             err.println("restore: --into requires exactly one --account");
             return CommandLine.ExitCode.USAGE;
         }
+        if (destination == null && !(sessionId.startsWith("full") || sessionId.startsWith("inc"))) {
+            err.println(
+                    "restore: '--session=" + sessionId
+                            + "' is not a full/incremental session; use 'restore ldap', 'restore domain', or"
+                            + " 'restore mailbox' to restore one kind of content on its own.");
+            return CommandLine.ExitCode.USAGE;
+        }
 
         AppContext context = AppContext.fromConfigFile(parent.configFile());
         PrintWriter out = spec.commandLine().getOut();

--- a/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
@@ -96,7 +96,7 @@ class BackupCommandTest {
                 cmd.execute("--config", configFile.toString(), "backup", "ldap", "--account", "alice@example.com");
 
         assertEquals(0, exitCode);
-        assertTrue(Files.exists(tempDir.resolve("ldap-" + sessionSuffixOf(out) + "/alice@example.com.ldiff")));
+        assertTrue(Files.exists(tempDir.resolve("ldap-" + sessionSuffixOf(out, "ldap-") + "/alice@example.com.ldiff")));
     }
 
     @Test
@@ -265,6 +265,37 @@ class BackupCommandTest {
     }
 
     @Test
+    void distlistWithDomainOptionRestrictsDiscoveryToThatDomain() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "cn=engineering,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraDistributionList"),
+                new Attribute("cn", "engineering"),
+                new Attribute("mail", "engineering@example.com"));
+        directoryServer.add(
+                "dc=other,dc=com",
+                new Attribute("objectClass", "zimbraDomain"),
+                new Attribute("dc", "other"),
+                new Attribute("zimbraDomainName", "other.com"));
+        directoryServer.add(
+                "cn=sales,dc=other,dc=com",
+                new Attribute("objectClass", "zimbraDistributionList"),
+                new Attribute("cn", "sales"),
+                new Attribute("mail", "sales@other.com"));
+        Path configFile = writeConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode =
+                cmd.execute("--config", configFile.toString(), "backup", "distlist", "--domain", "other.com");
+
+        assertEquals(0, exitCode);
+        String sessionId = "distlist-" + sessionSuffixOf(out, "distlist-");
+        assertTrue(Files.exists(tempDir.resolve(sessionId + "/sales@other.com.ldiff")));
+        assertTrue(Files.notExists(tempDir.resolve(sessionId + "/engineering@example.com.ldiff")));
+    }
+
+    @Test
     void signaturePrintsNothingFoundWhenDirectoryHasNoSignatures() throws Exception {
         directoryServer = startDirectoryServer();
         Path configFile = writeConfig();
@@ -314,9 +345,9 @@ class BackupCommandTest {
         assertTrue(out.toString().contains("FINISHED"));
     }
 
-    private static String sessionSuffixOf(StringWriter out) {
+    private static String sessionSuffixOf(StringWriter out, String prefix) {
         String output = out.toString();
-        int start = output.indexOf("ldap-") + "ldap-".length();
+        int start = output.indexOf(prefix) + prefix.length();
         int end = output.indexOf(' ', start);
         return output.substring(start, end);
     }

--- a/app/src/test/java/io/zmbackup/app/cli/HousekeepCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/HousekeepCommandTest.java
@@ -27,7 +27,7 @@ class HousekeepCommandTest {
     Path tempDir;
 
     @Test
-    void removesOldAndEmptySessions() throws Exception {
+    void removesOldSessionsAndEmptyFiles() throws Exception {
         Path configFile = writeConfig(7);
         AppContext context = AppContext.fromConfigFile(configFile);
         Instant now = Instant.now();
@@ -46,9 +46,11 @@ class HousekeepCommandTest {
         context.metadataStore()
                 .recordAccountBackup(
                         new BackupAccountRecord(null, "ldap-recent", "bob@example.com", "1K", now, now));
-
-        BackupSession empty = session("ldap-empty", now);
-        context.metadataStore().save(empty);
+        context.storageProvider().openWrite("ldap-recent", "bob@example.com", "ldiff").close();
+        context.storageProvider().openWrite("ldap-recent", "carol@example.com", "ldiff").close();
+        try (var writer = context.storageProvider().openWrite("ldap-recent", "dan@example.com", "ldiff")) {
+            writer.write("dn: uid=dan\n".getBytes());
+        }
 
         StringWriter out = new StringWriter();
         CommandLine cmd = commandLine(out);
@@ -58,11 +60,13 @@ class HousekeepCommandTest {
         assertEquals(0, exitCode);
         String output = out.toString();
         assertTrue(output.contains("Backup session ldap-old removed."));
-        assertTrue(output.contains("Backup session ldap-empty removed."));
+        assertTrue(output.contains("empty file(s) removed."));
         assertFalse(output.contains("ldap-recent removed"));
         assertTrue(context.metadataStore().findSession("ldap-old").isEmpty());
-        assertTrue(context.metadataStore().findSession("ldap-empty").isEmpty());
         assertTrue(context.metadataStore().findSession("ldap-recent").isPresent());
+        assertTrue(context.storageProvider().exists("ldap-recent", "dan@example.com", "ldiff"));
+        assertFalse(context.storageProvider().exists("ldap-recent", "bob@example.com", "ldiff"));
+        assertFalse(context.storageProvider().exists("ldap-recent", "carol@example.com", "ldiff"));
     }
 
     @Test

--- a/app/src/test/java/io/zmbackup/app/cli/RestoreCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/RestoreCommandTest.java
@@ -183,6 +183,56 @@ class RestoreCommandTest {
     }
 
     @Test
+    void topLevelRestoreWithIntoBypassesTheFullIncrementalSessionCheck() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        startMailboxServer();
+        Path configFile = writeConfig();
+        StringWriter backupOut = new StringWriter();
+        commandLine(backupOut, new StringWriter())
+                .execute("--config", configFile.toString(), "backup", "mailbox", "--account", "alice@example.com");
+        String sessionId = sessionIdOf(backupOut, "mbox-");
+
+        StringWriter restoreOut = new StringWriter();
+        int restoreExit = commandLine(restoreOut, new StringWriter())
+                .execute(
+                        "--config", configFile.toString(), "restore", "--session", sessionId, "--account",
+                        "alice@example.com", "--into", "bob@example.com");
+
+        assertEquals(0, restoreExit);
+        assertEquals(List.of("POST /home/bob@example.com/"), mailboxRestorePosts);
+    }
+
+    @Test
+    void topLevelRestoreRejectsNonFullIncrementalSession() throws Exception {
+        directoryServer = startDirectoryServer();
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("mail", "alice@example.com"));
+        Path configFile = writeConfig();
+        StringWriter backupOut = new StringWriter();
+        int backupExit = commandLine(backupOut, new StringWriter())
+                .execute("--config", configFile.toString(), "backup", "ldap", "--account", "alice@example.com");
+        assertEquals(0, backupExit);
+        String sessionId = sessionIdOf(backupOut, "ldap-");
+        StringWriter err = new StringWriter();
+
+        int exitCode = commandLine(new StringWriter(), err)
+                .execute("--config", configFile.toString(), "restore", "--session", sessionId);
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(err.toString().contains("not a full/incremental session"));
+    }
+
+    @Test
     void topLevelRestoreRestoresLdapAndMailbox() throws Exception {
         directoryServer = startDirectoryServer();
         directoryServer.add(

--- a/core/src/main/java/io/zmbackup/core/port/MetadataStore.java
+++ b/core/src/main/java/io/zmbackup/core/port/MetadataStore.java
@@ -47,8 +47,17 @@ public interface MetadataStore {
     /**
      * When {@code email} was last successfully backed up — the latest
      * {@link BackupAccountRecord#completedAt()} across all of its sessions — or empty if it was
-     * never backed up. Used both to compute the "after" cutoff for incremental mailbox backups
-     * and to skip accounts already backed up today.
+     * never backed up. Used to compute the "after" cutoff for incremental mailbox backups.
      */
     Optional<Instant> lastSuccessfulBackupTime(String email) throws IOException;
+
+    /**
+     * Whether {@code identifier} has any account-level backup record ({@link
+     * BackupAccountRecord#completedAt()}) after {@code since}, across every session type and
+     * regardless of the owning session's overall status. Mirrors the bash tool's {@code
+     * ldap_filter} LOCK_BACKUP dedup check ({@code conclusion_date > YESTERDAY}): used by {@code
+     * BackupService} to skip discovery-based backups (not explicit {@code --account} lists) for
+     * objects already backed up within roughly the last day.
+     */
+    boolean backedUpSince(String identifier, Instant since) throws IOException;
 }

--- a/core/src/main/java/io/zmbackup/core/port/Notifier.java
+++ b/core/src/main/java/io/zmbackup/core/port/Notifier.java
@@ -13,6 +13,18 @@ public interface Notifier {
     /** Notifies that the backup session {@code sessionId} of {@code type} has started. */
     void notifyBegin(String sessionId, BackupType type) throws IOException;
 
-    /** Notifies that the backup session {@code sessionId} of {@code type} finished with {@code status}. */
-    void notifyFinish(String sessionId, BackupType type, SessionStatus status) throws IOException;
+    /**
+     * Notifies that the backup session {@code sessionId} of {@code type} finished with
+     * {@code status}, mirroring {@code notify_finish}'s {@code Size}/{@code Accounts} summary
+     * lines.
+     *
+     * @param size         the session's total stored size (e.g. {@code "10M"}), or {@code "0"}
+     *                     when {@code status} is not {@link SessionStatus#FINISHED}, mirroring
+     *                     {@code notify_finish}'s {@code SIZE=0} on failure
+     * @param accountCount how many objects were successfully backed up, or {@code 0} when
+     *                     {@code status} is not {@link SessionStatus#FINISHED}, mirroring
+     *                     {@code notify_finish}'s {@code QTDE=0} on failure
+     */
+    void notifyFinish(String sessionId, BackupType type, SessionStatus status, String size, int accountCount)
+            throws IOException;
 }

--- a/core/src/main/java/io/zmbackup/core/port/StorageProvider.java
+++ b/core/src/main/java/io/zmbackup/core/port/StorageProvider.java
@@ -40,4 +40,15 @@ public interface StorageProvider {
 
     /** Permanently removes all stored content for {@code sessionId}. */
     void deleteSession(String sessionId) throws IOException;
+
+    /**
+     * Deletes every zero-byte file stored across every session, mirroring the bash tool's
+     * {@code clean_empty} ({@code find "$WORKDIR" -type f -size 0 -delete}): a stray leftover
+     * from an interrupted or failed export, left behind alongside an otherwise-successful
+     * session's content. Unlike {@link #deleteSession}, this never removes a whole session or its
+     * metadata - only individual empty files.
+     *
+     * @return how many files were removed
+     */
+    int deleteEmptyFiles() throws IOException;
 }

--- a/core/src/main/java/io/zmbackup/core/service/BackupService.java
+++ b/core/src/main/java/io/zmbackup/core/service/BackupService.java
@@ -41,7 +41,8 @@ public class BackupService {
         public void notifyBegin(String sessionId, BackupType type) {}
 
         @Override
-        public void notifyFinish(String sessionId, BackupType type, SessionStatus status) {}
+        public void notifyFinish(
+                String sessionId, BackupType type, SessionStatus status, String size, int accountCount) {}
     };
 
     private static final DateTimeFormatter SESSION_TIMESTAMP =
@@ -55,6 +56,12 @@ public class BackupService {
      */
     private static final Duration INCREMENTAL_LOOKBACK = Duration.ofHours(48);
 
+    /**
+     * How far back {@code lockBackup} looks for a prior backup of a discovered identifier,
+     * mirroring {@code ldap_filter}'s {@code YESTERDAY} cutoff.
+     */
+    private static final Duration LOCK_BACKUP_WINDOW = Duration.ofHours(24);
+
     private final AccountDiscovery accountDiscovery;
     private final ZimbraLdapExporter ldapExporter;
     private final ZimbraMailboxExporter mailboxExporter;
@@ -63,6 +70,7 @@ public class BackupService {
     private final Blocklist blocklist;
     private final Notifier notifier;
     private final int maxParallelProcesses;
+    private final boolean lockBackup;
 
     public BackupService(
             AccountDiscovery accountDiscovery,
@@ -147,6 +155,41 @@ public class BackupService {
             Blocklist blocklist,
             Notifier notifier,
             int maxParallelProcesses) {
+        this(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                blocklist,
+                notifier,
+                maxParallelProcesses,
+                false);
+    }
+
+    /**
+     * @param blocklist            discovered accounts (or domains) found here are skipped rather
+     *                             than backed up, mirroring {@code ldap_filter}'s blocklist check
+     * @param notifier             notified when a session starts and finishes, mirroring {@code
+     *                             notify_begin}/{@code notify_finish}
+     * @param maxParallelProcesses how many accounts to back up concurrently, mirroring the bash
+     *                             tool's {@code MAX_PARALLEL_PROCESS}; values below 1 are treated
+     *                             as 1
+     * @param lockBackup           when true, discovered identifiers (not explicit {@code
+     *                             --account} lists) with an account-level backup completed within
+     *                             the last 24 hours are skipped, mirroring {@code ldap_filter}'s
+     *                             {@code LOCK_BACKUP} dedup check
+     */
+    public BackupService(
+            AccountDiscovery accountDiscovery,
+            ZimbraLdapExporter ldapExporter,
+            ZimbraMailboxExporter mailboxExporter,
+            StorageProvider storageProvider,
+            MetadataStore metadataStore,
+            Blocklist blocklist,
+            Notifier notifier,
+            int maxParallelProcesses,
+            boolean lockBackup) {
         this.accountDiscovery = Objects.requireNonNull(accountDiscovery, "accountDiscovery must not be null");
         this.ldapExporter = Objects.requireNonNull(ldapExporter, "ldapExporter must not be null");
         this.mailboxExporter = Objects.requireNonNull(mailboxExporter, "mailboxExporter must not be null");
@@ -155,6 +198,7 @@ public class BackupService {
         this.blocklist = Objects.requireNonNull(blocklist, "blocklist must not be null");
         this.notifier = Objects.requireNonNull(notifier, "notifier must not be null");
         this.maxParallelProcesses = maxParallelProcesses;
+        this.lockBackup = lockBackup;
     }
 
     /** Backs up every object of {@code type} found across the whole directory. */
@@ -205,7 +249,11 @@ public class BackupService {
         SessionStatus status = allSucceeded ? SessionStatus.FINISHED : SessionStatus.FAILED;
         BackupSession completed = new BackupSession(sessionId, type, status, sessionStart, sessionEnd, size);
         metadataStore.save(completed);
-        notifySafely(() -> notifier.notifyFinish(sessionId, type, status));
+        // Mirrors notify_finish's SIZE=0/QTDE=0 on a failed session: only report real numbers on success.
+        String notifySize = status == SessionStatus.FINISHED ? size : "0";
+        int notifyAccountCount =
+                status == SessionStatus.FINISHED ? metadataStore.findAccountsForSession(sessionId).size() : 0;
+        notifySafely(() -> notifier.notifyFinish(sessionId, type, status, notifySize, notifyAccountCount));
         return Optional.of(completed);
     }
 
@@ -284,9 +332,10 @@ public class BackupService {
 
     /**
      * Resolves the objects to back up. Explicit {@code identifiers} are used as-is, bypassing the
-     * blocklist, mirroring {@code backup_main}'s {@code -a}/{@code --account} path (which bypasses
-     * {@code build_listBKP} entirely); discovered objects are filtered against the blocklist, same
-     * as {@code build_listBKP} always does via {@code ldap_filter}.
+     * blocklist and {@code lockBackup} dedup, mirroring {@code backup_main}'s {@code -a}/{@code
+     * --account} path (which bypasses {@code build_listBKP} entirely); discovered objects are
+     * filtered against the blocklist and, when {@link #lockBackup} is enabled, against identifiers
+     * already backed up today - same as {@code build_listBKP} always does via {@code ldap_filter}.
      */
     private List<String> resolveIdentifiers(BackupType type, List<String> identifiers, String domain)
             throws IOException {
@@ -302,7 +351,7 @@ public class BackupService {
                     ? accountDiscovery.discover(objectType)
                     : accountDiscovery.discoverForDomain(objectType, domain);
         }
-        return filterBlocked(discovered);
+        return filterAlreadyBackedUpToday(filterBlocked(discovered));
     }
 
     private List<String> filterBlocked(List<String> identifiers) {
@@ -310,6 +359,27 @@ public class BackupService {
         for (String identifier : identifiers) {
             if (blocklist.isBlocked(identifier)) {
                 LOG.info(() -> identifier + " found inside blocked list - skipping.");
+            } else {
+                allowed.add(identifier);
+            }
+        }
+        return allowed;
+    }
+
+    /**
+     * When {@link #lockBackup} is enabled, drops identifiers already backed up within {@link
+     * #LOCK_BACKUP_WINDOW}, mirroring {@code ldap_filter}'s {@code LOCK_BACKUP} check. A no-op
+     * when {@link #lockBackup} is disabled.
+     */
+    private List<String> filterAlreadyBackedUpToday(List<String> identifiers) throws IOException {
+        if (!lockBackup) {
+            return identifiers;
+        }
+        Instant since = Instant.now().minus(LOCK_BACKUP_WINDOW);
+        List<String> allowed = new ArrayList<>(identifiers.size());
+        for (String identifier : identifiers) {
+            if (metadataStore.backedUpSince(identifier, since)) {
+                LOG.info(() -> identifier + " already has backup today - skipping.");
             } else {
                 allowed.add(identifier);
             }

--- a/core/src/main/java/io/zmbackup/core/service/HousekeepService.java
+++ b/core/src/main/java/io/zmbackup/core/service/HousekeepService.java
@@ -6,7 +6,6 @@ import io.zmbackup.core.port.StorageProvider;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -44,20 +43,14 @@ public class HousekeepService {
     }
 
     /**
-     * Deletes every session with no account records, mirroring {@code clean_empty}'s removal of
-     * empty leftovers from an interrupted or failed backup.
+     * Deletes every zero-byte file left under storage, mirroring {@code clean_empty}'s removal of
+     * empty leftovers (e.g. a partial export) from an interrupted or failed backup. Unlike {@link
+     * #rotateOldSessions}, this never removes a whole session or its metadata.
      *
-     * @return the sessions that were removed
+     * @return how many empty files were removed
      */
-    public List<BackupSession> cleanEmpty() throws IOException {
-        List<BackupSession> removed = new ArrayList<>();
-        for (BackupSession session : metadataStore.listSessions()) {
-            if (metadataStore.findAccountsForSession(session.sessionId()).isEmpty()) {
-                remove(session);
-                removed.add(session);
-            }
-        }
-        return removed;
+    public int cleanEmpty() throws IOException {
+        return storageProvider.deleteEmptyFiles();
     }
 
     private void remove(BackupSession session) throws IOException {

--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -175,6 +175,91 @@ class BackupServiceTest {
     }
 
     @Test
+    void lockBackupSkipsDiscoveredAccountAlreadyBackedUpToday() throws IOException {
+        accountDiscovery.wholeDirectory.put(LdapObjectType.ACCOUNT, List.of("alice@example.com", "bob@example.com"));
+        metadataStore.recordAccountBackup(new BackupAccountRecord(
+                null, "ldap-earlier", "bob@example.com", "1B", Instant.now(), Instant.now()));
+        BackupService lockedBackup = new BackupService(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                identifier -> false,
+                new RecordingNotifier(),
+                1,
+                true);
+
+        Optional<BackupSession> result = lockedBackup.backup(BackupType.LDAP);
+
+        assertTrue(result.isPresent());
+        assertEquals(
+                Set.of("alice@example.com"), namesOf(metadataStore.findAccountsForSession(result.get().sessionId())));
+    }
+
+    @Test
+    void lockBackupDoesNotSkipWhenPriorBackupIsOlderThanADay() throws IOException {
+        accountDiscovery.wholeDirectory.put(LdapObjectType.ACCOUNT, List.of("alice@example.com"));
+        metadataStore.recordAccountBackup(new BackupAccountRecord(
+                null,
+                "ldap-earlier",
+                "alice@example.com",
+                "1B",
+                Instant.now().minus(Duration.ofHours(30)),
+                Instant.now().minus(Duration.ofHours(30))));
+        BackupService lockedBackup = new BackupService(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                identifier -> false,
+                new RecordingNotifier(),
+                1,
+                true);
+
+        Optional<BackupSession> result = lockedBackup.backup(BackupType.LDAP);
+
+        assertTrue(result.isPresent());
+        assertEquals(
+                Set.of("alice@example.com"), namesOf(metadataStore.findAccountsForSession(result.get().sessionId())));
+    }
+
+    @Test
+    void lockBackupDisabledDoesNotSkipRecentlyBackedUpAccount() throws IOException {
+        accountDiscovery.wholeDirectory.put(LdapObjectType.ACCOUNT, List.of("alice@example.com"));
+        metadataStore.recordAccountBackup(new BackupAccountRecord(
+                null, "ldap-earlier", "alice@example.com", "1B", Instant.now(), Instant.now()));
+
+        Optional<BackupSession> result = backupService.backup(BackupType.LDAP);
+
+        assertTrue(result.isPresent());
+        assertEquals(
+                Set.of("alice@example.com"), namesOf(metadataStore.findAccountsForSession(result.get().sessionId())));
+    }
+
+    @Test
+    void explicitAccountBypassesLockBackup() throws IOException {
+        metadataStore.recordAccountBackup(new BackupAccountRecord(
+                null, "ldap-earlier", "alice@example.com", "1B", Instant.now(), Instant.now()));
+        BackupService lockedBackup = new BackupService(
+                accountDiscovery,
+                ldapExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                identifier -> false,
+                new RecordingNotifier(),
+                1,
+                true);
+
+        Optional<BackupSession> result = lockedBackup.backup(BackupType.LDAP, List.of("alice@example.com"));
+
+        assertTrue(result.isPresent());
+        assertEquals(SessionStatus.FINISHED, result.get().status());
+    }
+
+    @Test
     void explicitAccountBypassesBlocklist() throws IOException {
         BackupService blocklisted = new BackupService(
                 accountDiscovery,
@@ -257,7 +342,9 @@ class BackupServiceTest {
         assertEquals(2, notifier.calls.size());
         assertTrue(notifier.calls.get(0).startsWith("begin:"));
         assertEquals(
-                "finish:" + result.get().sessionId() + ":LDAP:" + result.get().status(), notifier.calls.get(1));
+                "finish:" + result.get().sessionId() + ":LDAP:" + result.get().status() + ":" + result.get().size()
+                        + ":1",
+                notifier.calls.get(1));
     }
 
     @Test
@@ -557,6 +644,11 @@ class BackupServiceTest {
             content.keySet().removeIf(key -> key.startsWith(sessionId + "/"));
         }
 
+        @Override
+        public int deleteEmptyFiles() {
+            throw new UnsupportedOperationException();
+        }
+
         private static String key(String sessionId, String account, String suffix) {
             return sessionId + "/" + account + "." + suffix;
         }
@@ -573,8 +665,9 @@ class BackupServiceTest {
         }
 
         @Override
-        public void notifyFinish(String sessionId, BackupType type, SessionStatus status) {
-            calls.add("finish:" + sessionId + ":" + type + ":" + status);
+        public void notifyFinish(
+                String sessionId, BackupType type, SessionStatus status, String size, int accountCount) {
+            calls.add("finish:" + sessionId + ":" + type + ":" + status + ":" + size + ":" + accountCount);
         }
     }
 
@@ -629,6 +722,15 @@ class BackupServiceTest {
         @Override
         public Optional<Instant> lastSuccessfulBackupTime(String email) {
             return Optional.ofNullable(lastBackupTimes.get(email));
+        }
+
+        @Override
+        public boolean backedUpSince(String identifier, Instant since) {
+            return accounts.values().stream()
+                    .flatMap(List::stream)
+                    .anyMatch(record -> record.email().equals(identifier)
+                            && record.completedAt() != null
+                            && record.completedAt().isAfter(since));
         }
     }
 }

--- a/core/src/test/java/io/zmbackup/core/service/HousekeepServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/HousekeepServiceTest.java
@@ -54,33 +54,41 @@ class HousekeepServiceTest {
     }
 
     @Test
-    void cleanEmptyRemovesSessionsWithNoAccountRecords() throws IOException {
-        BackupSession empty = session("ldap-empty", Instant.now());
-        BackupSession withAccounts = session("ldap-full", Instant.now());
-        metadataStore.save(empty);
-        metadataStore.save(withAccounts);
+    void cleanEmptyRemovesZeroByteFilesButKeepsTheSessionAndOtherContent() throws IOException {
+        BackupSession session = session("ldap-full", Instant.now());
+        metadataStore.save(session);
         metadataStore.recordAccountBackup(
                 new BackupAccountRecord(null, "ldap-full", "alice@example.com", "1K", Instant.now(), Instant.now()));
+        storageProvider.content.put("ldap-full/alice@example.com.ldiff", new byte[] {1});
+        storageProvider.content.put("ldap-full/bob@example.com.ldiff", new byte[0]);
 
-        List<BackupSession> removed = housekeepService.cleanEmpty();
+        int removed = housekeepService.cleanEmpty();
 
-        assertEquals(List.of(empty), removed);
-        assertEquals(Optional.empty(), metadataStore.findSession("ldap-empty"));
+        assertEquals(1, removed);
         assertTrue(metadataStore.findSession("ldap-full").isPresent());
-        assertTrue(storageProvider.deletedSessions.contains("ldap-empty"));
+        assertTrue(storageProvider.content.containsKey("ldap-full/alice@example.com.ldiff"));
+        assertTrue(!storageProvider.content.containsKey("ldap-full/bob@example.com.ldiff"));
+        assertTrue(!storageProvider.deletedSessions.contains("ldap-full"));
     }
 
     @Test
-    void cleanEmptyKeepsSessionsWithAccountRecords() throws IOException {
-        BackupSession withAccounts = session("ldap-full", Instant.now());
-        metadataStore.save(withAccounts);
-        metadataStore.recordAccountBackup(
-                new BackupAccountRecord(null, "ldap-full", "alice@example.com", "1K", Instant.now(), Instant.now()));
+    void cleanEmptyCountsZeroByteFilesAcrossSessions() throws IOException {
+        storageProvider.content.put("ldap-one/alice@example.com.ldiff", new byte[0]);
+        storageProvider.content.put("ldap-two/bob@example.com.ldiff", new byte[0]);
 
-        List<BackupSession> removed = housekeepService.cleanEmpty();
+        int removed = housekeepService.cleanEmpty();
 
-        assertTrue(removed.isEmpty());
-        assertTrue(metadataStore.findSession("ldap-full").isPresent());
+        assertEquals(2, removed);
+    }
+
+    @Test
+    void cleanEmptyReturnsZeroWhenNothingIsEmpty() throws IOException {
+        storageProvider.content.put("ldap-full/alice@example.com.ldiff", new byte[] {1});
+
+        int removed = housekeepService.cleanEmpty();
+
+        assertEquals(0, removed);
+        assertTrue(storageProvider.content.containsKey("ldap-full/alice@example.com.ldiff"));
     }
 
     private static BackupSession session(String sessionId, Instant completedAt) {
@@ -122,6 +130,17 @@ class HousekeepServiceTest {
         public void deleteSession(String sessionId) {
             deletedSessions.add(sessionId);
             content.keySet().removeIf(key -> key.startsWith(sessionId + "/"));
+        }
+
+        @Override
+        public int deleteEmptyFiles() {
+            List<String> empty =
+                    content.entrySet().stream()
+                            .filter(entry -> entry.getValue().length == 0)
+                            .map(Map.Entry::getKey)
+                            .toList();
+            empty.forEach(content::remove);
+            return empty.size();
         }
     }
 
@@ -175,6 +194,11 @@ class HousekeepServiceTest {
 
         @Override
         public Optional<Instant> lastSuccessfulBackupTime(String email) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean backedUpSince(String identifier, Instant since) {
             throw new UnsupportedOperationException();
         }
     }

--- a/core/src/test/java/io/zmbackup/core/service/MigrationServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/MigrationServiceTest.java
@@ -130,6 +130,11 @@ class MigrationServiceTest {
         public void deleteSession(String sessionId) {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public int deleteEmptyFiles() {
+            throw new UnsupportedOperationException();
+        }
     }
 
     /** In-memory {@link MetadataStore} fake backed by simple maps. */
@@ -179,6 +184,11 @@ class MigrationServiceTest {
 
         @Override
         public Optional<Instant> lastSuccessfulBackupTime(String email) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean backedUpSince(String identifier, Instant since) {
             throw new UnsupportedOperationException();
         }
     }

--- a/core/src/test/java/io/zmbackup/core/service/RestoreServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/RestoreServiceTest.java
@@ -324,6 +324,11 @@ class RestoreServiceTest {
             content.keySet().removeIf(key -> key.startsWith(sessionId + "/"));
         }
 
+        @Override
+        public int deleteEmptyFiles() {
+            throw new UnsupportedOperationException();
+        }
+
         private static String key(String sessionId, String account, String suffix) {
             return sessionId + "/" + account + "." + suffix;
         }
@@ -375,6 +380,11 @@ class RestoreServiceTest {
 
         @Override
         public Optional<Instant> lastSuccessfulBackupTime(String email) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean backedUpSince(String identifier, Instant since) {
             throw new UnsupportedOperationException();
         }
     }

--- a/core/src/test/java/io/zmbackup/core/service/SessionServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/SessionServiceTest.java
@@ -129,6 +129,11 @@ class SessionServiceTest {
             deletedSessions.add(sessionId);
             content.keySet().removeIf(key -> key.startsWith(sessionId + "/"));
         }
+
+        @Override
+        public int deleteEmptyFiles() {
+            throw new UnsupportedOperationException();
+        }
     }
 
     /** In-memory {@link MetadataStore} fake backed by simple maps. */
@@ -184,6 +189,11 @@ class SessionServiceTest {
 
         @Override
         public Optional<Instant> lastSuccessfulBackupTime(String email) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean backedUpSince(String identifier, Instant since) {
             throw new UnsupportedOperationException();
         }
     }

--- a/local/src/main/java/io/zmbackup/local/EmailNotifier.java
+++ b/local/src/main/java/io/zmbackup/local/EmailNotifier.java
@@ -65,15 +65,20 @@ public class EmailNotifier implements Notifier {
     }
 
     @Override
-    public void notifyFinish(String sessionId, BackupType type, SessionStatus status) throws IOException {
+    public void notifyFinish(
+            String sessionId, BackupType type, SessionStatus status, String size, int accountCount)
+            throws IOException {
         boolean shouldNotify = status == SessionStatus.FINISHED ? notifyOnFinishSuccess : notifyOnFinishError;
         if (!shouldNotify) {
             return;
         }
         String subject = "Zmbackup - Backup routine for " + type.sessionPrefix() + " " + status.dbValue();
         String body = "This is an automatic message to inform you that the " + type.sessionPrefix()
-                + " backup session " + sessionId + " completed at " + Instant.now() + " with status "
-                + status.dbValue() + ".\n";
+                + " backup session " + sessionId + " completed at " + Instant.now() + ".\n\n"
+                + "Here some information about this session:\n\n"
+                + "Size: " + size + "\n"
+                + "Accounts: " + accountCount + "\n"
+                + "Status: " + status.dbValue() + "\n";
         send(subject, body);
     }
 

--- a/local/src/main/java/io/zmbackup/local/LocalStorageProvider.java
+++ b/local/src/main/java/io/zmbackup/local/LocalStorageProvider.java
@@ -99,6 +99,25 @@ public class LocalStorageProvider implements StorageProvider {
         });
     }
 
+    @Override
+    public int deleteEmptyFiles() throws IOException {
+        if (!Files.isDirectory(workDir)) {
+            return 0;
+        }
+        int[] removed = {0};
+        Files.walkFileTree(workDir, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if (attrs.isRegularFile() && attrs.size() == 0) {
+                    Files.delete(file);
+                    removed[0]++;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        return removed[0];
+    }
+
     private Path sessionDir(String sessionId) {
         return workDir.resolve(sessionId);
     }

--- a/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
+++ b/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
@@ -231,6 +231,21 @@ public class SqliteMetadataStore implements MetadataStore {
         }
     }
 
+    @Override
+    public boolean backedUpSince(String identifier, Instant since) throws IOException {
+        String sql = "select 1 from backup_account where email = ? and conclusion_date > ? limit 1";
+        try (Connection connection = connect();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, identifier);
+            statement.setString(2, toDb(since));
+            try (ResultSet rs = statement.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
     private Connection connect() throws SQLException {
         Connection connection = DriverManager.getConnection(jdbcUrl);
         // Backup and restore sessions now run accounts through a thread pool (see

--- a/local/src/test/java/io/zmbackup/local/EmailNotifierTest.java
+++ b/local/src/test/java/io/zmbackup/local/EmailNotifierTest.java
@@ -64,10 +64,12 @@ class EmailNotifierTest {
         EmailNotifier notifier = new EmailNotifier(
                 "127.0.0.1", smtpServer.port(), "root@example.com", "admin@example.com", true, true, false);
 
-        notifier.notifyFinish("full-1", BackupType.FULL, SessionStatus.FINISHED);
+        notifier.notifyFinish("full-1", BackupType.FULL, SessionStatus.FINISHED, "10M", 3);
 
         FakeSmtpServer.Message message = smtpServer.awaitMessage();
         assertTrue(message.data().contains("FINISHED"));
+        assertTrue(message.data().contains("Size: 10M"));
+        assertTrue(message.data().contains("Accounts: 3"));
     }
 
     @Test
@@ -76,7 +78,7 @@ class EmailNotifierTest {
         EmailNotifier notifier = new EmailNotifier(
                 "127.0.0.1", smtpServer.port(), "root@example.com", "admin@example.com", true, false, true);
 
-        notifier.notifyFinish("full-1", BackupType.FULL, SessionStatus.FINISHED);
+        notifier.notifyFinish("full-1", BackupType.FULL, SessionStatus.FINISHED, "10M", 3);
 
         assertFalse(smtpServer.receivedAnyMessage());
     }
@@ -87,10 +89,12 @@ class EmailNotifierTest {
         EmailNotifier notifier = new EmailNotifier(
                 "127.0.0.1", smtpServer.port(), "root@example.com", "admin@example.com", true, false, true);
 
-        notifier.notifyFinish("full-1", BackupType.FULL, SessionStatus.FAILED);
+        notifier.notifyFinish("full-1", BackupType.FULL, SessionStatus.FAILED, "0", 0);
 
         FakeSmtpServer.Message message = smtpServer.awaitMessage();
         assertTrue(message.data().contains("FAILED"));
+        assertTrue(message.data().contains("Size: 0"));
+        assertTrue(message.data().contains("Accounts: 0"));
     }
 
     @Test

--- a/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
+++ b/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
@@ -201,6 +201,48 @@ class SqliteMetadataStoreTest {
         assertEquals(Optional.empty(), store.lastSuccessfulBackupTime("user@example.com"));
     }
 
+    @Test
+    void backedUpSinceIsFalseWhenAccountNeverBackedUp() throws IOException {
+        assertEquals(false, store.backedUpSince("user@example.com", Instant.now().minus(24, ChronoUnit.HOURS)));
+    }
+
+    @Test
+    void backedUpSinceIsTrueWhenAccountBackedUpAfterCutoff() throws IOException {
+        Instant now = Instant.now();
+        store.save(session("ldap-1", BackupType.LDAP, SessionStatus.FINISHED, now));
+        store.recordAccountBackup(accountRecord("ldap-1", "user@example.com", now));
+
+        assertEquals(true, store.backedUpSince("user@example.com", now.minus(24, ChronoUnit.HOURS)));
+    }
+
+    @Test
+    void backedUpSinceIsFalseWhenLastBackupIsBeforeCutoff() throws IOException {
+        Instant old = Instant.now().minus(30, ChronoUnit.HOURS);
+        store.save(session("ldap-1", BackupType.LDAP, SessionStatus.FINISHED, old));
+        store.recordAccountBackup(accountRecord("ldap-1", "user@example.com", old));
+
+        assertEquals(
+                false, store.backedUpSince("user@example.com", Instant.now().minus(24, ChronoUnit.HOURS)));
+    }
+
+    @Test
+    void backedUpSinceIgnoresTheOwningSessionsOverallStatus() throws IOException {
+        Instant now = Instant.now();
+        store.save(session("full-1", BackupType.FULL, SessionStatus.FAILED, now));
+        store.recordAccountBackup(accountRecord("full-1", "user@example.com", now));
+
+        assertEquals(true, store.backedUpSince("user@example.com", now.minus(24, ChronoUnit.HOURS)));
+    }
+
+    @Test
+    void backedUpSinceIgnoresOtherAccounts() throws IOException {
+        Instant now = Instant.now();
+        store.save(session("ldap-1", BackupType.LDAP, SessionStatus.FINISHED, now));
+        store.recordAccountBackup(accountRecord("ldap-1", "other@example.com", now));
+
+        assertEquals(false, store.backedUpSince("user@example.com", now.minus(24, ChronoUnit.HOURS)));
+    }
+
     private static BackupSession session(String sessionId, SessionStatus status, String size) {
         Instant now = Instant.now();
         Instant completedAt = status == SessionStatus.IN_PROGRESS ? null : now;


### PR DESCRIPTION
## Summary

Fixes five behavioral gaps identified in a bash-vs-Java parity audit, ahead of decommissioning `project/lib/bash/` (tracked in #324, gated on #260/#323):

- **`backup.lockBackup` wired up** — `BackupService` now skips discovery-based identifiers (not explicit `--account`/`--domain` ones) already backed up in the last 24h, mirroring `ldap_filter`'s `LOCK_BACKUP` dedup. Previously the config field was parsed but never consulted, so a repeated `backup full` in the same day would re-back-up every account.
- **`--domain` added to `backup alias`/`backup distlist`/`backup signature`** — these three subcommands were missing domain scoping that `backup ldap`/`backup full`/etc. already had, even though bash's `build_listBKP` supports `-d`/`--domain` uniformly across every LDAP object type.
- **Bare `restore --session <id>` now rejects non-full/incremental sessions** — matches the bash entry script's `[[ "$2" == "full"* || "$2" == "inc"* ]]` guard. Previously it would attempt an LDAP+mailbox restore against any session type (e.g. `ldap-*`, `mbox-*`), producing confusing partial-failure output instead of a clear usage error. `--into`/restore-on-account is unaffected (mirrors bash's separate `-ro` flag, which has no such restriction).
- **`housekeep`'s `cleanEmpty()` fixed to actually mirror `clean_empty`** — it now deletes zero-byte files anywhere under storage (`find "$WORKDIR" -type f -size 0 -delete`), same as bash, instead of deleting whole sessions with zero recorded accounts, which was a different and more destructive operation bash never performed. Added `StorageProvider.deleteEmptyFiles()` to back it.
- **Finish notification email content restored** — the `Size`/`Accounts`/`Status` summary lines from bash's `notify_finish` are back (they were dropped to a bare status line during the port). `Notifier.notifyFinish` now takes `size`/`accountCount`, computed by `BackupService` the same way bash does (`"0"`/`0` on a failed session).

## Test plan

- [x] `./gradlew test` — full suite across `core`, `local`, `zimbra`, `app` (including the Cucumber integration suite and the shadow-jar packaging smoke test) passes.
- [x] Added/updated unit and CLI-level tests for each fix (`BackupServiceTest`, `SqliteMetadataStoreTest`, `RestoreCommandTest`, `HousekeepServiceTest`, `HousekeepCommandTest`, `EmailNotifierTest`, `BackupCommandTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4dy4uwgGMbZUTFngRGJE2

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4dy4uwgGMbZUTFngRGJE2)_