### PR TITLE
Collapse Backup*Command CLI classes into a shared base

### DIFF
--- a/app/src/main/java/io/zmbackup/app/cli/AbstractAccountScopedBackupCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/AbstractAccountScopedBackupCommand.java
@@ -1,0 +1,19 @@
+package io.zmbackup.app.cli;
+
+import picocli.CommandLine.Option;
+
+/**
+ * Shared base for the {@code backup} subcommands that filter discovery by {@code --domain} and
+ * take a repeatable {@code --account}-style identifier option: {@code full}, {@code incremental},
+ * {@code mailbox}, {@code ldap}, {@code alias}, {@code distlist}, {@code signature}.
+ */
+abstract class AbstractAccountScopedBackupCommand extends AbstractBackupCommand {
+
+    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
+    private String domain;
+
+    @Override
+    final String domain() {
+        return domain;
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/AbstractBackupCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/AbstractBackupCommand.java
@@ -1,0 +1,41 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.BackupType;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+/**
+ * Shared body for every {@code backup} subcommand: resolves the {@link AppContext}, takes the
+ * backup work-dir lock, and delegates to {@link BackupRunner} with the concrete subcommand's
+ * {@link BackupType}, identifiers, and domain filter.
+ */
+abstract class AbstractBackupCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private BackupCommand parent;
+
+    @Spec
+    private CommandSpec spec;
+
+    abstract BackupType type();
+
+    /** The account/alias/distribution-list/domain identifiers to restrict this backup to. */
+    abstract List<String> identifiers();
+
+    /** The Zimbra domain to restrict discovery to, or {@code null} for no restriction. */
+    abstract String domain();
+
+    @Override
+    public final Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
+        return LockedExecution.run(
+                context,
+                spec.commandLine().getErr(),
+                () -> BackupRunner.run(
+                        context, spec.commandLine().getOut(), spec.commandLine().getErr(), type(), identifiers(), domain()));
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/cli/BackupAliasCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupAliasCommand.java
@@ -1,38 +1,25 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.BackupType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParentCommand;
-import picocli.CommandLine.Spec;
 
 /** Backs up Zimbra aliases from LDAP, mirroring {@code zmbackup -f -alp} in the bash tool. */
 @Command(name = "alias", description = "Back up Zimbra aliases from LDAP.")
-public final class BackupAliasCommand implements Callable<Integer> {
-
-    @ParentCommand
-    private BackupCommand parent;
+public final class BackupAliasCommand extends AbstractAccountScopedBackupCommand {
 
     @Option(names = "--account", description = "Back up only this alias (repeatable); default: every alias.")
     private List<String> accounts = new ArrayList<>();
 
-    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
-    private String domain;
-
-    @Spec
-    private CommandSpec spec;
+    @Override
+    BackupType type() {
+        return BackupType.ALIAS;
+    }
 
     @Override
-    public Integer call() throws Exception {
-        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(
-                context,
-                spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), spec.commandLine().getErr(), BackupType.ALIAS, accounts, domain));
+    List<String> identifiers() {
+        return accounts;
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupDistlistCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupDistlistCommand.java
@@ -1,46 +1,27 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.BackupType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParentCommand;
-import picocli.CommandLine.Spec;
 
 /** Backs up Zimbra distribution lists from LDAP, mirroring {@code zmbackup -f -dl} in the bash tool. */
 @Command(name = "distlist", description = "Back up Zimbra distribution lists from LDAP.")
-public final class BackupDistlistCommand implements Callable<Integer> {
-
-    @ParentCommand
-    private BackupCommand parent;
+public final class BackupDistlistCommand extends AbstractAccountScopedBackupCommand {
 
     @Option(
             names = "--account",
             description = "Back up only this distribution list (repeatable); default: every distribution list.")
     private List<String> accounts = new ArrayList<>();
 
-    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
-    private String domain;
-
-    @Spec
-    private CommandSpec spec;
+    @Override
+    BackupType type() {
+        return BackupType.DISTRIBUTION_LIST;
+    }
 
     @Override
-    public Integer call() throws Exception {
-        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(
-                context,
-                spec.commandLine().getErr(),
-                () -> BackupRunner.run(
-                        context,
-                        spec.commandLine().getOut(),
-                        spec.commandLine().getErr(),
-                        BackupType.DISTRIBUTION_LIST,
-                        accounts,
-                        domain));
+    List<String> identifiers() {
+        return accounts;
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupDomainCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupDomainCommand.java
@@ -1,35 +1,30 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.BackupType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParentCommand;
-import picocli.CommandLine.Spec;
 
 /** Backs up Zimbra domains from LDAP, mirroring {@code zmbackup -f -dom} in the bash tool. */
 @Command(name = "domain", description = "Back up Zimbra domains from LDAP.")
-public final class BackupDomainCommand implements Callable<Integer> {
-
-    @ParentCommand
-    private BackupCommand parent;
+public final class BackupDomainCommand extends AbstractBackupCommand {
 
     @Option(names = "--domain", description = "Back up only this domain (repeatable); default: every domain.")
     private List<String> domains = new ArrayList<>();
 
-    @Spec
-    private CommandSpec spec;
+    @Override
+    BackupType type() {
+        return BackupType.DOMAIN;
+    }
 
     @Override
-    public Integer call() throws Exception {
-        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(
-                context,
-                spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), spec.commandLine().getErr(), BackupType.DOMAIN, domains, null));
+    List<String> identifiers() {
+        return domains;
+    }
+
+    @Override
+    String domain() {
+        return null;
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupFullCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupFullCommand.java
@@ -1,41 +1,28 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.BackupType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParentCommand;
-import picocli.CommandLine.Spec;
 
 /**
  * Backs up Zimbra accounts from LDAP and their mailbox content, mirroring {@code zmbackup -f -a}
  * in the bash tool.
  */
 @Command(name = "full", description = "Back up Zimbra accounts from LDAP and their mailbox content.")
-public final class BackupFullCommand implements Callable<Integer> {
-
-    @ParentCommand
-    private BackupCommand parent;
+public final class BackupFullCommand extends AbstractAccountScopedBackupCommand {
 
     @Option(names = "--account", description = "Back up only this account (repeatable); default: every account.")
     private List<String> accounts = new ArrayList<>();
 
-    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
-    private String domain;
-
-    @Spec
-    private CommandSpec spec;
+    @Override
+    BackupType type() {
+        return BackupType.FULL;
+    }
 
     @Override
-    public Integer call() throws Exception {
-        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(
-                context,
-                spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), spec.commandLine().getErr(), BackupType.FULL, accounts, domain));
+    List<String> identifiers() {
+        return accounts;
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupIncrementalCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupIncrementalCommand.java
@@ -1,47 +1,28 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.BackupType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParentCommand;
-import picocli.CommandLine.Spec;
 
 /**
  * Backs up mail received since each account's last successful backup, mirroring {@code zmbackup
  * -i -a} in the bash tool.
  */
 @Command(name = "incremental", description = "Back up mail received since each account's last successful backup.")
-public final class BackupIncrementalCommand implements Callable<Integer> {
-
-    @ParentCommand
-    private BackupCommand parent;
+public final class BackupIncrementalCommand extends AbstractAccountScopedBackupCommand {
 
     @Option(names = "--account", description = "Back up only this account (repeatable); default: every account.")
     private List<String> accounts = new ArrayList<>();
 
-    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
-    private String domain;
-
-    @Spec
-    private CommandSpec spec;
+    @Override
+    BackupType type() {
+        return BackupType.INCREMENTAL;
+    }
 
     @Override
-    public Integer call() throws Exception {
-        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(
-                context,
-                spec.commandLine().getErr(),
-                () -> BackupRunner.run(
-                        context,
-                        spec.commandLine().getOut(),
-                        spec.commandLine().getErr(),
-                        BackupType.INCREMENTAL,
-                        accounts,
-                        domain));
+    List<String> identifiers() {
+        return accounts;
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupLdapCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupLdapCommand.java
@@ -1,38 +1,25 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.BackupType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParentCommand;
-import picocli.CommandLine.Spec;
 
 /** Backs up Zimbra accounts from LDAP, mirroring {@code zmbackup -f -ldp} in the bash tool. */
 @Command(name = "ldap", description = "Back up Zimbra accounts from LDAP.")
-public final class BackupLdapCommand implements Callable<Integer> {
-
-    @ParentCommand
-    private BackupCommand parent;
+public final class BackupLdapCommand extends AbstractAccountScopedBackupCommand {
 
     @Option(names = "--account", description = "Back up only this account (repeatable); default: every account.")
     private List<String> accounts = new ArrayList<>();
 
-    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
-    private String domain;
-
-    @Spec
-    private CommandSpec spec;
+    @Override
+    BackupType type() {
+        return BackupType.LDAP;
+    }
 
     @Override
-    public Integer call() throws Exception {
-        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(
-                context,
-                spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), spec.commandLine().getErr(), BackupType.LDAP, accounts, domain));
+    List<String> identifiers() {
+        return accounts;
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupMailboxCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupMailboxCommand.java
@@ -1,41 +1,28 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.BackupType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParentCommand;
-import picocli.CommandLine.Spec;
 
 /**
  * Backs up Zimbra accounts' mailbox content only, mirroring {@code zmbackup -f -m -a} in the bash
  * tool.
  */
 @Command(name = "mailbox", description = "Back up Zimbra accounts' mailbox content only.")
-public final class BackupMailboxCommand implements Callable<Integer> {
-
-    @ParentCommand
-    private BackupCommand parent;
+public final class BackupMailboxCommand extends AbstractAccountScopedBackupCommand {
 
     @Option(names = "--account", description = "Back up only this account (repeatable); default: every account.")
     private List<String> accounts = new ArrayList<>();
 
-    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
-    private String domain;
-
-    @Spec
-    private CommandSpec spec;
+    @Override
+    BackupType type() {
+        return BackupType.MAILBOX;
+    }
 
     @Override
-    public Integer call() throws Exception {
-        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(
-                context,
-                spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), spec.commandLine().getErr(), BackupType.MAILBOX, accounts, domain));
+    List<String> identifiers() {
+        return accounts;
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/BackupSignatureCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupSignatureCommand.java
@@ -1,40 +1,27 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.BackupType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParentCommand;
-import picocli.CommandLine.Spec;
 
 /** Backs up Zimbra signatures from LDAP, mirroring {@code zmbackup -f -sig} in the bash tool. */
 @Command(name = "signature", description = "Back up Zimbra signatures from LDAP.")
-public final class BackupSignatureCommand implements Callable<Integer> {
-
-    @ParentCommand
-    private BackupCommand parent;
+public final class BackupSignatureCommand extends AbstractAccountScopedBackupCommand {
 
     @Option(
             names = "--account",
             description = "Back up only this account's signatures (repeatable); default: every account.")
     private List<String> accounts = new ArrayList<>();
 
-    @Option(names = "--domain", description = "Restrict discovery to this Zimbra domain (e.g. example.com).")
-    private String domain;
-
-    @Spec
-    private CommandSpec spec;
+    @Override
+    BackupType type() {
+        return BackupType.SIGNATURE;
+    }
 
     @Override
-    public Integer call() throws Exception {
-        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(
-                context,
-                spec.commandLine().getErr(),
-                () -> BackupRunner.run(context, spec.commandLine().getOut(), spec.commandLine().getErr(), BackupType.SIGNATURE, accounts, domain));
+    List<String> identifiers() {
+        return accounts;
     }
 }


### PR DESCRIPTION
## Summary
- `BackupFullCommand`, `BackupMailboxCommand`, `BackupLdapCommand`, `BackupAliasCommand`, `BackupDistlistCommand`, `BackupSignatureCommand`, and `BackupIncrementalCommand` were ~40-line copies differing only in the `BackupType` constant, the `@Command` name/description, and the `--account` option's help text. They now extend a new `AbstractAccountScopedBackupCommand`, which holds the shared `--domain` option and the `call()` template method (config/context resolution, `PidLock` acquisition, and dispatch to `BackupRunner`).
- `BackupDomainCommand` has a different option shape (no `--account`; a repeatable `--domain` used as the identifier list), so it extends the more general `AbstractBackupCommand` directly, reusing just the parent/spec wiring and the `call()` template.
- CLI-visible behavior (option names, help text, error messages, exit codes) is unchanged.

Closes #383.

## Test plan
- [x] `./gradlew :app:compileJava :app:compileTestJava`
- [x] `./gradlew :app:test --tests "io.zmbackup.app.cli.BackupCommandTest"` (all 20 cases pass unmodified)
- [x] `./gradlew :app:test` (full app test suite passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReyFgsF32wPPni1MjFJ3NZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReyFgsF32wPPni1MjFJ3NZ)_