### PR TITLE
Require explicit opt-in to trust-all for LDAP StartTLS

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -78,6 +78,11 @@ public final class AppContext {
             LOG.warn(
                     "zimbraLdap.sslEnabled is false: the LDAP admin bind will not use StartTLS and its"
                             + " credentials will be sent in cleartext. The bash tool never allowed this.");
+        } else if (config.zimbraLdap().caCertificatePath() == null && config.zimbraLdap().trustAllCertificates()) {
+            LOG.warn(
+                    "zimbraLdap.trustAllCertificates is true: the LDAP StartTLS connection will accept any"
+                            + " server certificate, which does not protect against an active MITM attack."
+                            + " Configure zimbraLdap.caCertificatePath instead for production use.");
         }
         this.storageProvider = new LocalStorageProvider(config.backup().workDir());
         this.metadataStore = new SqliteMetadataStore(config.backup().workDir().resolve(METADATA_STORE_FILENAME));
@@ -85,7 +90,9 @@ public final class AppContext {
                 config.zimbraLdap().url(),
                 config.zimbraLdap().bindDn(),
                 config.zimbraLdap().bindPassword(),
-                config.zimbraLdap().sslEnabled());
+                config.zimbraLdap().sslEnabled(),
+                config.zimbraLdap().caCertificatePath(),
+                config.zimbraLdap().trustAllCertificates());
         this.accountDiscovery = ldapAdapter;
         this.ldapExporter = ldapAdapter;
         this.mailboxExporter = new ZimbraRestMailboxExporter(

--- a/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
+++ b/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
@@ -52,7 +52,9 @@ public final class YamlConfigLoader {
                 requireString(root, "zimbraLdap.url"),
                 requireString(root, "zimbraLdap.bindDn"),
                 requireString(root, "zimbraLdap.bindPassword"),
-                optionalBoolean(root, "zimbraLdap.sslEnabled", true));
+                optionalBoolean(root, "zimbraLdap.sslEnabled", true),
+                optionalString(root, "zimbraLdap.caCertificatePath"),
+                optionalBoolean(root, "zimbraLdap.trustAllCertificates", false));
     }
 
     private static ZimbraMailboxConfig parseZimbraMailbox(Map<String, Object> root) {
@@ -116,6 +118,11 @@ public final class YamlConfigLoader {
 
     private static Path requirePath(Map<String, Object> root, String dottedPath) {
         return Path.of(requireString(root, dottedPath));
+    }
+
+    private static String optionalString(Map<String, Object> root, String dottedPath) {
+        Object value = get(root, dottedPath);
+        return value == null ? null : value.toString();
     }
 
     private static boolean optionalBoolean(Map<String, Object> root, String dottedPath, boolean defaultValue) {

--- a/app/src/main/java/io/zmbackup/app/config/ZimbraLdapConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/ZimbraLdapConfig.java
@@ -6,13 +6,26 @@ import java.util.Objects;
  * LDAP connection settings, mirroring the {@code LDAPSERVER}/{@code LDAPADMIN}/{@code LDAPPASS}/
  * {@code SSL_ENABLE} fields of the bash tool's {@code zmbackup.conf}.
  *
- * @param url          the LDAP server URL, e.g. {@code "ldap://127.0.0.1:389"}
- * @param bindDn       the admin distinguished name used to bind, e.g.
- *                     {@code "uid=zimbra,cn=admins,cn=zimbra"}
- * @param bindPassword the admin password used to bind
- * @param sslEnabled   whether to use SSL when talking to the Zimbra server
+ * @param url                  the LDAP server URL, e.g. {@code "ldap://127.0.0.1:389"}
+ * @param bindDn               the admin distinguished name used to bind, e.g.
+ *                             {@code "uid=zimbra,cn=admins,cn=zimbra"}
+ * @param bindPassword         the admin password used to bind
+ * @param sslEnabled           whether to use SSL (StartTLS) when talking to the Zimbra server
+ * @param caCertificatePath    path to a PEM-encoded CA certificate (bundle) used to verify the
+ *                             server's certificate, or {@code null} to use the JVM's default trust
+ *                             manager (or, if {@code trustAllCertificates} is set, to trust any
+ *                             certificate)
+ * @param trustAllCertificates whether to accept any server certificate when {@code caCertificatePath}
+ *                             is not set; must be explicitly enabled, since it offers no protection
+ *                             against an active MITM attack
  */
-public record ZimbraLdapConfig(String url, String bindDn, String bindPassword, boolean sslEnabled) {
+public record ZimbraLdapConfig(
+        String url,
+        String bindDn,
+        String bindPassword,
+        boolean sslEnabled,
+        String caCertificatePath,
+        boolean trustAllCertificates) {
 
     public ZimbraLdapConfig {
         Objects.requireNonNull(url, "url must not be null");

--- a/app/src/test/java/io/zmbackup/app/AppContextTest.java
+++ b/app/src/test/java/io/zmbackup/app/AppContextTest.java
@@ -91,7 +91,8 @@ class AppContextTest {
 
     private static AppConfig configWithWorkDir(Path workDir, String backupUser) {
         return new AppConfig(
-                new ZimbraLdapConfig("ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true),
+                new ZimbraLdapConfig(
+                        "ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true, null, false),
                 new ZimbraMailboxConfig(
                         backupUser,
                         Path.of("/opt/zimbra/bin/zmmailbox"),

--- a/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
@@ -23,6 +23,8 @@ class YamlConfigLoaderTest {
               bindDn: uid=zimbra,cn=admins,cn=zimbra
               bindPassword: secret
               sslEnabled: false
+              caCertificatePath: /etc/zmbackup/ldap-ca.pem
+              trustAllCertificates: true
             zimbraMailbox:
               backupUser: zimbra
               zmmailboxPath: /opt/zimbra/bin/zmmailbox
@@ -72,6 +74,8 @@ class YamlConfigLoaderTest {
         assertEquals("uid=zimbra,cn=admins,cn=zimbra", config.zimbraLdap().bindDn());
         assertEquals("secret", config.zimbraLdap().bindPassword());
         assertFalseSsl(config);
+        assertEquals("/etc/zmbackup/ldap-ca.pem", config.zimbraLdap().caCertificatePath());
+        assertEquals(true, config.zimbraLdap().trustAllCertificates());
 
         assertEquals("zimbra", config.zimbraMailbox().backupUser());
         assertEquals(Path.of("/opt/zimbra/bin/zmmailbox"), config.zimbraMailbox().zmmailboxPath());
@@ -100,6 +104,8 @@ class YamlConfigLoaderTest {
         AppConfig config = YamlConfigLoader.load(new StringReader(MINIMAL_YAML));
 
         assertTrue(config.zimbraLdap().sslEnabled());
+        assertEquals(null, config.zimbraLdap().caCertificatePath());
+        assertEquals(false, config.zimbraLdap().trustAllCertificates());
         assertTrue(config.zimbraMailbox().backupInactiveAccounts());
         assertEquals(3, config.backup().maxParallelProcesses());
         assertEquals(30, config.backup().rotateDays());

--- a/app/src/test/java/io/zmbackup/app/cucumber/BackupIntegrationSteps.java
+++ b/app/src/test/java/io/zmbackup/app/cucumber/BackupIntegrationSteps.java
@@ -97,7 +97,7 @@ public class BackupIntegrationSteps {
                 "dc=example,dc=com", new Attribute("objectClass", "domain"), new Attribute("dc", "example"));
 
         UnboundIdLdapAdapter ldapAdapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         mailboxServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
         mailboxServer.start();

--- a/project/config/zmbackup.yaml
+++ b/project/config/zmbackup.yaml
@@ -13,6 +13,15 @@ zimbraLdap:
   bindPassword: {OSE_INSTALL_LDAPPASS}
   # Whether to use SSL when talking to the Zimbra server. Optional, defaults to true.
   sslEnabled: true
+  # Path to a PEM-encoded CA certificate (bundle) used to verify the LDAP server's certificate
+  # during StartTLS negotiation, e.g. Zimbra's self-signed CA at
+  # /opt/zimbra/ssl/zimbra/ca/ca.pem. Optional; if unset, the JVM's default trust manager is
+  # used (or, if trustAllCertificates is true, any certificate is trusted).
+  # caCertificatePath: /opt/zimbra/ssl/zimbra/ca/ca.pem
+  # Whether to accept any LDAP server certificate when caCertificatePath is not set. This does
+  # NOT protect against an active MITM attack; only enable it for self-signed Zimbra certs in
+  # dev/test environments. Optional, defaults to false.
+  trustAllCertificates: false
 
 zimbraMailbox:
   # Zimbra service account used to start/stop the service and run zmmailbox.

--- a/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
@@ -15,11 +15,13 @@ import com.unboundid.ldap.sdk.extensions.StartTLSExtendedRequest;
 import com.unboundid.ldif.LDIFException;
 import com.unboundid.ldif.LDIFReader;
 import com.unboundid.ldif.LDIFWriter;
+import com.unboundid.util.ssl.PEMFileTrustManager;
 import com.unboundid.util.ssl.SSLUtil;
 import com.unboundid.util.ssl.TrustAllTrustManager;
 import io.zmbackup.core.domain.LdapObjectType;
 import io.zmbackup.core.port.AccountDiscovery;
 import io.zmbackup.core.port.ZimbraLdapExporter;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -39,14 +41,30 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
     private final String bindDn;
     private final String bindPassword;
     private final boolean startTls;
+    private final String caCertificatePath;
+    private final boolean trustAllCertificates;
 
     /**
-     * @param url          the LDAP server URL, e.g. {@code "ldap://127.0.0.1:389"}
-     * @param bindDn       the admin distinguished name used to bind
-     * @param bindPassword the admin password used to bind
-     * @param startTls     whether to upgrade the connection with StartTLS before binding
+     * @param url                   the LDAP server URL, e.g. {@code "ldap://127.0.0.1:389"}
+     * @param bindDn                the admin distinguished name used to bind
+     * @param bindPassword          the admin password used to bind
+     * @param startTls              whether to upgrade the connection with StartTLS before binding
+     * @param caCertificatePath     path to a PEM-encoded CA certificate (bundle) used to verify the server's
+     *                              certificate during StartTLS negotiation, or {@code null} to fall back to
+     *                              the JVM's default trust manager (or, if {@code trustAllCertificates} is
+     *                              set, to trusting any certificate)
+     * @param trustAllCertificates  whether to accept any server certificate during StartTLS negotiation when
+     *                              {@code caCertificatePath} is not set; must be explicitly enabled, e.g. for
+     *                              self-signed Zimbra certificates in dev/test environments, since it offers
+     *                              no protection against an active MITM attack
      */
-    public UnboundIdLdapAdapter(String url, String bindDn, String bindPassword, boolean startTls) {
+    public UnboundIdLdapAdapter(
+            String url,
+            String bindDn,
+            String bindPassword,
+            boolean startTls,
+            String caCertificatePath,
+            boolean trustAllCertificates) {
         LDAPURL parsedUrl;
         try {
             parsedUrl = new LDAPURL(url);
@@ -58,6 +76,8 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
         this.bindDn = bindDn;
         this.bindPassword = bindPassword;
         this.startTls = startTls;
+        this.caCertificatePath = caCertificatePath;
+        this.trustAllCertificates = trustAllCertificates;
     }
 
     /**
@@ -258,10 +278,7 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
         try {
             connection = new LDAPConnection(host, port);
             if (startTls) {
-                // Zimbra's own LDAP server uses a self-signed certificate that isn't in the JVM's
-                // default trust store, so trust it the same way the bash tool's ldapsearch does
-                // via its default ldaprc (TLS_REQCERT never) rather than requiring a CA bundle.
-                SSLContext sslContext = new SSLUtil(new TrustAllTrustManager()).createSSLContext();
+                SSLContext sslContext = startTlsSslContext();
                 ExtendedResult startTlsResult =
                         connection.processExtendedOperation(new StartTLSExtendedRequest(sslContext));
                 if (startTlsResult.getResultCode() != ResultCode.SUCCESS) {
@@ -278,5 +295,22 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
             }
             throw new IOException("Failed to connect to Zimbra LDAP at " + host + ":" + port, e);
         }
+    }
+
+    /**
+     * Builds the {@link SSLContext} used to verify the server's certificate during StartTLS
+     * negotiation: a configured CA certificate takes precedence, then an explicit opt-in to trust
+     * any certificate (e.g. for self-signed Zimbra certs in dev/test environments), and otherwise
+     * the JVM's default trust manager, which validates against real CAs and protects against an
+     * active MITM attack.
+     */
+    private SSLContext startTlsSslContext() throws GeneralSecurityException {
+        if (caCertificatePath != null) {
+            return new SSLUtil(new PEMFileTrustManager(new File(caCertificatePath))).createSSLContext();
+        }
+        if (trustAllCertificates) {
+            return new SSLUtil(new TrustAllTrustManager()).createSSLContext();
+        }
+        return new SSLUtil().createSSLContext();
     }
 }

--- a/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
@@ -42,6 +42,7 @@ class UnboundIdLdapAdapterTest {
 
     private InMemoryDirectoryServer directoryServer;
     private Path keyStoreFile;
+    private Path caCertificateFile;
 
     @AfterEach
     void tearDown() throws IOException {
@@ -51,13 +52,16 @@ class UnboundIdLdapAdapterTest {
         if (keyStoreFile != null) {
             Files.deleteIfExists(keyStoreFile);
         }
+        if (caCertificateFile != null) {
+            Files.deleteIfExists(caCertificateFile);
+        }
     }
 
     @Test
     void connectsAndBindsWithoutStartTls() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         try (LDAPConnection connection = adapter.connect()) {
             assertTrue(connection.isConnected());
@@ -65,28 +69,53 @@ class UnboundIdLdapAdapterTest {
     }
 
     @Test
-    void connectsAndBindsWithStartTls() throws Exception {
+    void connectsAndBindsWithStartTlsWhenTrustAllCertificatesIsEnabled() throws Exception {
         directoryServer = startDirectoryServer(serverStartTlsSocketFactory());
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, true);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, true, null, true);
 
         try (LDAPConnection connection = adapter.connect()) {
             assertTrue(connection.isConnected());
         }
+    }
+
+    @Test
+    void connectsAndBindsWithStartTlsUsingConfiguredCaCertificate() throws Exception {
+        directoryServer = startDirectoryServer(serverStartTlsSocketFactory());
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(),
+                BIND_DN,
+                BIND_PASSWORD,
+                true,
+                caCertificateFile.toString(),
+                false);
+
+        try (LDAPConnection connection = adapter.connect()) {
+            assertTrue(connection.isConnected());
+        }
+    }
+
+    @Test
+    void startTlsRejectsUntrustedCertificateWhenNoTrustIsConfigured() throws Exception {
+        directoryServer = startDirectoryServer(serverStartTlsSocketFactory());
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, true, null, false);
+
+        assertThrows(IOException.class, adapter::connect);
     }
 
     @Test
     void wrapsInvalidCredentialsInIOException() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, "wrong-password", false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, "wrong-password", false, null, false);
 
         assertThrows(IOException.class, adapter::connect);
     }
 
     @Test
     void wrapsUnreachableServerInIOException() {
-        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false, null, false);
 
         assertThrows(IOException.class, adapter::connect);
     }
@@ -95,7 +124,7 @@ class UnboundIdLdapAdapterTest {
     void rejectsInvalidUrl() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> new UnboundIdLdapAdapter("not-a-url", BIND_DN, BIND_PASSWORD, false));
+                () -> new UnboundIdLdapAdapter("not-a-url", BIND_DN, BIND_PASSWORD, false, null, false));
     }
 
     @Test
@@ -117,7 +146,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("cn", "engineering"),
                 new Attribute("mail", "engineering@example.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         List<String> accounts = adapter.discover(LdapObjectType.ACCOUNT);
 
@@ -128,7 +157,7 @@ class UnboundIdLdapAdapterTest {
     void discoverReturnsEmptyListWhenNoEntriesMatch() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         assertEquals(List.of(), adapter.discover(LdapObjectType.ACCOUNT));
     }
@@ -149,7 +178,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("uid", "carol"),
                 new Attribute("zimbraMailDeliveryAddress", "carol@other.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         List<String> accounts = adapter.discoverForDomain(LdapObjectType.ACCOUNT, "example.com");
 
@@ -160,7 +189,7 @@ class UnboundIdLdapAdapterTest {
     void discoverForDomainReturnsEmptyListWhenDomainHasNoMatches() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         assertEquals(List.of(), adapter.discoverForDomain(LdapObjectType.ACCOUNT, "example.com"));
     }
@@ -169,7 +198,7 @@ class UnboundIdLdapAdapterTest {
     void discoverForDomainWrapsUnknownBaseDnInIOException() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         assertThrows(IOException.class, () -> adapter.discoverForDomain(LdapObjectType.ACCOUNT, "nowhere.invalid"));
     }
@@ -188,7 +217,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("uid", "alice"),
                 new Attribute("zimbraMailDeliveryAddress", "alice@example.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         List<String> domains = adapter.listDomains();
 
@@ -199,7 +228,7 @@ class UnboundIdLdapAdapterTest {
     void listDomainsReturnsEmptyListWhenNoDomainsMatch() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         assertEquals(List.of(), adapter.listDomains());
     }
@@ -214,7 +243,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
                 new Attribute("mail", "alice@example.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         ByteArrayOutputStream destination = new ByteArrayOutputStream();
         adapter.export("alice@example.com", LdapObjectType.ACCOUNT, destination);
@@ -233,7 +262,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("cn", "engineering"),
                 new Attribute("uid", "engineering@example.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         ByteArrayOutputStream destination = new ByteArrayOutputStream();
         adapter.export("engineering@example.com", LdapObjectType.DISTRIBUTION_LIST, destination);
@@ -245,7 +274,7 @@ class UnboundIdLdapAdapterTest {
     void exportWritesNothingWhenNoEntryMatches() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         ByteArrayOutputStream destination = new ByteArrayOutputStream();
         adapter.export("nobody@example.com", LdapObjectType.ACCOUNT, destination);
@@ -257,7 +286,7 @@ class UnboundIdLdapAdapterTest {
     void exportRejectsDomainObjectType() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         assertThrows(
                 UnsupportedOperationException.class,
@@ -266,7 +295,7 @@ class UnboundIdLdapAdapterTest {
 
     @Test
     void exportWrapsUnreachableServerInIOException() {
-        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false, null, false);
 
         assertThrows(
                 IOException.class,
@@ -282,7 +311,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("dc", "other"),
                 new Attribute("zimbraDomainName", "other.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         ByteArrayOutputStream destination = new ByteArrayOutputStream();
         adapter.exportDomain("other.com", destination);
@@ -296,14 +325,14 @@ class UnboundIdLdapAdapterTest {
     void exportDomainWrapsUnknownDomainInIOException() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         assertThrows(IOException.class, () -> adapter.exportDomain("nowhere.invalid", new ByteArrayOutputStream()));
     }
 
     @Test
     void exportDomainWrapsUnreachableServerInIOException() {
-        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false, null, false);
 
         assertThrows(
                 IOException.class, () -> adapter.exportDomain("example.com", new ByteArrayOutputStream()));
@@ -320,7 +349,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("mail", "alice@example.com"),
                 new Attribute("description", "stale"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
         String ldif =
                 "dn: uid=alice,dc=example,dc=com\n"
                         + "objectClass: zimbraAccount\n"
@@ -339,7 +368,7 @@ class UnboundIdLdapAdapterTest {
     void restoreAddsEntryThatDidNotPreviouslyExist() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
         String ldif =
                 "dn: uid=alice,dc=example,dc=com\n"
                         + "objectClass: zimbraAccount\n"
@@ -356,7 +385,7 @@ class UnboundIdLdapAdapterTest {
     void restoreThrowsIOExceptionWhenLdifHasNoEntry() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
 
         assertThrows(
                 IOException.class,
@@ -367,7 +396,7 @@ class UnboundIdLdapAdapterTest {
     void restoreDomainAddsEntryThatDidNotPreviouslyExist() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
         String ldif =
                 "dn: dc=other,dc=com\n"
                         + "objectClass: zimbraDomain\n"
@@ -389,7 +418,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("dc", "other"),
                 new Attribute("zimbraDomainName", "other.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
         String ldif =
                 "dn: dc=other,dc=com\n"
                         + "objectClass: zimbraDomain\n"
@@ -403,7 +432,7 @@ class UnboundIdLdapAdapterTest {
     void restoreDomainThrowsIOExceptionOnOtherFailures() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
         String ldif = "dn: dc=other,dc=nowhere,dc=missing\nobjectClass: zimbraDomain\ndc: other\n";
 
         assertThrows(
@@ -413,7 +442,7 @@ class UnboundIdLdapAdapterTest {
 
     @Test
     void restoreWrapsUnreachableServerInIOException() {
-        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false, null, false);
         String ldif = "dn: uid=alice,dc=example,dc=com\nobjectClass: zimbraAccount\nuid: alice\n";
 
         assertThrows(
@@ -457,6 +486,9 @@ class UnboundIdLdapAdapterTest {
         try (OutputStream out = Files.newOutputStream(keyStoreFile)) {
             keyStore.store(out, BIND_PASSWORD.toCharArray());
         }
+
+        caCertificateFile = Files.createTempFile("zmbackup-test-ca-cert", ".pem");
+        Files.writeString(caCertificateFile, certAndKey.getFirst().toPEMString());
 
         KeyStoreKeyManager keyManager = new KeyStoreKeyManager(keyStoreFile.toFile(), BIND_PASSWORD.toCharArray());
         return new SSLUtil(keyManager, new TrustAllTrustManager()).createSSLSocketFactory();


### PR DESCRIPTION
## Summary
- `UnboundIdLdapAdapter.connect()` always built its StartTLS `SSLContext` with `TrustAllTrustManager`, so an admin bind with `sslEnabled=true` accepted any server certificate — no protection against an active MITM attack, even though the bind credentials (and LDAP dumps, which include password hashes) travel over that connection.
- Added `zimbraLdap.caCertificatePath`, an optional path to a PEM-encoded CA certificate (or bundle) used to verify the server's certificate during StartTLS negotiation.
- Added `zimbraLdap.trustAllCertificates` (defaults to `false`), which must be explicitly enabled to fall back to trusting any certificate — e.g. for self-signed Zimbra certs in dev/test environments.
- When neither is configured, the JVM's default trust manager is used (validates against real CAs), instead of silently trusting everything as before.
- `AppContext` now logs a warning at startup when `trustAllCertificates` is enabled without a CA path, mirroring the existing warning for `sslEnabled=false`.

## Test plan
- [x] `./gradlew test` (all modules) — full suite passes.
- [x] New/updated tests in `UnboundIdLdapAdapterTest`:
  - `connectsAndBindsWithStartTlsWhenTrustAllCertificatesIsEnabled` — explicit opt-in still works.
  - `connectsAndBindsWithStartTlsUsingConfiguredCaCertificate` — StartTLS succeeds against a self-signed cert verified via a configured CA file.
  - `startTlsRejectsUntrustedCertificateWhenNoTrustIsConfigured` — StartTLS now fails against an untrusted self-signed cert by default (the security fix).
- [x] `YamlConfigLoaderTest` updated to cover the two new optional config fields and their defaults.

Fixes #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YF8Beh6UJZKktVRodXcZn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01YF8Beh6UJZKktVRodXcZn6)_