### PR TITLE
Log swallowed IOExceptions in backup/restore failure paths

### DIFF
--- a/core/src/main/java/io/zmbackup/core/service/BackupService.java
+++ b/core/src/main/java/io/zmbackup/core/service/BackupService.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -308,6 +309,7 @@ public class BackupService {
                 }
             }
         } catch (IOException e) {
+            LOG.log(Level.WARNING, "Backup failed for " + identifier, e);
             return false;
         }
         Instant completedAt = Instant.now();

--- a/core/src/main/java/io/zmbackup/core/service/RestoreService.java
+++ b/core/src/main/java/io/zmbackup/core/service/RestoreService.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Restores previously backed-up LDAP entries and mailbox content, mirroring {@code
@@ -23,6 +25,7 @@ import java.util.concurrent.Callable;
  */
 public class RestoreService {
 
+    private static final Logger LOG = Logger.getLogger(RestoreService.class.getName());
     private static final String LDIFF_SUFFIX = "ldiff";
     private static final String TGZ_SUFFIX = "tgz";
 
@@ -134,6 +137,7 @@ public class RestoreService {
             ldapExporter.restore(LdapObjectType.ACCOUNT, source);
             return true;
         } catch (IOException e) {
+            LOG.log(Level.WARNING, "LDAP restore failed for " + account, e);
             return false;
         }
     }
@@ -143,6 +147,7 @@ public class RestoreService {
             ldapExporter.restoreDomain(source);
             return true;
         } catch (IOException e) {
+            LOG.log(Level.WARNING, "Domain restore failed for " + domain, e);
             return false;
         }
     }
@@ -157,6 +162,7 @@ public class RestoreService {
             mailboxExporter.restore(destination, source);
             return true;
         } catch (IOException e) {
+            LOG.log(Level.WARNING, "Mailbox restore failed for " + account, e);
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- `BackupService.backupOne` and the three helper methods in `RestoreService` (`restoreLdapOne`, `restoreDomainOne`, `restoreMailboxOne`) caught `IOException` and returned `false` without recording the exception, so operators only ever saw a `FAILED` session status with no way to diagnose why.
- Each of these catch blocks now logs the exception at `WARNING` (via `java.util.logging.Logger`, consistent with the loggers already used elsewhere in these classes) before returning `false`, so the underlying cause (auth failure, disk full, network error, etc.) is preserved for triage.

Fixes #377

## Test plan
- [x] `./gradlew :core:compileJava` — compiles cleanly
- [x] `./gradlew :core:test --tests "io.zmbackup.core.service.BackupServiceTest" --tests "io.zmbackup.core.service.RestoreServiceTest"` — existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbFzcNB2RUK7RwXVRDCPcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbFzcNB2RUK7RwXVRDCPcs)_