### PR TITLE
Add CLI input validation and privilege-boundary enforcement

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -52,6 +52,8 @@ public final class AppContext {
     /** Root logger name every zmbackup class logs under, so one appender pair covers all of them. */
     private static final String ROOT_LOGGER_NAME = "io.zmbackup";
 
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(AppContext.class);
+
     private final AppConfig config;
     private final StorageProvider storageProvider;
     private final MetadataStore metadataStore;
@@ -65,8 +67,18 @@ public final class AppContext {
     private final MigrationService migrationService;
 
     public AppContext(AppConfig config) throws IOException {
+        checkBackupUser(config);
         this.config = config;
         installLogging(config.backup().logFile());
+        if (!config.zimbraLdap().sslEnabled()) {
+            // Unlike the bash tool, whose ldapsearch/ldapadd/ldapdelete calls always upgraded with
+            // StartTLS (-Z) regardless of SSL_ENABLE (which there only chose http vs. https for the
+            // mailbox REST endpoint), zimbraLdap.sslEnabled here directly gates StartTLS on the LDAP
+            // admin bind - disabling it sends the bind password in cleartext.
+            LOG.warn(
+                    "zimbraLdap.sslEnabled is false: the LDAP admin bind will not use StartTLS and its"
+                            + " credentials will be sent in cleartext. The bash tool never allowed this.");
+        }
         this.storageProvider = new LocalStorageProvider(config.backup().workDir());
         this.metadataStore = new SqliteMetadataStore(config.backup().workDir().resolve(METADATA_STORE_FILENAME));
         UnboundIdLdapAdapter ldapAdapter = new UnboundIdLdapAdapter(
@@ -97,6 +109,20 @@ public final class AppContext {
                 ldapExporter, mailboxExporter, storageProvider, metadataStore, config.backup().maxParallelProcesses());
         this.housekeepService = new HousekeepService(storageProvider, metadataStore);
         this.migrationService = new MigrationService(storageProvider, metadataStore);
+    }
+
+    /**
+     * Refuses to run when the OS user invoking the process doesn't match {@code
+     * zimbraMailbox.backupUser}, mirroring the bash tool's {@code validate_config}: {@code if [
+     * "$(whoami)" != "$BACKUPUSER" ]; then echo "You need to be $BACKUPUSER to run this
+     * software."; exit 2; fi}.
+     */
+    private static void checkBackupUser(AppConfig config) {
+        String expected = config.zimbraMailbox().backupUser();
+        String actual = System.getProperty("user.name");
+        if (!expected.equals(actual)) {
+            throw new PrivilegeException("You need to be " + expected + " to run this software.");
+        }
     }
 
     /**

--- a/app/src/main/java/io/zmbackup/app/PrivilegeException.java
+++ b/app/src/main/java/io/zmbackup/app/PrivilegeException.java
@@ -1,0 +1,13 @@
+package io.zmbackup.app;
+
+/**
+ * Thrown when the OS user running zmbackup doesn't match {@code zimbraMailbox.backupUser},
+ * mirroring the bash tool's {@code validate_config} refusing to run unless {@code whoami ==
+ * $BACKUPUSER}.
+ */
+public class PrivilegeException extends RuntimeException {
+
+    public PrivilegeException(String message) {
+        super(message);
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/AccountsListCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/AccountsListCommand.java
@@ -6,6 +6,7 @@ import io.zmbackup.core.port.AccountDiscovery;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.concurrent.Callable;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
@@ -30,6 +31,9 @@ public final class AccountsListCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
+        if (!CliValidation.validateDomain(domain, spec.commandLine().getErr())) {
+            return CommandLine.ExitCode.USAGE;
+        }
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
         AccountDiscovery accountDiscovery = context.accountDiscovery();
         List<String> accounts =

--- a/app/src/main/java/io/zmbackup/app/cli/BackupAliasCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupAliasCommand.java
@@ -33,6 +33,6 @@ public final class BackupAliasCommand implements Callable<Integer> {
         return LockedExecution.run(
                 context,
                 spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.ALIAS, accounts, domain));
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), spec.commandLine().getErr(), BackupType.ALIAS, accounts, domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupDistlistCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupDistlistCommand.java
@@ -36,6 +36,11 @@ public final class BackupDistlistCommand implements Callable<Integer> {
                 context,
                 spec.commandLine().getErr(),
                 () -> BackupRunner.run(
-                        context, spec.commandLine().getOut(), BackupType.DISTRIBUTION_LIST, accounts, domain));
+                        context,
+                        spec.commandLine().getOut(),
+                        spec.commandLine().getErr(),
+                        BackupType.DISTRIBUTION_LIST,
+                        accounts,
+                        domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupDomainCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupDomainCommand.java
@@ -30,6 +30,6 @@ public final class BackupDomainCommand implements Callable<Integer> {
         return LockedExecution.run(
                 context,
                 spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.DOMAIN, domains, null));
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), spec.commandLine().getErr(), BackupType.DOMAIN, domains, null));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupFullCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupFullCommand.java
@@ -36,6 +36,6 @@ public final class BackupFullCommand implements Callable<Integer> {
         return LockedExecution.run(
                 context,
                 spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.FULL, accounts, domain));
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), spec.commandLine().getErr(), BackupType.FULL, accounts, domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupIncrementalCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupIncrementalCommand.java
@@ -37,6 +37,11 @@ public final class BackupIncrementalCommand implements Callable<Integer> {
                 context,
                 spec.commandLine().getErr(),
                 () -> BackupRunner.run(
-                        context, spec.commandLine().getOut(), BackupType.INCREMENTAL, accounts, domain));
+                        context,
+                        spec.commandLine().getOut(),
+                        spec.commandLine().getErr(),
+                        BackupType.INCREMENTAL,
+                        accounts,
+                        domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupLdapCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupLdapCommand.java
@@ -33,6 +33,6 @@ public final class BackupLdapCommand implements Callable<Integer> {
         return LockedExecution.run(
                 context,
                 spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.LDAP, accounts, domain));
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), spec.commandLine().getErr(), BackupType.LDAP, accounts, domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupMailboxCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupMailboxCommand.java
@@ -36,6 +36,6 @@ public final class BackupMailboxCommand implements Callable<Integer> {
         return LockedExecution.run(
                 context,
                 spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.MAILBOX, accounts, domain));
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), spec.commandLine().getErr(), BackupType.MAILBOX, accounts, domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupRunner.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupRunner.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Optional;
+import picocli.CommandLine;
 
 /** Shared body for the {@code backup ldap/alias/distlist/signature/domain} subcommands. */
 final class BackupRunner {
@@ -19,11 +20,23 @@ final class BackupRunner {
      * {@code out}.
      *
      * @return {@code 0} if the session finished (or there was nothing to back up), {@code 1} if
-     *     any object in the session failed to export
+     *     any object in the session failed to export, or the usage exit code if {@code
+     *     identifiers}/{@code domain} fail CLI-level format validation (see {@link CliValidation})
      */
     static int run(
-            AppContext context, PrintWriter out, BackupType type, List<String> identifiers, String domain)
+            AppContext context,
+            PrintWriter out,
+            PrintWriter err,
+            BackupType type,
+            List<String> identifiers,
+            String domain)
             throws IOException {
+        boolean valid = type == BackupType.DOMAIN
+                ? CliValidation.validateDomains(identifiers, err)
+                : CliValidation.validateEmails(identifiers, err) && CliValidation.validateDomain(domain, err);
+        if (!valid) {
+            return CommandLine.ExitCode.USAGE;
+        }
         Optional<BackupSession> result = context.backupService().backup(type, identifiers, domain);
         if (result.isEmpty()) {
             out.println("Nothing found to back up for " + type.sessionPrefix() + ".");

--- a/app/src/main/java/io/zmbackup/app/cli/BackupSignatureCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupSignatureCommand.java
@@ -35,6 +35,6 @@ public final class BackupSignatureCommand implements Callable<Integer> {
         return LockedExecution.run(
                 context,
                 spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), BackupType.SIGNATURE, accounts, domain));
+                () -> BackupRunner.run(context, spec.commandLine().getOut(), spec.commandLine().getErr(), BackupType.SIGNATURE, accounts, domain));
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/CliValidation.java
+++ b/app/src/main/java/io/zmbackup/app/cli/CliValidation.java
@@ -1,0 +1,100 @@
+package io.zmbackup.app.cli;
+
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * CLI-level input format validation for {@code --account}/{@code --domain}/{@code --session}
+ * values, mirroring the bash tool's {@code validate_email}/{@code validate_domain}/{@code
+ * validate_session_id} ({@code MiscAction.sh}), applied before {@code build_listBKP}/{@code
+ * backup_main} in {@code validate_account_args} and before each {@code -r} branch's own session
+ * lookup in {@code project/zmbackup}. Rejecting malformed input here, before it reaches an LDAP
+ * filter, file path, or SQL parameter, gives an immediate, explicit error instead of the value
+ * failing deeper in the stack (e.g. an LDAP search returning zero results, or a restore reporting
+ * "0/0 accounts restored" for a session that could never have existed).
+ */
+final class CliValidation {
+
+    private static final Pattern EMAIL = Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+    private static final Pattern DOMAIN = Pattern.compile("^[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+    private static final Pattern SESSION_ID =
+            Pattern.compile("^(full|inc|ldap|domain|distlist|alias|mbox|signature)-[0-9]{14}$");
+
+    private CliValidation() {}
+
+    /**
+     * Validates every value in {@code emails} against the bash tool's email pattern, printing
+     * {@code "Error! Invalid email address: <value>"} to {@code err} and returning {@code false}
+     * on the first mismatch.
+     */
+    static boolean validateEmails(List<String> emails, PrintWriter err) {
+        for (String email : emails) {
+            if (!EMAIL.matcher(email).matches()) {
+                err.println("Error! Invalid email address: " + email);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Validates a single email value (e.g. {@code --into}), printing {@code "Error! Invalid email
+     * address: <value>"} to {@code err} and returning {@code false} on a mismatch. {@code null} is
+     * treated as valid (an absent optional value).
+     */
+    static boolean validateEmail(String email, PrintWriter err) {
+        if (email == null) {
+            return true;
+        }
+        if (!EMAIL.matcher(email).matches()) {
+            err.println("Error! Invalid email address: " + email);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Validates every value in {@code domains} against the bash tool's domain pattern, printing
+     * {@code "Error! Invalid domain name: <value>"} to {@code err} and returning {@code false} on
+     * the first mismatch.
+     */
+    static boolean validateDomains(List<String> domains, PrintWriter err) {
+        for (String domain : domains) {
+            if (!DOMAIN.matcher(domain).matches()) {
+                err.println("Error! Invalid domain name: " + domain);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Validates a single domain value, printing {@code "Error! Invalid domain name: <value>"} to
+     * {@code err} and returning {@code false} on a mismatch. {@code null} is treated as valid (an
+     * absent optional value).
+     */
+    static boolean validateDomain(String domain, PrintWriter err) {
+        if (domain == null) {
+            return true;
+        }
+        if (!DOMAIN.matcher(domain).matches()) {
+            err.println("Error! Invalid domain name: " + domain);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Validates {@code sessionId} against the bash tool's {@code {prefix}-{14-digit timestamp}}
+     * session ID pattern, printing {@code "Error! Invalid session ID: <value>"} to {@code err} and
+     * returning {@code false} on a mismatch.
+     */
+    static boolean validateSessionId(String sessionId, PrintWriter err) {
+        if (!SESSION_ID.matcher(sessionId).matches()) {
+            err.println("Error! Invalid session ID: " + sessionId);
+            return false;
+        }
+        return true;
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/DeleteCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/DeleteCommand.java
@@ -3,6 +3,7 @@ package io.zmbackup.app.cli;
 import io.zmbackup.app.AppContext;
 import java.io.PrintWriter;
 import java.util.concurrent.Callable;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
@@ -24,9 +25,13 @@ public final class DeleteCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
+        PrintWriter err = spec.commandLine().getErr();
+        if (!CliValidation.validateSessionId(sessionId, err)) {
+            return CommandLine.ExitCode.USAGE;
+        }
+
         AppContext context = AppContext.fromConfigFile(parent.configFile());
         PrintWriter out = spec.commandLine().getOut();
-        PrintWriter err = spec.commandLine().getErr();
 
         return LockedExecution.run(context, err, () -> {
             out.println("Removing session " + sessionId + " - please wait.");

--- a/app/src/main/java/io/zmbackup/app/cli/Main.java
+++ b/app/src/main/java/io/zmbackup/app/cli/Main.java
@@ -1,5 +1,6 @@
 package io.zmbackup.app.cli;
 
+import io.zmbackup.app.PrivilegeException;
 import io.zmbackup.app.config.YamlConfigLoader;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
@@ -41,7 +42,25 @@ public final class Main implements Callable<Integer> {
     private CommandSpec spec;
 
     public static void main(String[] args) {
-        System.exit(new CommandLine(new Main()).execute(args));
+        System.exit(commandLine().execute(args));
+    }
+
+    /**
+     * Builds the {@link CommandLine} with a handler that reports {@link PrivilegeException}
+     * cleanly (message + the usage exit code, mirroring the bash tool's {@code validate_config}
+     * {@code exit 2}) instead of picocli's default stack-trace dump.
+     */
+    static CommandLine commandLine() {
+        CommandLine cmd = new CommandLine(new Main());
+        cmd.setExecutionExceptionHandler((ex, commandLine, parseResult) -> {
+            if (ex instanceof PrivilegeException) {
+                commandLine.getErr().println(ex.getMessage());
+                return CommandLine.ExitCode.USAGE;
+            }
+            ex.printStackTrace(commandLine.getErr());
+            return CommandLine.ExitCode.SOFTWARE;
+        });
+        return cmd;
     }
 
     /** The config file passed via {@code --config}, or {@link YamlConfigLoader#DEFAULT_CONFIG_PATH}. */

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
@@ -55,6 +55,12 @@ public final class RestoreCommand implements Callable<Integer> {
             err.println("restore: missing required option '--session=<sessionId>'");
             return CommandLine.ExitCode.USAGE;
         }
+        if (!CliValidation.validateSessionId(sessionId, err)) {
+            return CommandLine.ExitCode.USAGE;
+        }
+        if (!(CliValidation.validateEmails(accounts, err) && CliValidation.validateEmail(destination, err))) {
+            return CommandLine.ExitCode.USAGE;
+        }
         if (destination != null && accounts.size() != 1) {
             err.println("restore: --into requires exactly one --account");
             return CommandLine.ExitCode.USAGE;

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreDomainCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreDomainCommand.java
@@ -2,9 +2,11 @@ package io.zmbackup.app.cli;
 
 import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.RestoreResult;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
@@ -29,8 +31,12 @@ public final class RestoreDomainCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
+        PrintWriter err = spec.commandLine().getErr();
+        if (!CliValidation.validateSessionId(sessionId, err) || !CliValidation.validateDomains(domains, err)) {
+            return CommandLine.ExitCode.USAGE;
+        }
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(context, spec.commandLine().getErr(), () -> {
+        return LockedExecution.run(context, err, () -> {
             RestoreResult result = context.restoreService().restoreDomain(sessionId, domains);
             return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
         });

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreLdapCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreLdapCommand.java
@@ -2,9 +2,11 @@ package io.zmbackup.app.cli;
 
 import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.RestoreResult;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
@@ -29,8 +31,12 @@ public final class RestoreLdapCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
+        PrintWriter err = spec.commandLine().getErr();
+        if (!CliValidation.validateSessionId(sessionId, err) || !CliValidation.validateEmails(accounts, err)) {
+            return CommandLine.ExitCode.USAGE;
+        }
         AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(context, spec.commandLine().getErr(), () -> {
+        return LockedExecution.run(context, err, () -> {
             RestoreResult result = context.restoreService().restoreLdap(sessionId, accounts);
             return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
         });

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreMailboxCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreMailboxCommand.java
@@ -37,6 +37,11 @@ public final class RestoreMailboxCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         PrintWriter err = spec.commandLine().getErr();
+        if (!CliValidation.validateSessionId(sessionId, err)
+                || !CliValidation.validateEmails(accounts, err)
+                || !CliValidation.validateEmail(destination, err)) {
+            return CommandLine.ExitCode.USAGE;
+        }
         if (destination != null && accounts.size() != 1) {
             err.println("restore mailbox: --into requires exactly one --account");
             return CommandLine.ExitCode.USAGE;

--- a/app/src/test/java/io/zmbackup/app/AppContextTest.java
+++ b/app/src/test/java/io/zmbackup/app/AppContextTest.java
@@ -2,6 +2,7 @@ package io.zmbackup.app;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.zmbackup.app.config.AppConfig;
@@ -50,7 +51,7 @@ class AppContextTest {
                   bindDn: uid=zimbra,cn=admins,cn=zimbra
                   bindPassword: secret
                 zimbraMailbox:
-                  backupUser: zimbra
+                  backupUser: %s
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
@@ -64,7 +65,10 @@ class AppContextTest {
                     sender: root@example.com
                 """
                         .formatted(
-                                tempDir, tempDir.resolve("zmbackup.log"), tempDir.resolve("blockedlist.conf")));
+                                System.getProperty("user.name"),
+                                tempDir,
+                                tempDir.resolve("zmbackup.log"),
+                                tempDir.resolve("blockedlist.conf")));
 
         AppContext context = AppContext.fromConfigFile(configFile);
 
@@ -72,11 +76,24 @@ class AppContextTest {
         assertTrue(Files.exists(tempDir.resolve("sessions.sqlite3")));
     }
 
+    @Test
+    void constructorRejectsMismatchedBackupUser() {
+        AppConfig config = configWithWorkDir(tempDir, "not-the-real-user");
+
+        PrivilegeException exception = assertThrows(PrivilegeException.class, () -> new AppContext(config));
+
+        assertEquals("You need to be not-the-real-user to run this software.", exception.getMessage());
+    }
+
     private static AppConfig configWithWorkDir(Path workDir) {
+        return configWithWorkDir(workDir, System.getProperty("user.name"));
+    }
+
+    private static AppConfig configWithWorkDir(Path workDir, String backupUser) {
         return new AppConfig(
                 new ZimbraLdapConfig("ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true),
                 new ZimbraMailboxConfig(
-                        "zimbra",
+                        backupUser,
                         Path.of("/opt/zimbra/bin/zmmailbox"),
                         true,
                         "https://127.0.0.1:7071",

--- a/app/src/test/java/io/zmbackup/app/cli/AccountsCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/AccountsCommandTest.java
@@ -117,7 +117,7 @@ class AccountsCommandTest {
                   bindPassword: secret
                   sslEnabled: false
                 zimbraMailbox:
-                  backupUser: zimbra
+                  backupUser: %s
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
@@ -132,6 +132,7 @@ class AccountsCommandTest {
                 """
                         .formatted(
                                 directoryServer.getListenPort(),
+                                System.getProperty("user.name"),
                                 tempDir,
                                 tempDir.resolve("zmbackup.log"),
                                 tempDir.resolve("blockedlist.conf")));
@@ -139,7 +140,7 @@ class AccountsCommandTest {
     }
 
     private static CommandLine commandLine(StringWriter out, StringWriter err) {
-        CommandLine cmd = new CommandLine(new Main());
+        CommandLine cmd = Main.commandLine();
         cmd.setOut(new PrintWriter(out));
         cmd.setErr(new PrintWriter(err));
         return cmd;

--- a/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
@@ -53,6 +53,46 @@ class BackupCommandTest {
     }
 
     @Test
+    void ldapWithMalformedAccountIsRejected() throws Exception {
+        directoryServer = startDirectoryServer();
+        Path configFile = writeConfig();
+        StringWriter err = new StringWriter();
+        CommandLine cmd = commandLine(new StringWriter(), err);
+
+        int exitCode =
+                cmd.execute("--config", configFile.toString(), "backup", "ldap", "--account", "not-an-email");
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(err.toString().contains("Error! Invalid email address: not-an-email"));
+    }
+
+    @Test
+    void ldapWithMalformedDomainIsRejected() throws Exception {
+        directoryServer = startDirectoryServer();
+        Path configFile = writeConfig();
+        StringWriter err = new StringWriter();
+        CommandLine cmd = commandLine(new StringWriter(), err);
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "backup", "ldap", "--domain", "not a domain");
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(err.toString().contains("Error! Invalid domain name: not a domain"));
+    }
+
+    @Test
+    void domainBackupWithMalformedDomainIsRejected() throws Exception {
+        directoryServer = startDirectoryServer();
+        Path configFile = writeConfig();
+        StringWriter err = new StringWriter();
+        CommandLine cmd = commandLine(new StringWriter(), err);
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "backup", "domain", "--domain", "??");
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(err.toString().contains("Error! Invalid domain name: ??"));
+    }
+
+    @Test
     void ldapBacksUpEveryDiscoveredAccount() throws Exception {
         directoryServer = startDirectoryServer();
         directoryServer.add(
@@ -387,7 +427,7 @@ class BackupCommandTest {
                   bindPassword: secret
                   sslEnabled: false
                 zimbraMailbox:
-                  backupUser: zimbra
+                  backupUser: %s
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: %s
                   adminUser: zimbra
@@ -402,6 +442,7 @@ class BackupCommandTest {
                 """
                         .formatted(
                                 directoryServer.getListenPort(),
+                                System.getProperty("user.name"),
                                 mailboxRestBaseUrl,
                                 tempDir,
                                 tempDir.resolve("zmbackup.log"),
@@ -410,7 +451,7 @@ class BackupCommandTest {
     }
 
     private static CommandLine commandLine(StringWriter out, StringWriter err) {
-        CommandLine cmd = new CommandLine(new Main());
+        CommandLine cmd = Main.commandLine();
         cmd.setOut(new PrintWriter(out));
         cmd.setErr(new PrintWriter(err));
         return cmd;

--- a/app/src/test/java/io/zmbackup/app/cli/CliValidationTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/CliValidationTest.java
@@ -1,0 +1,94 @@
+package io.zmbackup.app.cli;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CliValidationTest {
+
+    @Test
+    void validEmailPasses() {
+        StringWriter err = new StringWriter();
+        assertTrue(CliValidation.validateEmail("alice@example.com", new PrintWriter(err)));
+        assertTrue(err.toString().isEmpty());
+    }
+
+    @Test
+    void nullEmailIsTreatedAsValid() {
+        assertTrue(CliValidation.validateEmail(null, new PrintWriter(new StringWriter())));
+    }
+
+    @Test
+    void malformedEmailFails() {
+        StringWriter err = new StringWriter();
+        assertFalse(CliValidation.validateEmail("not-an-email", new PrintWriter(err)));
+        assertTrue(err.toString().contains("Error! Invalid email address: not-an-email"));
+    }
+
+    @Test
+    void allEmailsValidStopsAtFirstMismatch() {
+        StringWriter err = new StringWriter();
+        assertFalse(CliValidation.validateEmails(
+                List.of("alice@example.com", "bad-email", "bob@example.com"), new PrintWriter(err)));
+        assertTrue(err.toString().contains("Error! Invalid email address: bad-email"));
+    }
+
+    @Test
+    void emptyEmailListIsValid() {
+        assertTrue(CliValidation.validateEmails(List.of(), new PrintWriter(new StringWriter())));
+    }
+
+    @Test
+    void validDomainPasses() {
+        assertTrue(CliValidation.validateDomain("example.com", new PrintWriter(new StringWriter())));
+    }
+
+    @Test
+    void nullDomainIsTreatedAsValid() {
+        assertTrue(CliValidation.validateDomain(null, new PrintWriter(new StringWriter())));
+    }
+
+    @Test
+    void malformedDomainFails() {
+        StringWriter err = new StringWriter();
+        assertFalse(CliValidation.validateDomain("not a domain", new PrintWriter(err)));
+        assertTrue(err.toString().contains("Error! Invalid domain name: not a domain"));
+    }
+
+    @Test
+    void allDomainsValidStopsAtFirstMismatch() {
+        StringWriter err = new StringWriter();
+        assertFalse(CliValidation.validateDomains(List.of("example.com", "??"), new PrintWriter(err)));
+        assertTrue(err.toString().contains("Error! Invalid domain name: ??"));
+    }
+
+    @Test
+    void validSessionIdsPassForEveryKnownPrefix() {
+        PrintWriter err = new PrintWriter(new StringWriter());
+        for (String prefix :
+                List.of("full", "inc", "ldap", "domain", "distlist", "alias", "mbox", "signature")) {
+            assertTrue(CliValidation.validateSessionId(prefix + "-20260101120000", err), prefix);
+        }
+    }
+
+    @Test
+    void malformedSessionIdFails() {
+        StringWriter err = new StringWriter();
+        assertFalse(CliValidation.validateSessionId("does-not-exist", new PrintWriter(err)));
+        assertTrue(err.toString().contains("Error! Invalid session ID: does-not-exist"));
+    }
+
+    @Test
+    void sessionIdWithUnknownPrefixFails() {
+        assertFalse(CliValidation.validateSessionId("bogus-20260101120000", new PrintWriter(new StringWriter())));
+    }
+
+    @Test
+    void sessionIdWithShortTimestampFails() {
+        assertFalse(CliValidation.validateSessionId("full-202601011200", new PrintWriter(new StringWriter())));
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/cli/HousekeepCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/HousekeepCommandTest.java
@@ -74,7 +74,7 @@ class HousekeepCommandTest {
         Path configFile = writeConfig(7);
         StringWriter out = new StringWriter();
         StringWriter err = new StringWriter();
-        CommandLine cmd = new CommandLine(new Main());
+        CommandLine cmd = Main.commandLine();
         cmd.setOut(new PrintWriter(out));
         cmd.setErr(new PrintWriter(err));
 
@@ -102,7 +102,7 @@ class HousekeepCommandTest {
                   bindPassword: secret
                   sslEnabled: false
                 zimbraMailbox:
-                  backupUser: zimbra
+                  backupUser: %s
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
@@ -117,6 +117,7 @@ class HousekeepCommandTest {
                     sender: root@example.com
                 """
                         .formatted(
+                                System.getProperty("user.name"),
                                 tempDir,
                                 tempDir.resolve("zmbackup.log"),
                                 tempDir.resolve("blockedlist.conf"),
@@ -125,7 +126,7 @@ class HousekeepCommandTest {
     }
 
     private static CommandLine commandLine(StringWriter out) {
-        CommandLine cmd = new CommandLine(new Main());
+        CommandLine cmd = Main.commandLine();
         cmd.setOut(new PrintWriter(out));
         cmd.setErr(new PrintWriter(new StringWriter()));
         return cmd;

--- a/app/src/test/java/io/zmbackup/app/cli/MainTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MainTest.java
@@ -139,13 +139,42 @@ class MainTest {
         StringWriter err = new StringWriter();
         CommandLine cmd = commandLine(new StringWriter(), err);
 
-        int exitCode = cmd.execute("--config", configFile.toString(), "delete", "--session", "does-not-exist");
+        int exitCode =
+                cmd.execute("--config", configFile.toString(), "delete", "--session", "full-20260101999999");
 
         assertEquals(1, exitCode);
-        assertTrue(err.toString().contains("does-not-exist not found in database"));
+        assertTrue(err.toString().contains("full-20260101999999 not found in database"));
+    }
+
+    @Test
+    void deleteRejectsMalformedSessionId() throws IOException {
+        Path configFile = writeConfig();
+        StringWriter err = new StringWriter();
+        CommandLine cmd = commandLine(new StringWriter(), err);
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "delete", "--session", "does-not-exist");
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(err.toString().contains("Error! Invalid session ID: does-not-exist"));
+    }
+
+    @Test
+    void deniesAccessWhenBackupUserDoesNotMatchTheRunningUser() throws IOException {
+        Path configFile = writeConfig("not-the-real-user");
+        StringWriter err = new StringWriter();
+        CommandLine cmd = commandLine(new StringWriter(), err);
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "list");
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(err.toString().contains("You need to be not-the-real-user to run this software."));
     }
 
     private Path writeConfig() throws IOException {
+        return writeConfig(System.getProperty("user.name"));
+    }
+
+    private Path writeConfig(String backupUser) throws IOException {
         Path configFile = tempDir.resolve("zmbackup.yaml");
         Files.writeString(
                 configFile,
@@ -155,7 +184,7 @@ class MainTest {
                   bindDn: uid=zimbra,cn=admins,cn=zimbra
                   bindPassword: secret
                 zimbraMailbox:
-                  backupUser: zimbra
+                  backupUser: %s
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
@@ -169,12 +198,15 @@ class MainTest {
                     sender: root@example.com
                 """
                         .formatted(
-                                tempDir, tempDir.resolve("zmbackup.log"), tempDir.resolve("blockedlist.conf")));
+                                backupUser,
+                                tempDir,
+                                tempDir.resolve("zmbackup.log"),
+                                tempDir.resolve("blockedlist.conf")));
         return configFile;
     }
 
     private static CommandLine commandLine(StringWriter out, StringWriter err) {
-        CommandLine cmd = new CommandLine(new Main());
+        CommandLine cmd = Main.commandLine();
         cmd.setOut(new PrintWriter(out));
         cmd.setErr(new PrintWriter(err));
         return cmd;

--- a/app/src/test/java/io/zmbackup/app/cli/MigrateCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MigrateCommandTest.java
@@ -84,7 +84,7 @@ class MigrateCommandTest {
         Path configFile = writeConfig();
         StringWriter out = new StringWriter();
         StringWriter err = new StringWriter();
-        CommandLine cmd = new CommandLine(new Main());
+        CommandLine cmd = Main.commandLine();
         cmd.setOut(new PrintWriter(out));
         cmd.setErr(new PrintWriter(err));
 
@@ -106,7 +106,7 @@ class MigrateCommandTest {
                   bindDn: uid=zimbra,cn=admins,cn=zimbra
                   bindPassword: secret
                 zimbraMailbox:
-                  backupUser: zimbra
+                  backupUser: %s
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
@@ -120,12 +120,15 @@ class MigrateCommandTest {
                     sender: root@example.com
                 """
                         .formatted(
-                                tempDir, tempDir.resolve("zmbackup.log"), tempDir.resolve("blockedlist.conf")));
+                                System.getProperty("user.name"),
+                                tempDir,
+                                tempDir.resolve("zmbackup.log"),
+                                tempDir.resolve("blockedlist.conf")));
         return configFile;
     }
 
     private static CommandLine commandLine(StringWriter out) {
-        CommandLine cmd = new CommandLine(new Main());
+        CommandLine cmd = Main.commandLine();
         cmd.setOut(new PrintWriter(out));
         cmd.setErr(new PrintWriter(new StringWriter()));
         return cmd;

--- a/app/src/test/java/io/zmbackup/app/cli/RestoreCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/RestoreCommandTest.java
@@ -56,6 +56,49 @@ class RestoreCommandTest {
     }
 
     @Test
+    void ldapSubcommandRejectsMalformedSessionId() throws Exception {
+        directoryServer = startDirectoryServer();
+        Path configFile = writeConfig();
+        StringWriter err = new StringWriter();
+
+        int exitCode = commandLine(new StringWriter(), err)
+                .execute("--config", configFile.toString(), "restore", "ldap", "--session", "not-a-session");
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(err.toString().contains("Error! Invalid session ID: not-a-session"));
+    }
+
+    @Test
+    void ldapSubcommandRejectsMalformedAccount() throws Exception {
+        directoryServer = startDirectoryServer();
+        Path configFile = writeConfig();
+        StringWriter err = new StringWriter();
+
+        int exitCode = commandLine(new StringWriter(), err)
+                .execute(
+                        "--config", configFile.toString(), "restore", "ldap", "--session",
+                        "ldap-20260101120000", "--account", "not-an-email");
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(err.toString().contains("Error! Invalid email address: not-an-email"));
+    }
+
+    @Test
+    void topLevelRestoreRejectsMalformedIntoDestination() throws Exception {
+        directoryServer = startDirectoryServer();
+        Path configFile = writeConfig();
+        StringWriter err = new StringWriter();
+
+        int exitCode = commandLine(new StringWriter(), err)
+                .execute(
+                        "--config", configFile.toString(), "restore", "--session", "full-20260101120000",
+                        "--account", "alice@example.com", "--into", "not-an-email");
+
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertTrue(err.toString().contains("Error! Invalid email address: not-an-email"));
+    }
+
+    @Test
     void ldapSubcommandRestoresAccountEntry() throws Exception {
         directoryServer = startDirectoryServer();
         directoryServer.add(
@@ -175,8 +218,9 @@ class RestoreCommandTest {
 
         int exitCode = commandLine(new StringWriter(), err)
                 .execute(
-                        "--config", configFile.toString(), "restore", "--session", "full-1", "--account",
-                        "alice@example.com", "--account", "bob@example.com", "--into", "carol@example.com");
+                        "--config", configFile.toString(), "restore", "--session", "full-20260101120000",
+                        "--account", "alice@example.com", "--account", "bob@example.com", "--into",
+                        "carol@example.com");
 
         assertEquals(CommandLine.ExitCode.USAGE, exitCode);
         assertTrue(err.toString().contains("--into requires exactly one --account"));
@@ -309,7 +353,7 @@ class RestoreCommandTest {
                   bindPassword: secret
                   sslEnabled: false
                 zimbraMailbox:
-                  backupUser: zimbra
+                  backupUser: %s
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: %s
                   adminUser: zimbra
@@ -324,6 +368,7 @@ class RestoreCommandTest {
                 """
                         .formatted(
                                 directoryServer.getListenPort(),
+                                System.getProperty("user.name"),
                                 mailboxRestBaseUrl,
                                 tempDir,
                                 tempDir.resolve("zmbackup.log"),
@@ -332,7 +377,7 @@ class RestoreCommandTest {
     }
 
     private static CommandLine commandLine(StringWriter out, StringWriter err) {
-        CommandLine cmd = new CommandLine(new Main());
+        CommandLine cmd = Main.commandLine();
         cmd.setOut(new PrintWriter(out));
         cmd.setErr(new PrintWriter(err));
         return cmd;

--- a/app/src/test/java/io/zmbackup/app/cli/ShadowJarSmokeTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/ShadowJarSmokeTest.java
@@ -75,7 +75,7 @@ class ShadowJarSmokeTest {
                   bindDn: uid=zimbra,cn=admins,cn=zimbra
                   bindPassword: secret
                 zimbraMailbox:
-                  backupUser: zimbra
+                  backupUser: %s
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
@@ -89,7 +89,10 @@ class ShadowJarSmokeTest {
                     sender: root@example.com
                 """
                         .formatted(
-                                tempDir, tempDir.resolve("zmbackup.log"), tempDir.resolve("blockedlist.conf")));
+                                System.getProperty("user.name"),
+                                tempDir,
+                                tempDir.resolve("zmbackup.log"),
+                                tempDir.resolve("blockedlist.conf")));
         return configFile;
     }
 }

--- a/app/src/test/java/io/zmbackup/app/cli/TruncateCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/TruncateCommandTest.java
@@ -84,7 +84,7 @@ class TruncateCommandTest {
                   bindDn: uid=zimbra,cn=admins,cn=zimbra
                   bindPassword: secret
                 zimbraMailbox:
-                  backupUser: zimbra
+                  backupUser: %s
                   zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
@@ -98,12 +98,15 @@ class TruncateCommandTest {
                     sender: root@example.com
                 """
                         .formatted(
-                                tempDir, tempDir.resolve("zmbackup.log"), tempDir.resolve("blockedlist.conf")));
+                                System.getProperty("user.name"),
+                                tempDir,
+                                tempDir.resolve("zmbackup.log"),
+                                tempDir.resolve("blockedlist.conf")));
         return configFile;
     }
 
     private static CommandLine commandLine(StringWriter out, StringWriter err) {
-        CommandLine cmd = new CommandLine(new Main());
+        CommandLine cmd = Main.commandLine();
         cmd.setOut(new PrintWriter(out));
         cmd.setErr(new PrintWriter(err));
         return cmd;

--- a/core/src/main/java/io/zmbackup/core/port/MetadataStore.java
+++ b/core/src/main/java/io/zmbackup/core/port/MetadataStore.java
@@ -60,4 +60,12 @@ public interface MetadataStore {
      * objects already backed up within roughly the last day.
      */
     boolean backedUpSince(String identifier, Instant since) throws IOException;
+
+    /**
+     * Reclaims disk space freed by earlier deletions, mirroring the bash tool's {@code sqlite3
+     * ... VACUUM} run at the end of {@code delete_old}/{@code leeroy_jenkins}. A no-op by default
+     * - purely a maintenance operation with no effect on stored data, so backends that don't need
+     * it (or in-memory test fakes) don't have to implement it.
+     */
+    default void vacuum() throws IOException {}
 }

--- a/core/src/main/java/io/zmbackup/core/service/HousekeepService.java
+++ b/core/src/main/java/io/zmbackup/core/service/HousekeepService.java
@@ -25,7 +25,9 @@ public class HousekeepService {
 
     /**
      * Deletes every session that completed more than {@code days} days ago, mirroring
-     * {@code delete_old}'s {@code conclusion_date < datetime('now','-$ROTATE_TIME day')} cutoff.
+     * {@code delete_old}'s {@code conclusion_date < datetime('now','-$ROTATE_TIME day')} cutoff,
+     * then reclaims the freed space (mirroring {@code delete_old}'s trailing {@code sqlite3 ...
+     * VACUUM}).
      *
      * @param days how many days of backups to keep; sessions completed before this cutoff are removed
      * @return the sessions that were removed
@@ -39,6 +41,7 @@ public class HousekeepService {
         for (BackupSession session : old) {
             remove(session);
         }
+        metadataStore.vacuum();
         return old;
     }
 

--- a/core/src/test/java/io/zmbackup/core/service/HousekeepServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/HousekeepServiceTest.java
@@ -46,6 +46,7 @@ class HousekeepServiceTest {
         assertTrue(metadataStore.findSession("ldap-recent").isPresent());
         assertTrue(storageProvider.deletedSessions.contains("ldap-old"));
         assertTrue(!storageProvider.deletedSessions.contains("ldap-recent"));
+        assertEquals(1, metadataStore.vacuumCalls);
     }
 
     @Test
@@ -148,6 +149,7 @@ class HousekeepServiceTest {
     private static final class InMemoryMetadataStore implements MetadataStore {
         final Map<String, BackupSession> sessions = new LinkedHashMap<>();
         final Map<String, List<BackupAccountRecord>> accounts = new LinkedHashMap<>();
+        int vacuumCalls = 0;
 
         @Override
         public void save(BackupSession session) {
@@ -200,6 +202,11 @@ class HousekeepServiceTest {
         @Override
         public boolean backedUpSince(String identifier, Instant since) {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void vacuum() {
+            vacuumCalls++;
         }
     }
 }

--- a/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
+++ b/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
@@ -164,7 +164,18 @@ public class SqliteMetadataStore implements MetadataStore {
             }
             statement.execute("delete from backup_account");
             statement.execute("delete from backup_session");
+            statement.execute("VACUUM");
             return removed;
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void vacuum() throws IOException {
+        try (Connection connection = connect();
+                Statement statement = connection.createStatement()) {
+            statement.execute("VACUUM");
         } catch (SQLException e) {
             throw new IOException(e);
         }

--- a/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
+++ b/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
@@ -134,6 +134,22 @@ class SqliteMetadataStoreTest {
     }
 
     @Test
+    void vacuumLeavesStoredDataIntact() throws IOException {
+        store.save(session("full-1", SessionStatus.FINISHED, "10M"));
+        store.recordAccountBackup(accountRecord("full-1", "user@example.com"));
+
+        store.vacuum();
+
+        assertEquals(1, store.listSessions().size());
+        assertEquals(1, store.findAccountsForSession("full-1").size());
+    }
+
+    @Test
+    void vacuumOnEmptyStoreDoesNotThrow() {
+        assertDoesNotThrow(() -> store.vacuum());
+    }
+
+    @Test
     void recordedAccountBackupCanBeFoundBySession() throws IOException {
         store.save(session("full-1", SessionStatus.FINISHED, "10M"));
         BackupAccountRecord record = accountRecord("full-1", "user@example.com");


### PR DESCRIPTION
## Summary

Closes the last two gaps from the bash-parity audit (both previously reported as documented-but-not-fixed), plus two smaller findings surfaced while re-investigating for anything else missing:

- **CLI-level format validation** (`CliValidation`) — mirrors the bash tool's `validate_email`/`validate_domain`/`validate_session_id` (`MiscAction.sh`), rejecting malformed `--account`/`--domain`/`--session` values with an immediate `"Error! Invalid ...: <value>"` message and the usage exit code, before they reach an LDAP filter, file path, or SQL parameter. Wired into every `backup *` subcommand (via the shared `BackupRunner`), `restore`/`restore ldap`/`restore domain`/`restore mailbox`, and `delete`. This is a superset of bash's own coverage — bash only validated emails on its `-ro` restore-on-account path; Java validates every occurrence uniformly.
- **Privilege-boundary enforcement** (`AppContext.checkBackupUser`) — mirrors `validate_config`'s `whoami == $BACKUPUSER` check: refuses to run when the OS user doesn't match `zimbraMailbox.backupUser`, thrown as a new `PrivilegeException` and reported cleanly (message + usage exit code `2`, matching bash's `exit 2`) via a new picocli execution exception handler, instead of a stack-trace dump. Every CLI test's `zmbackup.yaml` fixture now sets `backupUser` to the actual test-runner's OS user, the same trick the bash test suite's own fixtures use, so the check is exercised for real rather than bypassed.
- **`MetadataStore.vacuum()`** — mirrors `delete_old`/`leeroy_jenkins`'s trailing `sqlite3 ... VACUUM`, called once per `housekeep` run and as part of `truncate`, so `sessions.sqlite3` no longer grows monotonically forever.
- **`zimbraLdap.sslEnabled` StartTLS warning** — bash always used LDAP StartTLS regardless of `SSL_ENABLE` (which only chose the mailbox REST scheme there); Java's `sslEnabled` directly gates LDAP StartTLS, so disabling it sends the admin bind in cleartext, unlike bash. Kept as a real, working toggle rather than hardcoded always-on (this project's own test suite relies on disabling it to talk to plaintext in-memory LDAP servers), but `AppContext` now logs a `WARN` whenever it's off, so the divergence is visible instead of silent.

A full re-investigation for anything else missing (aside from what needs a real Zimbra instance to validate) turned up a few more findings not included in this PR, since they're either large in scope or carry real regression risk in this test harness — reported separately rather than pushed blind:
- No multi-mailbox-server routing (single `restBaseUrl` for the whole tool; bash resolves each account's `zimbraMailHost` per-account).
- No SIGINT/SIGTERM failure-notification/session-cleanup (bash's `trap on_exit` sends a FAILURE notification on a kill mid-session; Java has no shutdown hook).
- The Java installer's cron file is owned by `OSE_USER`, not `root` (bash's is root-owned, matching every other `/etc/cron.d` entry) — a real fix, but `install -o root` fails outright for a non-root user, and this repo's own bats test harness invokes the installer functions directly without root, so fixing this needs test-harness support (e.g. an `install` mock) I didn't want to bundle in unverified.
- README's Usage section documents only the bash CLI, with no Java command examples.

## Test plan

- [x] `./gradlew test` — full suite across `core`, `local`, `zimbra`, `app` passes.
- [x] New/updated tests: `CliValidationTest` (new), plus CLI-level rejection tests added to `BackupCommandTest`/`RestoreCommandTest`/`MainTest`; `AppContextTest`/`MainTest` cover the privilege check (unit-level `PrivilegeException` + end-to-end clean-message/exit-code); `SqliteMetadataStoreTest`/`HousekeepServiceTest` cover `vacuum()`.
- [x] Verified `install -o root` genuinely fails for a non-root user (confirms the cron-ownership fix isn't safe to bundle here without test-harness changes) before deciding not to include it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4dy4uwgGMbZUTFngRGJE2

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4dy4uwgGMbZUTFngRGJE2)_