### PR TITLE
Redact credentials from ZimbraLdapConfig/ZimbraMailboxConfig toString()

### DIFF
--- a/app/src/main/java/io/zmbackup/app/config/ZimbraLdapConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/ZimbraLdapConfig.java
@@ -32,4 +32,20 @@ public record ZimbraLdapConfig(
         Objects.requireNonNull(bindDn, "bindDn must not be null");
         Objects.requireNonNull(bindPassword, "bindPassword must not be null");
     }
+
+    /**
+     * Overrides the record's default {@code toString()} to redact {@link #bindPassword()}, since
+     * this value is logged (e.g. via an uncaught exception's stack trace) wherever a config record
+     * ends up in a message.
+     */
+    @Override
+    public String toString() {
+        return "ZimbraLdapConfig[url=" + url
+                + ", bindDn=" + bindDn
+                + ", bindPassword=***"
+                + ", sslEnabled=" + sslEnabled
+                + ", caCertificatePath=" + caCertificatePath
+                + ", trustAllCertificates=" + trustAllCertificates
+                + "]";
+    }
 }

--- a/app/src/main/java/io/zmbackup/app/config/ZimbraMailboxConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/ZimbraMailboxConfig.java
@@ -32,4 +32,20 @@ public record ZimbraMailboxConfig(
         Objects.requireNonNull(adminUser, "adminUser must not be null");
         Objects.requireNonNull(adminPassword, "adminPassword must not be null");
     }
+
+    /**
+     * Overrides the record's default {@code toString()} to redact {@link #adminPassword()}, since
+     * this value is logged (e.g. via an uncaught exception's stack trace) wherever a config record
+     * ends up in a message.
+     */
+    @Override
+    public String toString() {
+        return "ZimbraMailboxConfig[backupUser=" + backupUser
+                + ", zmmailboxPath=" + zmmailboxPath
+                + ", backupInactiveAccounts=" + backupInactiveAccounts
+                + ", restBaseUrl=" + restBaseUrl
+                + ", adminUser=" + adminUser
+                + ", adminPassword=***"
+                + "]";
+    }
 }

--- a/app/src/test/java/io/zmbackup/app/config/ZimbraLdapConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/ZimbraLdapConfigTest.java
@@ -1,0 +1,27 @@
+package io.zmbackup.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ZimbraLdapConfigTest {
+
+    @Test
+    void toStringRedactsBindPassword() {
+        ZimbraLdapConfig config = new ZimbraLdapConfig(
+                "ldap://ldap.example.com:389",
+                "uid=zimbra,cn=admins,cn=zimbra",
+                "s3cr3t",
+                true,
+                "/etc/zmbackup/ldap-ca.pem",
+                false);
+
+        String result = config.toString();
+
+        assertFalse(result.contains("s3cr3t"), "toString() must not leak bindPassword: " + result);
+        assertTrue(result.contains("bindPassword=***"));
+        assertTrue(result.contains("ldap://ldap.example.com:389"));
+        assertTrue(result.contains("uid=zimbra,cn=admins,cn=zimbra"));
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/config/ZimbraMailboxConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/ZimbraMailboxConfigTest.java
@@ -1,0 +1,28 @@
+package io.zmbackup.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ZimbraMailboxConfigTest {
+
+    @Test
+    void toStringRedactsAdminPassword() {
+        ZimbraMailboxConfig config = new ZimbraMailboxConfig(
+                "zimbra",
+                Path.of("/opt/zimbra/bin/zmmailbox"),
+                false,
+                "https://mail.example.com:7071",
+                "zimbra",
+                "s3cr3t");
+
+        String result = config.toString();
+
+        assertFalse(result.contains("s3cr3t"), "toString() must not leak adminPassword: " + result);
+        assertTrue(result.contains("adminPassword=***"));
+        assertTrue(result.contains("https://mail.example.com:7071"));
+        assertTrue(result.contains("backupUser=zimbra"));
+    }
+}


### PR DESCRIPTION
## Summary

`ZimbraLdapConfig` (`app/src/main/java/io/zmbackup/app/config/ZimbraLdapConfig.java`) and `ZimbraMailboxConfig` (`app/src/main/java/io/zmbackup/app/config/ZimbraMailboxConfig.java`) are plain Java records holding `bindPassword`/`adminPassword` in the clear. Records' default `toString()` prints every component, so a future `LOG.debug(config)` call, or an uncaught exception whose stack trace includes one of these records via `toString()`, would leak credentials into the log file or syslog.

- Both records now override `toString()` to print `***` in place of the password field, leaving every other field (including `bindDn`/`adminUser`, which are useful for diagnostics) unchanged.

Fixes #384.

## Test plan

- [x] Added `ZimbraLdapConfigTest`/`ZimbraMailboxConfigTest`, each asserting the plaintext password never appears in `toString()` and that `***` (and the surrounding fields) does.
- [x] `./gradlew :app:test` — full `app` module suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrKeutfHQazhEmMsdY629u

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrKeutfHQazhEmMsdY629u)_