### PR TITLE
Fix HousekeepService to continue past per-session failures and avoid ghost DB rows

### DIFF
--- a/core/src/main/java/io/zmbackup/core/service/HousekeepService.java
+++ b/core/src/main/java/io/zmbackup/core/service/HousekeepService.java
@@ -6,14 +6,19 @@ import io.zmbackup.core.port.StorageProvider;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Housekeeping over stored backup sessions, mirroring the bash tool's {@code delete_old} and
  * {@code clean_empty} functions in {@code DeleteAction.sh}, driven by {@code zmbackup housekeep}.
  */
 public class HousekeepService {
+
+    private static final Logger LOG = Logger.getLogger(HousekeepService.class.getName());
 
     private final StorageProvider storageProvider;
     private final MetadataStore metadataStore;
@@ -29,8 +34,12 @@ public class HousekeepService {
      * then reclaims the freed space (mirroring {@code delete_old}'s trailing {@code sqlite3 ...
      * VACUUM}).
      *
+     * A session that fails to be removed (e.g. a permission error deleting one of its files) is
+     * logged and skipped rather than aborting the rest of the batch; {@link MetadataStore#vacuum()}
+     * still runs afterward over whatever was successfully removed.
+     *
      * @param days how many days of backups to keep; sessions completed before this cutoff are removed
-     * @return the sessions that were removed
+     * @return the sessions that were successfully removed
      */
     public List<BackupSession> rotateOldSessions(int days) throws IOException {
         if (days < 0) {
@@ -38,11 +47,14 @@ public class HousekeepService {
         }
         Instant cutoff = Instant.now().minus(days, ChronoUnit.DAYS);
         List<BackupSession> old = metadataStore.findSessionsCompletedBefore(cutoff);
+        List<BackupSession> removed = new ArrayList<>();
         for (BackupSession session : old) {
-            remove(session);
+            if (remove(session)) {
+                removed.add(session);
+            }
         }
         metadataStore.vacuum();
-        return old;
+        return removed;
     }
 
     /**
@@ -56,8 +68,20 @@ public class HousekeepService {
         return storageProvider.deleteEmptyFiles();
     }
 
-    private void remove(BackupSession session) throws IOException {
-        storageProvider.deleteSession(session.sessionId());
-        metadataStore.deleteSession(session.sessionId());
+    /**
+     * Deletes the metadata record before the stored files, so that if file deletion fails partway
+     * through, the DB is never left with a "ghost" row pointing at content that no longer exists.
+     *
+     * @return whether the session was fully removed
+     */
+    private boolean remove(BackupSession session) {
+        try {
+            metadataStore.deleteSession(session.sessionId());
+            storageProvider.deleteSession(session.sessionId());
+            return true;
+        } catch (IOException e) {
+            LOG.log(Level.WARNING, "Failed to remove backup session " + session.sessionId(), e);
+            return false;
+        }
     }
 }

--- a/core/src/test/java/io/zmbackup/core/service/HousekeepServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/HousekeepServiceTest.java
@@ -55,6 +55,28 @@ class HousekeepServiceTest {
     }
 
     @Test
+    void continuesPastAMidBatchFailureAndStillVacuums() throws IOException {
+        Instant now = Instant.now();
+        BackupSession failing = session("ldap-fail", now.minus(10, ChronoUnit.DAYS));
+        BackupSession ok = session("ldap-ok", now.minus(10, ChronoUnit.DAYS));
+        metadataStore.save(failing);
+        metadataStore.save(ok);
+        storageProvider.content.put("ldap-fail/alice@example.com.ldiff", new byte[0]);
+        storageProvider.content.put("ldap-ok/bob@example.com.ldiff", new byte[0]);
+        storageProvider.failOnDelete.add("ldap-fail");
+
+        List<BackupSession> removed = housekeepService.rotateOldSessions(7);
+
+        assertEquals(List.of(ok), removed);
+        assertTrue(storageProvider.content.containsKey("ldap-fail/alice@example.com.ldiff"));
+        assertTrue(storageProvider.deletedSessions.contains("ldap-ok"));
+        // Metadata is deleted before files, so a storage failure never leaves a ghost DB row
+        // pointing at content that's still there.
+        assertEquals(Optional.empty(), metadataStore.findSession("ldap-fail"));
+        assertEquals(1, metadataStore.vacuumCalls);
+    }
+
+    @Test
     void cleanEmptyRemovesZeroByteFilesButKeepsTheSessionAndOtherContent() throws IOException {
         BackupSession session = session("ldap-full", Instant.now());
         metadataStore.save(session);
@@ -101,6 +123,7 @@ class HousekeepServiceTest {
     private static final class InMemoryStorageProvider implements StorageProvider {
         final Map<String, byte[]> content = new LinkedHashMap<>();
         final Set<String> deletedSessions = new java.util.HashSet<>();
+        final Set<String> failOnDelete = new java.util.HashSet<>();
 
         @Override
         public OutputStream openWrite(String sessionId, String account, String suffix) {
@@ -128,7 +151,10 @@ class HousekeepServiceTest {
         }
 
         @Override
-        public void deleteSession(String sessionId) {
+        public void deleteSession(String sessionId) throws IOException {
+            if (failOnDelete.contains(sessionId)) {
+                throw new IOException("simulated failure deleting " + sessionId);
+            }
             deletedSessions.add(sessionId);
             content.keySet().removeIf(key -> key.startsWith(sessionId + "/"));
         }


### PR DESCRIPTION
## Summary

Fixes #382. `HousekeepService.rotateOldSessions` had two related bugs:

1. If `remove()` threw for one session mid-loop (e.g. a permission error on one file), the whole batch aborted: `vacuum()` never ran, and every session after the failing one was left un-rotated, with no report of which sessions failed.
2. Storage was deleted before metadata. If `storageProvider.deleteSession` succeeded but the subsequent `metadataStore.deleteSession` threw, the DB retained a session record pointing at now-deleted files (a "ghost" row).

## Changes

- `remove()` now deletes the metadata record *before* the stored files, so a failure deleting files never leaves a ghost DB row — at worst it leaves an orphaned file with no metadata pointing at it, which is the safer failure mode.
- A per-session failure is now logged (`Logger.WARNING`) and skipped instead of propagating and aborting the batch. The loop continues to the remaining sessions, and `metadataStore.vacuum()` still runs afterward.
- `rotateOldSessions` now returns only the sessions that were *successfully* removed (previously it returned every session that was found to be old, regardless of whether removal actually succeeded).

## Test plan

- [x] Added `continuesPastAMidBatchFailureAndStillVacuums` to `HousekeepServiceTest`, covering the "continue past failures, still vacuum" gap called out in the issue.
- [x] `./gradlew :core:test --tests "io.zmbackup.core.service.HousekeepServiceTest"` — all 6 tests pass.
- [x] Verified `HousekeepCommand` (the only other caller of `rotateOldSessions`) remains source-compatible with the unchanged `List<BackupSession>` return type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115w9doQ3MTCM5wybn29UDi

---
_Generated by [Claude Code](https://claude.ai/code/session_0115w9doQ3MTCM5wybn29UDi)_