### PR TITLE
Reject non-email-shaped account identifiers in Zimbra REST exporter

### DIFF
--- a/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
@@ -17,6 +17,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * Exports a single account's mailbox content as a {@code .tgz} archive over Zimbra's REST
@@ -34,6 +35,15 @@ public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
      */
     private static final DateTimeFormatter AFTER_DATE_FORMAT =
             DateTimeFormatter.ofPattern("MM/dd/yyyy").withZone(ZoneId.systemDefault());
+
+    /**
+     * Zimbra account identifiers are always email addresses. Enforcing that shape here (rather
+     * than relying solely on CLI-layer validation) guards {@link #restUri} against identifiers
+     * from unvalidated sources, e.g. LDAP discovery, that contain {@code /}, {@code ?}, or {@code
+     * #} and could otherwise redirect the REST request to an unintended path or query.
+     */
+    private static final Pattern ACCOUNT_PATTERN =
+            Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
 
     private final URI baseUri;
     private final String adminUser;
@@ -135,6 +145,9 @@ public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
     }
 
     private URI restUri(String account, String query) throws IOException {
+        if (!ACCOUNT_PATTERN.matcher(account).matches()) {
+            throw new IOException("Invalid Zimbra account identifier: " + account);
+        }
         String path = (baseUri.getRawPath() == null ? "" : baseUri.getRawPath()) + "/home/" + account + "/";
         try {
             return new URI(baseUri.getScheme(), baseUri.getAuthority(), path, query, null);

--- a/zimbra/src/test/java/io/zmbackup/zimbra/ZimbraRestMailboxExporterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/ZimbraRestMailboxExporterTest.java
@@ -164,6 +164,34 @@ class ZimbraRestMailboxExporterTest {
                 () -> exporter.restore(ACCOUNT, new ByteArrayInputStream("tgz-content".getBytes())));
     }
 
+    @Test
+    void exportRejectsNonEmailShapedAccountIdentifier() {
+        ZimbraRestMailboxExporter exporter = exporter();
+
+        for (String maliciousAccount :
+                new String[] {"../etc/passwd", "alice@example.com/../bob", "alice@example.com?x=1", "alice@example.com#frag"
+                }) {
+            IOException exception = assertThrows(
+                    IOException.class,
+                    () -> exporter.export(maliciousAccount, new ByteArrayOutputStream(), null),
+                    "expected rejection of " + maliciousAccount);
+            assertTrue(exception.getMessage().contains("Invalid Zimbra account identifier"));
+        }
+    }
+
+    @Test
+    void restoreRejectsNonEmailShapedAccountIdentifier() {
+        ZimbraRestMailboxExporter exporter = exporter();
+
+        IOException exception = assertThrows(
+                IOException.class,
+                () -> exporter.restore(
+                        "alice@example.com/../bob",
+                        new ByteArrayInputStream("tgz-content".getBytes(StandardCharsets.UTF_8))));
+
+        assertTrue(exception.getMessage().contains("Invalid Zimbra account identifier"));
+    }
+
     private ZimbraRestMailboxExporter exporter() {
         return new ZimbraRestMailboxExporter(wireMockServer.baseUrl(), ADMIN_USER, ADMIN_PASSWORD);
     }


### PR DESCRIPTION
## Summary

- `ZimbraRestMailboxExporter.restUri` built the `/home/{account}/` REST path by string concatenation with no encoding or validation of `account`. CLI-supplied accounts are constrained by `CliValidation`'s email regex, but identifiers coming from LDAP discovery (`mail`/`uid` attribute values) reached this exporter unvalidated, so a crafted identifier containing `/`, `?`, or `#` could redirect the request to an unintended path or query on the same server.
- Added an `ACCOUNT_PATTERN` check (mirroring `CliValidation`'s email regex, since the `zimbra` module can't depend on the `app` module) at the `restUri` boundary shared by both `export()` and `restore()`, rejecting non-email-shaped identifiers with an `IOException` before any request is built.

## Test plan

- [x] Added `exportRejectsNonEmailShapedAccountIdentifier()` and `restoreRejectsNonEmailShapedAccountIdentifier()` to `ZimbraRestMailboxExporterTest`, covering identifiers containing `/`, `?`, and `#`.
- [x] `./gradlew :zimbra:test` passes (all 11 tests in `ZimbraRestMailboxExporterTest`, full `zimbra` module suite).

Fixes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyLyCDFrmwka1jCsz8koza

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyLyCDFrmwka1jCsz8koza)_