### PR TITLE
Warn when zimbraMailbox.restBaseUrl does not use https://

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -29,6 +29,7 @@ import ch.qos.logback.core.FileAppender;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Locale;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
@@ -83,6 +84,17 @@ public final class AppContext {
                     "zimbraLdap.trustAllCertificates is true: the LDAP StartTLS connection will accept any"
                             + " server certificate, which does not protect against an active MITM attack."
                             + " Configure zimbraLdap.caCertificatePath instead for production use.");
+        }
+        if (!config.zimbraMailbox().restBaseUrl().toLowerCase(Locale.ROOT).startsWith("https://")) {
+            // The bash tool's SSL_ENABLE defaulted to (and warned toward) true, choosing https for the
+            // mailbox REST endpoint; nothing here stopped an operator from setting it false, but the
+            // default was safe. zimbraMailbox.restBaseUrl carries no equivalent toggle or default: it's
+            // an operator-supplied URL, and ZimbraRestMailboxExporter sends the admin Basic-auth
+            // credentials over whatever scheme it's given, without any warning of its own.
+            LOG.warn(
+                    "zimbraMailbox.restBaseUrl does not start with https://: mailbox REST requests,"
+                            + " including the admin Basic-auth credentials, will be sent in cleartext."
+                            + " Configure an https:// URL for production use.");
         }
         this.storageProvider = new LocalStorageProvider(config.backup().workDir());
         this.metadataStore = new SqliteMetadataStore(config.backup().workDir().resolve(METADATA_STORE_FILENAME));


### PR DESCRIPTION
## Summary

- `ZimbraRestMailboxExporter` sends the admin HTTP Basic-auth credentials, and every mailbox's exported/restored content, over whatever scheme `zimbraMailbox.restBaseUrl` specifies. Nothing in `YamlConfigLoader` or the exporter constructor enforced or even flagged `http://`, unlike the bash tool's `SSL_ENABLE`, which defaulted to (and nudged operators toward) `https`.
- `AppContext` now warns at startup when `restBaseUrl` doesn't start with `https://`, mirroring the existing `zimbraLdap.sslEnabled`/`trustAllCertificates` warning pattern already used there for the LDAP admin bind.
- Chose a warning over a hard rejection: `BackupCommandTest` and `RestoreCommandTest` legitimately point `restBaseUrl` at a local plaintext HTTP test double for their integration tests, so a hard requirement would need test-harness support (e.g. a TLS test double) this fix doesn't warrant.

Fixes #385

## Test plan

- [x] `./gradlew test` — full suite (285 tests) passes across `core`, `local`, `zimbra`, `app`.
- [x] `./gradlew :app:compileJava :app:compileTestJava` — compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNLLk7k6evDxCUcqSJaz8X

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNLLk7k6evDxCUcqSJaz8X)_