### PR TITLE
Record failed session when Parallel.run throws mid-backup

### DIFF
--- a/core/src/main/java/io/zmbackup/core/service/BackupService.java
+++ b/core/src/main/java/io/zmbackup/core/service/BackupService.java
@@ -243,7 +243,13 @@ public class BackupService {
         for (String identifier : resolved) {
             tasks.add(() -> backupOne(sessionId, type, identifier));
         }
-        boolean allSucceeded = !Parallel.run(maxParallelProcesses, tasks).contains(false);
+        boolean allSucceeded;
+        try {
+            allSucceeded = !Parallel.run(maxParallelProcesses, tasks).contains(false);
+        } catch (IOException e) {
+            recordFailedSession(sessionId, type, sessionStart);
+            throw e;
+        }
 
         Instant sessionEnd = Instant.now();
         String size = storageProvider.sizeOfSession(sessionId);
@@ -256,6 +262,19 @@ public class BackupService {
                 status == SessionStatus.FINISHED ? metadataStore.findAccountsForSession(sessionId).size() : 0;
         notifySafely(() -> notifier.notifyFinish(sessionId, type, status, notifySize, notifyAccountCount));
         return Optional.of(completed);
+    }
+
+    /**
+     * Records {@code sessionId} as {@code FAILED} when {@link Parallel#run} itself threw (e.g. the
+     * calling thread was interrupted by SIGTERM/shutdown) rather than any individual task failing,
+     * so the session is never left orphaned as {@code IN_PROGRESS} forever.
+     */
+    private void recordFailedSession(String sessionId, BackupType type, Instant sessionStart) throws IOException {
+        Instant sessionEnd = Instant.now();
+        String size = storageProvider.sizeOfSession(sessionId);
+        BackupSession failed = new BackupSession(sessionId, type, SessionStatus.FAILED, sessionStart, sessionEnd, size);
+        metadataStore.save(failed);
+        notifySafely(() -> notifier.notifyFinish(sessionId, type, SessionStatus.FAILED, "0", 0));
     }
 
     private interface NotifierCall {

--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -2,6 +2,7 @@ package io.zmbackup.core.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.zmbackup.core.domain.BackupAccountRecord;
@@ -384,6 +385,54 @@ class BackupServiceTest {
         assertEquals(SessionStatus.FAILED, result.get().status());
         List<BackupAccountRecord> records = metadataStore.findAccountsForSession(result.get().sessionId());
         assertEquals(Set.of("good@example.com"), namesOf(records));
+    }
+
+    @Test
+    void interruptedRunIsRecordedAsFailedRatherThanLeftInProgress() throws IOException {
+        accountDiscovery.wholeDirectory.put(LdapObjectType.ACCOUNT, List.of("alice@example.com"));
+        RecordingNotifier notifier = new RecordingNotifier();
+        ZimbraLdapExporter interruptingExporter = new ZimbraLdapExporter() {
+            @Override
+            public void export(String identifier, LdapObjectType type, OutputStream destination) {
+                // An unchecked exception escapes backupOne's IOException handling, propagating out
+                // of the task and forcing Parallel.run itself to throw - mirroring the interrupted
+                // shutdown scenario from the bug report, where Parallel.run throws before the
+                // session can be marked FINISHED/FAILED.
+                throw new RuntimeException("simulated interruption for " + identifier);
+            }
+
+            @Override
+            public void exportDomain(String domain, OutputStream destination) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void restore(LdapObjectType type, InputStream source) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void restoreDomain(InputStream source) {
+                throw new UnsupportedOperationException();
+            }
+        };
+        BackupService interrupted = new BackupService(
+                accountDiscovery,
+                interruptingExporter,
+                mailboxExporter,
+                storageProvider,
+                metadataStore,
+                identifier -> false,
+                notifier,
+                1);
+
+        assertThrows(IOException.class, () -> interrupted.backup(BackupType.LDAP));
+
+        List<BackupSession> sessions = metadataStore.listSessions();
+        assertEquals(1, sessions.size());
+        assertEquals(SessionStatus.FAILED, sessions.get(0).status());
+        assertTrue(notifier.calls.get(notifier.calls.size() - 1).startsWith("finish:"));
+        assertTrue(notifier.calls.get(notifier.calls.size() - 1).contains(":FAILED:"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
Fixes #378. `BackupService.backup()` saved the session as `IN_PROGRESS` and then called `Parallel.run(...)`. If that call threw (e.g. the calling thread was interrupted by SIGTERM/shutdown), everything after it — marking the session `FINISHED`/`FAILED` and `notifyFinish` — never ran, orphaning the session row as `IN_PROGRESS` forever. `HousekeepService.rotateOldSessions` only matches sessions with a non-null `conclusion_date`, so these were never cleaned up, and `zmbackup list` would show a phantom running session indefinitely.

- Wraps the `Parallel.run` call in `BackupService.backup()` so a thrown exception is caught, the session is recorded as `FAILED` (via a new `recordFailedSession` helper, with a best-effort `notifyFinish`), and the original exception is then rethrown.
- Adds `BackupServiceTest.interruptedRunIsRecordedAsFailedRatherThanLeftInProgress`, which makes a task escape with an exception that forces `Parallel.run` itself to throw, and asserts the session ends up `FAILED` rather than stuck `IN_PROGRESS`.

## Test plan
- [x] `./gradlew :core:test --tests "io.zmbackup.core.service.BackupServiceTest"` — 28 tests pass, including the new one
- [x] `./gradlew :core:test` — full core suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WuQqXsKxmV9ETSbv3WTCPC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuQqXsKxmV9ETSbv3WTCPC)_