### PR TITLE
Fix session-delete order, SMTP CRLF injection, interrupted-pool shutdown, PidLock test coverage

### DIFF
--- a/app/src/test/java/io/zmbackup/app/PidLockHolderMain.java
+++ b/app/src/test/java/io/zmbackup/app/PidLockHolderMain.java
@@ -1,0 +1,26 @@
+package io.zmbackup.app;
+
+import java.nio.file.Path;
+
+/**
+ * Test helper run as a separate JVM process by {@link PidLockTest} to exercise the cross-process
+ * branch of {@link PidLock#acquire}: a {@code FileLock} held by a different process, rather than
+ * the same-JVM {@code OverlappingFileLockException} path.
+ *
+ * <p>Acquires the lock in the given work directory, signals readiness by printing {@code LOCKED}
+ * to stdout, then blocks until stdin is closed (the test destroys this process) so the lock stays
+ * held for the duration of the assertion.
+ */
+public final class PidLockHolderMain {
+
+    private PidLockHolderMain() {}
+
+    public static void main(String[] args) throws Exception {
+        Path workDir = Path.of(args[0]);
+        try (PidLock lock = PidLock.acquire(workDir)) {
+            System.out.println("LOCKED");
+            System.out.flush();
+            System.in.read();
+        }
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/PidLockTest.java
+++ b/app/src/test/java/io/zmbackup/app/PidLockTest.java
@@ -4,8 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -13,6 +19,15 @@ class PidLockTest {
 
     @TempDir
     Path tempDir;
+
+    private Process holderProcess;
+
+    @AfterEach
+    void tearDown() {
+        if (holderProcess != null) {
+            holderProcess.destroyForcibly();
+        }
+    }
 
     @Test
     void acquireWritesTheCurrentProcessPidToTheLockFile() throws Exception {
@@ -41,5 +56,51 @@ class PidLockTest {
             String content = Files.readString(tempDir.resolve("zmbackup.pid")).strip();
             assertEquals(Long.toString(ProcessHandle.current().pid()), content);
         }
+    }
+
+    /**
+     * Exercises the cross-process branch of {@link PidLock#acquire}, where {@code tryLock()}
+     * returns {@code null} because a <em>different process</em> holds the lock, rather than the
+     * same-JVM {@link java.nio.channels.OverlappingFileLockException} path already covered above.
+     * A real subprocess is used since the JVM only raises that exception for locks it holds
+     * itself; a lock held by another process is invisible to that same-JVM tracking.
+     */
+    @Test
+    void secondAcquireWhileAnotherProcessHoldsTheLockFailsWithTheHoldingPid() throws Exception {
+        holderProcess = startLockHolderProcess(tempDir);
+        long holderPid = holderProcess.pid();
+        awaitReady(holderProcess);
+
+        PidLock.AlreadyRunningException e =
+                assertThrows(PidLock.AlreadyRunningException.class, () -> PidLock.acquire(tempDir));
+        assertTrue(e.getMessage().contains(Long.toString(holderPid)));
+    }
+
+    private static Process startLockHolderProcess(Path workDir) throws IOException {
+        String javaBin = System.getProperty("java.home") + "/bin/java";
+        ProcessBuilder builder = new ProcessBuilder(
+                javaBin,
+                "-cp",
+                System.getProperty("java.class.path"),
+                PidLockHolderMain.class.getName(),
+                workDir.toString());
+        builder.redirectErrorStream(true);
+        return builder.start();
+    }
+
+    private static void awaitReady(Process process) throws IOException, InterruptedException {
+        BufferedReader out =
+                new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
+        // Skip any launcher diagnostics (e.g. a "Picked up JAVA_TOOL_OPTIONS" notice on stderr,
+        // merged into this stream) that can precede the holder's own readiness line.
+        String line;
+        while ((line = out.readLine()) != null && !"LOCKED".equals(line)) {
+            // keep reading
+        }
+        if (!"LOCKED".equals(line)) {
+            throw new IllegalStateException("Lock holder process exited without signaling readiness");
+        }
+        // Give the OS a brief moment to fully register the lock before the test tries to acquire it.
+        TimeUnit.MILLISECONDS.sleep(100);
     }
 }

--- a/core/src/main/java/io/zmbackup/core/service/Parallel.java
+++ b/core/src/main/java/io/zmbackup/core/service/Parallel.java
@@ -46,6 +46,7 @@ final class Parallel {
             return results;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            executor.shutdownNow();
             throw new IOException("Interrupted while running parallel tasks", e);
         } finally {
             executor.shutdown();

--- a/core/src/main/java/io/zmbackup/core/service/SessionService.java
+++ b/core/src/main/java/io/zmbackup/core/service/SessionService.java
@@ -34,6 +34,10 @@ public class SessionService {
      * Deletes the session with the given ID, mirroring {@code delete_one}: removes its stored
      * content and metadata.
      *
+     * <p>Deletes the metadata record before the stored files, so that if file deletion fails
+     * partway through, the DB is never left with a "ghost" row pointing at content that no longer
+     * exists.
+     *
      * @return {@code true} if the session existed and was removed, {@code false} if no session
      *     with that ID was found
      */
@@ -41,8 +45,8 @@ public class SessionService {
         if (metadataStore.findSession(sessionId).isEmpty()) {
             return false;
         }
-        storageProvider.deleteSession(sessionId);
         metadataStore.deleteSession(sessionId);
+        storageProvider.deleteSession(sessionId);
         return true;
     }
 

--- a/local/src/main/java/io/zmbackup/local/EmailNotifier.java
+++ b/local/src/main/java/io/zmbackup/local/EmailNotifier.java
@@ -46,8 +46,8 @@ public class EmailNotifier implements Notifier {
             boolean notifyOnFinishError) {
         this.smtpHost = Objects.requireNonNull(smtpHost, "smtpHost must not be null");
         this.smtpPort = smtpPort;
-        this.sender = Objects.requireNonNull(sender, "sender must not be null");
-        this.recipient = Objects.requireNonNull(recipient, "recipient must not be null");
+        this.sender = requireNoCrlf(sender, "sender");
+        this.recipient = requireNoCrlf(recipient, "recipient");
         this.notifyOnBegin = notifyOnBegin;
         this.notifyOnFinishSuccess = notifyOnFinishSuccess;
         this.notifyOnFinishError = notifyOnFinishError;
@@ -80,6 +80,14 @@ public class EmailNotifier implements Notifier {
                 + "Accounts: " + accountCount + "\n"
                 + "Status: " + status.dbValue() + "\n";
         send(subject, body);
+    }
+
+    private static String requireNoCrlf(String value, String fieldName) {
+        Objects.requireNonNull(value, fieldName + " must not be null");
+        if (value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0) {
+            throw new IllegalArgumentException(fieldName + " must not contain CR or LF characters");
+        }
+        return value;
     }
 
     private void send(String subject, String body) throws IOException {

--- a/local/src/test/java/io/zmbackup/local/EmailNotifierTest.java
+++ b/local/src/test/java/io/zmbackup/local/EmailNotifierTest.java
@@ -105,6 +105,24 @@ class EmailNotifierTest {
         assertThrows(IOException.class, () -> notifier.notifyBegin("full-1", BackupType.FULL));
     }
 
+    @Test
+    void rejectsSenderContainingCrlf() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new EmailNotifier(
+                        "127.0.0.1", 25, "root@example.com\r\nRCPT TO:<hacked@evil.com>", "admin@example.com",
+                        true, true, true));
+    }
+
+    @Test
+    void rejectsRecipientContainingCrlf() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new EmailNotifier(
+                        "127.0.0.1", 25, "root@example.com", "admin@example.com\r\nRCPT TO:<hacked@evil.com>",
+                        true, true, true));
+    }
+
     /** A minimal single-connection SMTP server that accepts one submission and records it. */
     private static final class FakeSmtpServer implements AutoCloseable {
         private final ServerSocket serverSocket;


### PR DESCRIPTION
## Summary

Fixes four low-impact issues:

- **#386** — `SessionService.deleteSession` now deletes the metadata row *before* the stored files, matching the order `HousekeepService.remove` already used since #382. If the storage delete then fails, the failure mode is an orphaned directory rather than a "ghost" DB row pointing at deleted content.
- **#387** — `EmailNotifier` now rejects `sender`/`recipient` values containing `\r`/`\n` (constructor-time `IllegalArgumentException`) before they're used to build the `MAIL FROM`/`RCPT TO` SMTP commands, closing a header-injection footgun.
- **#388** — `Parallel.run` now calls `executor.shutdownNow()` on the interrupted path (in addition to the existing `finally`-block `shutdown()`), so queued-but-not-yet-started tasks can't start after an interrupt has been signaled.
- **#389** — `PidLockTest` now covers the cross-process branch of `PidLock.acquire` (`tryLock()` returning `null` because a different process holds the lock) via a real subprocess (`PidLockHolderMain`), distinct from the existing same-JVM `OverlappingFileLockException` coverage. No mocking library is available in this project, so a real subprocess was used instead of mocking `FileChannel`/`FileLock`.

## Test plan

- [x] `./gradlew build` — full build, all modules, all tests pass
- [x] `./gradlew :core:test` — `SessionServiceTest`, `ParallelTest` pass
- [x] `./gradlew :local:test` — `EmailNotifierTest` (incl. two new CRLF-rejection tests) passes
- [x] `./gradlew :app:test --tests "io.zmbackup.app.PidLockTest"` — new cross-process test passes alongside existing coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TPBAggMYS2EMLMVMqr5JC

---
_Generated by [Claude Code](https://claude.ai/code/session_011TPBAggMYS2EMLMVMqr5JC)_