### PR TITLE
Harden backup file and metadata DB permissions to 0700/0600

### DIFF
--- a/local/src/main/java/io/zmbackup/local/LocalStorageProvider.java
+++ b/local/src/main/java/io/zmbackup/local/LocalStorageProvider.java
@@ -28,8 +28,8 @@ public class LocalStorageProvider implements StorageProvider {
     @Override
     public OutputStream openWrite(String sessionId, String account, String suffix) throws IOException {
         Path file = accountFile(sessionId, account, suffix);
-        Files.createDirectories(file.getParent());
-        return Files.newOutputStream(
+        PosixFileHardening.createDirectories(file.getParent());
+        return PosixFileHardening.newRestrictedOutputStream(
                 file, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
     }
 

--- a/local/src/main/java/io/zmbackup/local/PosixFileHardening.java
+++ b/local/src/main/java/io/zmbackup/local/PosixFileHardening.java
@@ -1,0 +1,68 @@
+package io.zmbackup.local;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+/**
+ * Restricts backup session directories, backed-up mail content, and the metadata database to
+ * owner-only access (0700/0600) so that a permissive default umask (e.g. 022) does not leave
+ * them world-readable. No-ops on filesystems without POSIX permission support.
+ */
+final class PosixFileHardening {
+
+    private static final Set<PosixFilePermission> DIRECTORY_PERMISSIONS = PosixFilePermissions.fromString("rwx------");
+    private static final Set<PosixFilePermission> FILE_PERMISSIONS = PosixFilePermissions.fromString("rw-------");
+
+    private static final boolean POSIX_SUPPORTED =
+            FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+
+    private PosixFileHardening() {}
+
+    /** Creates {@code dir} and any missing parents, restricting every directory it creates. */
+    static void createDirectories(Path dir) throws IOException {
+        if (POSIX_SUPPORTED) {
+            Files.createDirectories(dir, PosixFilePermissions.asFileAttribute(DIRECTORY_PERMISSIONS));
+        } else {
+            Files.createDirectories(dir);
+        }
+    }
+
+    /** Creates a new, empty, owner-only file. Fails if {@code file} already exists. */
+    static void createFile(Path file) throws IOException {
+        if (POSIX_SUPPORTED) {
+            Files.createFile(file, PosixFilePermissions.asFileAttribute(FILE_PERMISSIONS));
+        } else {
+            Files.createFile(file);
+        }
+    }
+
+    /** Restricts an existing file to owner-only access. */
+    static void restrictExistingFile(Path file) throws IOException {
+        if (POSIX_SUPPORTED) {
+            Files.setPosixFilePermissions(file, FILE_PERMISSIONS);
+        }
+    }
+
+    /**
+     * Opens {@code file} for writing with the given options, restricting it to owner-only access
+     * whether the file is created fresh or already existed.
+     */
+    static OutputStream newRestrictedOutputStream(Path file, StandardOpenOption... options) throws IOException {
+        if (!POSIX_SUPPORTED) {
+            return Files.newOutputStream(file, options);
+        }
+        SeekableByteChannel channel =
+                Files.newByteChannel(file, Set.of(options), PosixFilePermissions.asFileAttribute(FILE_PERMISSIONS));
+        Files.setPosixFilePermissions(file, FILE_PERMISSIONS);
+        return Channels.newOutputStream(channel);
+    }
+}

--- a/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
+++ b/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
@@ -6,6 +6,7 @@ import io.zmbackup.core.domain.BackupType;
 import io.zmbackup.core.domain.SessionStatus;
 import io.zmbackup.core.port.MetadataStore;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -49,16 +50,42 @@ public class SqliteMetadataStore implements MetadataStore {
             )
             """;
 
+    /**
+     * Prefix identifying a SQLite JDBC connection string (e.g. an in-memory or shared-cache URI)
+     * rather than a real filesystem path, so permission hardening is skipped for it.
+     */
+    private static final String SQLITE_URI_PREFIX = "file:";
+
     private final String jdbcUrl;
 
     public SqliteMetadataStore(Path databaseFile) throws IOException {
         this.jdbcUrl = "jdbc:sqlite:" + databaseFile;
+        if (!databaseFile.toString().startsWith(SQLITE_URI_PREFIX)) {
+            hardenDatabaseFile(databaseFile);
+        }
         try (Connection connection = connect();
                 Statement statement = connection.createStatement()) {
             statement.execute(CREATE_BACKUP_SESSION);
             statement.execute(CREATE_BACKUP_ACCOUNT);
         } catch (SQLException e) {
             throw new IOException(e);
+        }
+    }
+
+    /**
+     * Ensures the database's parent directory and the database file itself are restricted to
+     * owner-only access, whether this is the first run (nothing exists yet) or a later one
+     * against a database file that already exists.
+     */
+    private static void hardenDatabaseFile(Path databaseFile) throws IOException {
+        Path parent = databaseFile.toAbsolutePath().getParent();
+        if (parent != null) {
+            PosixFileHardening.createDirectories(parent);
+        }
+        if (Files.exists(databaseFile)) {
+            PosixFileHardening.restrictExistingFile(databaseFile);
+        } else {
+            PosixFileHardening.createFile(databaseFile);
         }
     }
 

--- a/local/src/test/java/io/zmbackup/local/LocalStorageProviderTest.java
+++ b/local/src/test/java/io/zmbackup/local/LocalStorageProviderTest.java
@@ -10,8 +10,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -43,6 +46,21 @@ class LocalStorageProviderTest {
 
         assertTrue(Files.isDirectory(workDir.resolve("session1")));
         assertTrue(Files.exists(workDir.resolve("session1").resolve("user@example.com.tgz")));
+    }
+
+    @Test
+    void openWriteRestrictsSessionDirectoryAndFileToOwnerOnlyAccess() throws IOException {
+        Assumptions.assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+
+        write("session1", "user@example.com", "tgz", "content");
+
+        assertEquals(
+                "rwx------",
+                PosixFilePermissions.toString(Files.getPosixFilePermissions(workDir.resolve("session1"))));
+        assertEquals(
+                "rw-------",
+                PosixFilePermissions.toString(
+                        Files.getPosixFilePermissions(workDir.resolve("session1").resolve("user@example.com.tgz"))));
     }
 
     @Test

--- a/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
+++ b/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
@@ -9,7 +9,10 @@ import io.zmbackup.core.domain.BackupType;
 import io.zmbackup.core.domain.SessionStatus;
 import io.zmbackup.core.port.MetadataStore;
 import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -18,8 +21,10 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class SqliteMetadataStoreTest {
 
@@ -257,6 +262,19 @@ class SqliteMetadataStoreTest {
         store.recordAccountBackup(accountRecord("ldap-1", "other@example.com", now));
 
         assertEquals(false, store.backedUpSince("user@example.com", now.minus(24, ChronoUnit.HOURS)));
+    }
+
+    @Test
+    void constructingAgainstARealFileRestrictsDirectoryAndDatabaseToOwnerOnlyAccess(@TempDir Path workDir)
+            throws IOException {
+        Assumptions.assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+        Path sessionDir = workDir.resolve("sessions");
+        Path databaseFile = sessionDir.resolve("sessions.sqlite3");
+
+        new SqliteMetadataStore(databaseFile);
+
+        assertEquals("rwx------", PosixFilePermissions.toString(Files.getPosixFilePermissions(sessionDir)));
+        assertEquals("rw-------", PosixFilePermissions.toString(Files.getPosixFilePermissions(databaseFile)));
     }
 
     private static BackupSession session(String sessionId, SessionStatus status, String size) {


### PR DESCRIPTION
## Summary

Fixes #380.

`LocalStorageProvider.openWrite` and `SqliteMetadataStore`'s JDBC connection created session directories, backed-up mail content files, and the SQLite metadata database via default file-creation APIs, with no explicit permission hardening. On a default umask (e.g. 022), that left backed-up mail content and account metadata world-readable.

- Added `PosixFileHardening`, a small POSIX-only utility that:
  - creates directories atomically with `0700` permissions (`rwx------`)
  - opens/creates files atomically with `0600` permissions (`rw-------`), also fixing permissions on pre-existing files
  - no-ops on filesystems without POSIX permission support
- `LocalStorageProvider.openWrite` now creates the session directory and account file through this helper.
- `SqliteMetadataStore`'s constructor now hardens the database's parent directory and the database file itself before the first connection, for both new and pre-existing databases. In-memory/shared-cache SQLite connection strings (used by tests, identified by the `file:` URI prefix) are left untouched since they aren't real filesystem paths.

## Test plan

- [x] `./gradlew :local:test` — added tests asserting the session directory/file and the metadata DB directory/file end up with `rwx------`/`rw-------` permissions (skipped on non-POSIX filesystems via `Assumptions.assumeTrue`)
- [x] `./gradlew test` — full multi-module suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtjMVitnpdTTsKBYZS73qn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtjMVitnpdTTsKBYZS73qn)_