### PR TITLE
Fix bugs and address design/testing gaps found in code review

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -1,6 +1,7 @@
 package io.zmbackup.app;
 
 import io.zmbackup.app.config.AppConfig;
+import io.zmbackup.app.config.ConfigException;
 import io.zmbackup.app.config.EmailNotifyLevel;
 import io.zmbackup.app.config.YamlConfigLoader;
 import io.zmbackup.core.port.AccountDiscovery;
@@ -71,31 +72,7 @@ public final class AppContext {
         checkBackupUser(config);
         this.config = config;
         installLogging(config.backup().logFile());
-        if (!config.zimbraLdap().sslEnabled()) {
-            // Unlike the bash tool, whose ldapsearch/ldapadd/ldapdelete calls always upgraded with
-            // StartTLS (-Z) regardless of SSL_ENABLE (which there only chose http vs. https for the
-            // mailbox REST endpoint), zimbraLdap.sslEnabled here directly gates StartTLS on the LDAP
-            // admin bind - disabling it sends the bind password in cleartext.
-            LOG.warn(
-                    "zimbraLdap.sslEnabled is false: the LDAP admin bind will not use StartTLS and its"
-                            + " credentials will be sent in cleartext. The bash tool never allowed this.");
-        } else if (config.zimbraLdap().caCertificatePath() == null && config.zimbraLdap().trustAllCertificates()) {
-            LOG.warn(
-                    "zimbraLdap.trustAllCertificates is true: the LDAP StartTLS connection will accept any"
-                            + " server certificate, which does not protect against an active MITM attack."
-                            + " Configure zimbraLdap.caCertificatePath instead for production use.");
-        }
-        if (!config.zimbraMailbox().restBaseUrl().toLowerCase(Locale.ROOT).startsWith("https://")) {
-            // The bash tool's SSL_ENABLE defaulted to (and warned toward) true, choosing https for the
-            // mailbox REST endpoint; nothing here stopped an operator from setting it false, but the
-            // default was safe. zimbraMailbox.restBaseUrl carries no equivalent toggle or default: it's
-            // an operator-supplied URL, and ZimbraRestMailboxExporter sends the admin Basic-auth
-            // credentials over whatever scheme it's given, without any warning of its own.
-            LOG.warn(
-                    "zimbraMailbox.restBaseUrl does not start with https://: mailbox REST requests,"
-                            + " including the admin Basic-auth credentials, will be sent in cleartext."
-                            + " Configure an https:// URL for production use.");
-        }
+        checkInsecureSettings(config);
         this.storageProvider = new LocalStorageProvider(config.backup().workDir());
         this.metadataStore = new SqliteMetadataStore(config.backup().workDir().resolve(METADATA_STORE_FILENAME));
         UnboundIdLdapAdapter ldapAdapter = new UnboundIdLdapAdapter(
@@ -104,7 +81,8 @@ public final class AppContext {
                 config.zimbraLdap().bindPassword(),
                 config.zimbraLdap().sslEnabled(),
                 config.zimbraLdap().caCertificatePath(),
-                config.zimbraLdap().trustAllCertificates());
+                config.zimbraLdap().trustAllCertificates(),
+                config.zimbraMailbox().backupInactiveAccounts());
         this.accountDiscovery = ldapAdapter;
         this.ldapExporter = ldapAdapter;
         this.mailboxExporter = new ZimbraRestMailboxExporter(
@@ -114,16 +92,13 @@ public final class AppContext {
         Blocklist blocklist = new FileBlocklist(config.backup().blockedListFile());
         Notifier notifier = emailNotifier(config);
         this.sessionService = new SessionService(storageProvider, metadataStore);
-        this.backupService = new BackupService(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                blocklist,
-                notifier,
-                config.backup().maxParallelProcesses(),
-                config.backup().lockBackup());
+        this.backupService = BackupService.builder(
+                        accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore)
+                .blocklist(blocklist)
+                .notifier(notifier)
+                .maxParallelProcesses(config.backup().maxParallelProcesses())
+                .lockBackup(config.backup().lockBackup())
+                .build();
         this.restoreService = new RestoreService(
                 ldapExporter, mailboxExporter, storageProvider, metadataStore, config.backup().maxParallelProcesses());
         this.housekeepService = new HousekeepService(storageProvider, metadataStore);
@@ -142,6 +117,44 @@ public final class AppContext {
         if (!expected.equals(actual)) {
             throw new PrivilegeException("You need to be " + expected + " to run this software.");
         }
+    }
+
+    /**
+     * Refuses to start with a setting that sends credentials in cleartext or skips certificate
+     * verification, unless {@code allowInsecure} explicitly opts in - logging the same warning as
+     * before in that case. Unlike the bash tool (whose {@code ldapsearch}/{@code ldapadd}/{@code
+     * ldapdelete} calls always upgraded with StartTLS, and whose {@code SSL_ENABLE} defaulted to
+     * safe), nothing here previously stopped a misconfigured production install from silently
+     * sending the LDAP bind password or REST admin Basic-auth credentials in cleartext, or
+     * accepting an MITM certificate.
+     */
+    private static void checkInsecureSettings(AppConfig config) {
+        if (!config.zimbraLdap().sslEnabled()) {
+            refuseUnlessAllowInsecure(
+                    config,
+                    "zimbraLdap.sslEnabled is false: the LDAP admin bind will not use StartTLS and its"
+                            + " credentials will be sent in cleartext. The bash tool never allowed this.");
+        } else if (config.zimbraLdap().caCertificatePath() == null && config.zimbraLdap().trustAllCertificates()) {
+            refuseUnlessAllowInsecure(
+                    config,
+                    "zimbraLdap.trustAllCertificates is true: the LDAP StartTLS connection will accept any"
+                            + " server certificate, which does not protect against an active MITM attack."
+                            + " Configure zimbraLdap.caCertificatePath instead for production use.");
+        }
+        if (!config.zimbraMailbox().restBaseUrl().toLowerCase(Locale.ROOT).startsWith("https://")) {
+            refuseUnlessAllowInsecure(
+                    config,
+                    "zimbraMailbox.restBaseUrl does not start with https://: mailbox REST requests,"
+                            + " including the admin Basic-auth credentials, will be sent in cleartext."
+                            + " Configure an https:// URL for production use.");
+        }
+    }
+
+    private static void refuseUnlessAllowInsecure(AppConfig config, String message) {
+        if (!config.allowInsecure()) {
+            throw new ConfigException(message + " Set allowInsecure: true in zmbackup.yaml to run anyway.");
+        }
+        LOG.warn(message);
     }
 
     /**

--- a/app/src/main/java/io/zmbackup/app/cli/CliValidation.java
+++ b/app/src/main/java/io/zmbackup/app/cli/CliValidation.java
@@ -97,4 +97,38 @@ final class CliValidation {
         }
         return true;
     }
+
+    /**
+     * Validates that {@code --into} (mailbox restore-on-account) is only given alongside exactly
+     * one {@code --account}, printing {@code "<commandName>: --into requires exactly one
+     * --account"} to {@code err} and returning {@code false} otherwise. A {@code null} destination
+     * (the common case: no {@code --into}) is always valid, regardless of {@code accounts}' size.
+     * Shared by {@code restore} and {@code restore mailbox}, the two commands that accept {@code
+     * --into}, so the two can't drift on this check the way separately duplicated copies could.
+     */
+    static boolean validateIntoRequiresSingleAccount(
+            String commandName, String destination, List<String> accounts, PrintWriter err) {
+        if (destination != null && accounts.size() != 1) {
+            err.println(commandName + ": --into requires exactly one --account");
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Validates that {@code sessionId} is a full or incremental session, the only kind the
+     * top-level {@code restore} command (as opposed to its {@code ldap}/{@code domain}/{@code
+     * mailbox} subcommands) can restore. Prints a message pointing at the matching subcommand and
+     * returns {@code false} otherwise.
+     */
+    static boolean validateFullOrIncrementalSessionPrefix(String sessionId, PrintWriter err) {
+        if (!(sessionId.startsWith("full") || sessionId.startsWith("inc"))) {
+            err.println(
+                    "restore: '--session=" + sessionId
+                            + "' is not a full/incremental session; use 'restore ldap', 'restore domain', or"
+                            + " 'restore mailbox' to restore one kind of content on its own.");
+            return false;
+        }
+        return true;
+    }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
@@ -61,15 +61,10 @@ public final class RestoreCommand implements Callable<Integer> {
         if (!(CliValidation.validateEmails(accounts, err) && CliValidation.validateEmail(destination, err))) {
             return CommandLine.ExitCode.USAGE;
         }
-        if (destination != null && accounts.size() != 1) {
-            err.println("restore: --into requires exactly one --account");
+        if (!CliValidation.validateIntoRequiresSingleAccount("restore", destination, accounts, err)) {
             return CommandLine.ExitCode.USAGE;
         }
-        if (destination == null && !(sessionId.startsWith("full") || sessionId.startsWith("inc"))) {
-            err.println(
-                    "restore: '--session=" + sessionId
-                            + "' is not a full/incremental session; use 'restore ldap', 'restore domain', or"
-                            + " 'restore mailbox' to restore one kind of content on its own.");
+        if (destination == null && !CliValidation.validateFullOrIncrementalSessionPrefix(sessionId, err)) {
             return CommandLine.ExitCode.USAGE;
         }
 

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreMailboxCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreMailboxCommand.java
@@ -42,8 +42,7 @@ public final class RestoreMailboxCommand implements Callable<Integer> {
                 || !CliValidation.validateEmail(destination, err)) {
             return CommandLine.ExitCode.USAGE;
         }
-        if (destination != null && accounts.size() != 1) {
-            err.println("restore mailbox: --into requires exactly one --account");
+        if (!CliValidation.validateIntoRequiresSingleAccount("restore mailbox", destination, accounts, err)) {
             return CommandLine.ExitCode.USAGE;
         }
 

--- a/app/src/main/java/io/zmbackup/app/config/AppConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/AppConfig.java
@@ -9,8 +9,15 @@ import java.util.Objects;
  * @param zimbraLdap    LDAP connection settings used for account discovery and LDAP object export
  * @param zimbraMailbox Zimbra mailbox export settings
  * @param backup        local backup behavior (storage, rotation, notifications)
+ * @param allowInsecure explicit opt-in required for {@link AppConfig} to start with any setting
+ *                      that sends credentials in cleartext or disables certificate verification
+ *                      ({@code zimbraLdap.sslEnabled=false}, {@code zimbraLdap.trustAllCertificates=true}
+ *                      with no {@code caCertificatePath}, or a non-{@code https://}
+ *                      {@code zimbraMailbox.restBaseUrl}); {@link io.zmbackup.app.AppContext} refuses to
+ *                      start with such a setting unless this is {@code true}
  */
-public record AppConfig(ZimbraLdapConfig zimbraLdap, ZimbraMailboxConfig zimbraMailbox, BackupConfig backup) {
+public record AppConfig(
+        ZimbraLdapConfig zimbraLdap, ZimbraMailboxConfig zimbraMailbox, BackupConfig backup, boolean allowInsecure) {
 
     public AppConfig {
         Objects.requireNonNull(zimbraLdap, "zimbraLdap must not be null");

--- a/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
+++ b/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
@@ -55,7 +55,11 @@ public final class YamlConfigLoader {
         if (root == null) {
             throw new ConfigException("Config file is empty");
         }
-        return new AppConfig(parseZimbraLdap(root), parseZimbraMailbox(root), parseBackup(root));
+        return new AppConfig(
+                parseZimbraLdap(root),
+                parseZimbraMailbox(root),
+                parseBackup(root),
+                optionalBoolean(root, "allowInsecure", false));
     }
 
     private static ZimbraLdapConfig parseZimbraLdap(Map<String, Object> root) {
@@ -71,7 +75,6 @@ public final class YamlConfigLoader {
     private static ZimbraMailboxConfig parseZimbraMailbox(Map<String, Object> root) {
         return new ZimbraMailboxConfig(
                 requireString(root, "zimbraMailbox.backupUser"),
-                requirePath(root, "zimbraMailbox.zmmailboxPath"),
                 optionalBoolean(root, "zimbraMailbox.backupInactiveAccounts", true),
                 requireString(root, "zimbraMailbox.restBaseUrl"),
                 requireString(root, "zimbraMailbox.adminUser"),

--- a/app/src/main/java/io/zmbackup/app/config/ZimbraMailboxConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/ZimbraMailboxConfig.java
@@ -1,16 +1,14 @@
 package io.zmbackup.app.config;
 
-import java.nio.file.Path;
 import java.util.Objects;
 
 /**
- * Zimbra mailbox export settings, mirroring the {@code BACKUPUSER}/{@code ZMMAILBOX}/
- * {@code BACKUP_INACTIVE_ACCOUNTS} fields of the bash tool's {@code zmbackup.conf}, plus the REST
- * endpoint settings used by {@code ZimbraRestMailboxExporter}.
+ * Zimbra mailbox export settings, mirroring the {@code BACKUPUSER}/{@code BACKUP_INACTIVE_ACCOUNTS}
+ * fields of the bash tool's {@code zmbackup.conf}, plus the REST endpoint settings used by {@code
+ * ZimbraRestMailboxExporter}.
  *
- * @param backupUser              the Zimbra service account used to start/stop the service and
- *                                run {@code zmmailbox}, e.g. {@code "zimbra"}
- * @param zmmailboxPath           location of the {@code zmmailbox} binary
+ * @param backupUser              the Zimbra service account used to start/stop the service, e.g.
+ *                                {@code "zimbra"}
  * @param backupInactiveAccounts whether to include disabled accounts
  * @param restBaseUrl             the Zimbra server's REST base URL, e.g.
  *                                {@code "https://mail.example.com:7071"}
@@ -19,7 +17,6 @@ import java.util.Objects;
  */
 public record ZimbraMailboxConfig(
         String backupUser,
-        Path zmmailboxPath,
         boolean backupInactiveAccounts,
         String restBaseUrl,
         String adminUser,
@@ -27,7 +24,6 @@ public record ZimbraMailboxConfig(
 
     public ZimbraMailboxConfig {
         Objects.requireNonNull(backupUser, "backupUser must not be null");
-        Objects.requireNonNull(zmmailboxPath, "zmmailboxPath must not be null");
         Objects.requireNonNull(restBaseUrl, "restBaseUrl must not be null");
         Objects.requireNonNull(adminUser, "adminUser must not be null");
         Objects.requireNonNull(adminPassword, "adminPassword must not be null");
@@ -41,7 +37,6 @@ public record ZimbraMailboxConfig(
     @Override
     public String toString() {
         return "ZimbraMailboxConfig[backupUser=" + backupUser
-                + ", zmmailboxPath=" + zmmailboxPath
                 + ", backupInactiveAccounts=" + backupInactiveAccounts
                 + ", restBaseUrl=" + restBaseUrl
                 + ", adminUser=" + adminUser

--- a/app/src/test/java/io/zmbackup/app/AppContextTest.java
+++ b/app/src/test/java/io/zmbackup/app/AppContextTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.zmbackup.app.config.AppConfig;
 import io.zmbackup.app.config.BackupConfig;
+import io.zmbackup.app.config.ConfigException;
 import io.zmbackup.app.config.EmailNotifyConfig;
 import io.zmbackup.app.config.EmailNotifyLevel;
 import io.zmbackup.app.config.ZimbraLdapConfig;
@@ -52,7 +53,6 @@ class AppContextTest {
                   bindPassword: secret
                 zimbraMailbox:
                   backupUser: %s
-                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
                   adminPassword: secret
@@ -85,6 +85,24 @@ class AppContextTest {
         assertEquals("You need to be not-the-real-user to run this software.", exception.getMessage());
     }
 
+    @Test
+    void constructorRefusesInsecureLdapSslWithoutAllowInsecure() {
+        AppConfig config = configWithSslEnabled(tempDir, false, false);
+
+        ConfigException exception = assertThrows(ConfigException.class, () -> new AppContext(config));
+
+        assertTrue(exception.getMessage().startsWith("zimbraLdap.sslEnabled is false"));
+    }
+
+    @Test
+    void constructorAllowsInsecureLdapSslWhenAllowInsecureIsSet() throws IOException {
+        AppConfig config = configWithSslEnabled(tempDir, false, true);
+
+        AppContext context = new AppContext(config);
+
+        assertEquals(config, context.config());
+    }
+
     private static AppConfig configWithWorkDir(Path workDir) {
         return configWithWorkDir(workDir, System.getProperty("user.name"));
     }
@@ -93,13 +111,7 @@ class AppContextTest {
         return new AppConfig(
                 new ZimbraLdapConfig(
                         "ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true, null, false),
-                new ZimbraMailboxConfig(
-                        backupUser,
-                        Path.of("/opt/zimbra/bin/zmmailbox"),
-                        true,
-                        "https://127.0.0.1:7071",
-                        "zimbra",
-                        "secret"),
+                new ZimbraMailboxConfig(backupUser, true, "https://127.0.0.1:7071", "zimbra", "secret"),
                 new BackupConfig(
                         workDir,
                         workDir.resolve("zmbackup.log"),
@@ -107,6 +119,29 @@ class AppContextTest {
                         3,
                         30,
                         true,
-                        new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com")));
+                        new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com")),
+                false);
+    }
+
+    private static AppConfig configWithSslEnabled(Path workDir, boolean sslEnabled, boolean allowInsecure) {
+        return new AppConfig(
+                new ZimbraLdapConfig(
+                        "ldap://127.0.0.1:389",
+                        "uid=zimbra,cn=admins,cn=zimbra",
+                        "secret",
+                        sslEnabled,
+                        null,
+                        false),
+                new ZimbraMailboxConfig(
+                        System.getProperty("user.name"), true, "https://127.0.0.1:7071", "zimbra", "secret"),
+                new BackupConfig(
+                        workDir,
+                        workDir.resolve("zmbackup.log"),
+                        workDir.resolve("blockedlist.conf"),
+                        3,
+                        30,
+                        true,
+                        new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com")),
+                allowInsecure);
     }
 }

--- a/app/src/test/java/io/zmbackup/app/cli/AccountsCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/AccountsCommandTest.java
@@ -118,7 +118,6 @@ class AccountsCommandTest {
                   sslEnabled: false
                 zimbraMailbox:
                   backupUser: %s
-                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
                   adminPassword: secret
@@ -129,6 +128,7 @@ class AccountsCommandTest {
                   emailNotify:
                     recipient: admin@example.com
                     sender: root@example.com
+                allowInsecure: true
                 """
                         .formatted(
                                 directoryServer.getListenPort(),

--- a/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/BackupCommandTest.java
@@ -428,7 +428,6 @@ class BackupCommandTest {
                   sslEnabled: false
                 zimbraMailbox:
                   backupUser: %s
-                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: %s
                   adminUser: zimbra
                   adminPassword: secret
@@ -439,6 +438,7 @@ class BackupCommandTest {
                   emailNotify:
                     recipient: admin@example.com
                     sender: root@example.com
+                allowInsecure: true
                 """
                         .formatted(
                                 directoryServer.getListenPort(),

--- a/app/src/test/java/io/zmbackup/app/cli/HousekeepCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/HousekeepCommandTest.java
@@ -103,7 +103,6 @@ class HousekeepCommandTest {
                   sslEnabled: false
                 zimbraMailbox:
                   backupUser: %s
-                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
                   adminPassword: secret
@@ -115,6 +114,7 @@ class HousekeepCommandTest {
                   emailNotify:
                     recipient: admin@example.com
                     sender: root@example.com
+                allowInsecure: true
                 """
                         .formatted(
                                 System.getProperty("user.name"),

--- a/app/src/test/java/io/zmbackup/app/cli/MainTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MainTest.java
@@ -185,7 +185,6 @@ class MainTest {
                   bindPassword: secret
                 zimbraMailbox:
                   backupUser: %s
-                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
                   adminPassword: secret

--- a/app/src/test/java/io/zmbackup/app/cli/MigrateCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MigrateCommandTest.java
@@ -107,7 +107,6 @@ class MigrateCommandTest {
                   bindPassword: secret
                 zimbraMailbox:
                   backupUser: %s
-                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
                   adminPassword: secret

--- a/app/src/test/java/io/zmbackup/app/cli/RestoreCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/RestoreCommandTest.java
@@ -354,7 +354,6 @@ class RestoreCommandTest {
                   sslEnabled: false
                 zimbraMailbox:
                   backupUser: %s
-                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: %s
                   adminUser: zimbra
                   adminPassword: secret
@@ -365,6 +364,7 @@ class RestoreCommandTest {
                   emailNotify:
                     recipient: admin@example.com
                     sender: root@example.com
+                allowInsecure: true
                 """
                         .formatted(
                                 directoryServer.getListenPort(),

--- a/app/src/test/java/io/zmbackup/app/cli/ShadowJarSmokeTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/ShadowJarSmokeTest.java
@@ -76,7 +76,6 @@ class ShadowJarSmokeTest {
                   bindPassword: secret
                 zimbraMailbox:
                   backupUser: %s
-                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
                   adminPassword: secret

--- a/app/src/test/java/io/zmbackup/app/cli/TruncateCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/TruncateCommandTest.java
@@ -85,7 +85,6 @@ class TruncateCommandTest {
                   bindPassword: secret
                 zimbraMailbox:
                   backupUser: %s
-                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
                   adminPassword: secret

--- a/app/src/test/java/io/zmbackup/app/config/AppConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/AppConfigTest.java
@@ -1,0 +1,54 @@
+package io.zmbackup.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class AppConfigTest {
+
+    private static final ZimbraLdapConfig LDAP_CONFIG = new ZimbraLdapConfig(
+            "ldap://ldap.example.com:389", "uid=zimbra,cn=admins,cn=zimbra", "ldap-s3cr3t", true, null, false);
+
+    private static final ZimbraMailboxConfig MAILBOX_CONFIG =
+            new ZimbraMailboxConfig("zimbra", true, "https://mail.example.com:7071", "zimbra", "mailbox-s3cr3t");
+
+    private static final BackupConfig BACKUP_CONFIG = new BackupConfig(
+            Path.of("/opt/zimbra/backup"),
+            Path.of("/opt/zimbra/log/zmbackup.log"),
+            Path.of("/etc/zmbackup/blockedlist.conf"),
+            3,
+            30,
+            true,
+            new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com"));
+
+    @Test
+    void rejectsNullZimbraLdap() {
+        assertThrows(NullPointerException.class, () -> new AppConfig(null, MAILBOX_CONFIG, BACKUP_CONFIG, false));
+    }
+
+    @Test
+    void rejectsNullZimbraMailbox() {
+        assertThrows(NullPointerException.class, () -> new AppConfig(LDAP_CONFIG, null, BACKUP_CONFIG, false));
+    }
+
+    @Test
+    void rejectsNullBackup() {
+        assertThrows(NullPointerException.class, () -> new AppConfig(LDAP_CONFIG, MAILBOX_CONFIG, null, false));
+    }
+
+    @Test
+    void toStringDoesNotLeakNestedSecrets() {
+        AppConfig config = new AppConfig(LDAP_CONFIG, MAILBOX_CONFIG, BACKUP_CONFIG, false);
+
+        String result = config.toString();
+
+        assertFalse(result.contains("ldap-s3cr3t"), "toString() must not leak the LDAP bind password: " + result);
+        assertFalse(
+                result.contains("mailbox-s3cr3t"), "toString() must not leak the mailbox admin password: " + result);
+        assertTrue(result.contains("bindPassword=***"));
+        assertTrue(result.contains("adminPassword=***"));
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/config/BackupConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/BackupConfigTest.java
@@ -1,0 +1,111 @@
+package io.zmbackup.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class BackupConfigTest {
+
+    private static final EmailNotifyConfig EMAIL_NOTIFY =
+            new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com");
+
+    @Test
+    void rejectsMaxParallelProcessesBelowOne() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> new BackupConfig(
+                        Path.of("/opt/zimbra/backup"),
+                        Path.of("/opt/zimbra/log/zmbackup.log"),
+                        Path.of("/etc/zmbackup/blockedlist.conf"),
+                        0,
+                        30,
+                        true,
+                        EMAIL_NOTIFY));
+
+        assertEquals("maxParallelProcesses must be at least 1", exception.getMessage());
+    }
+
+    @Test
+    void rejectsNegativeRotateDays() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> new BackupConfig(
+                        Path.of("/opt/zimbra/backup"),
+                        Path.of("/opt/zimbra/log/zmbackup.log"),
+                        Path.of("/etc/zmbackup/blockedlist.conf"),
+                        3,
+                        -1,
+                        true,
+                        EMAIL_NOTIFY));
+
+        assertEquals("rotateDays must not be negative", exception.getMessage());
+    }
+
+    @Test
+    void rejectsNullWorkDir() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new BackupConfig(
+                        null,
+                        Path.of("/opt/zimbra/log/zmbackup.log"),
+                        Path.of("/etc/zmbackup/blockedlist.conf"),
+                        3,
+                        30,
+                        true,
+                        EMAIL_NOTIFY));
+    }
+
+    @Test
+    void rejectsNullLogFile() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new BackupConfig(
+                        Path.of("/opt/zimbra/backup"),
+                        null,
+                        Path.of("/etc/zmbackup/blockedlist.conf"),
+                        3,
+                        30,
+                        true,
+                        EMAIL_NOTIFY));
+    }
+
+    @Test
+    void rejectsNullBlockedListFile() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new BackupConfig(
+                        Path.of("/opt/zimbra/backup"), Path.of("/opt/zimbra/log/zmbackup.log"), null, 3, 30, true,
+                        EMAIL_NOTIFY));
+    }
+
+    @Test
+    void rejectsNullEmailNotify() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new BackupConfig(
+                        Path.of("/opt/zimbra/backup"),
+                        Path.of("/opt/zimbra/log/zmbackup.log"),
+                        Path.of("/etc/zmbackup/blockedlist.conf"),
+                        3,
+                        30,
+                        true,
+                        null));
+    }
+
+    @Test
+    void acceptsZeroRotateDaysAndOneMaxParallelProcess() {
+        BackupConfig config = new BackupConfig(
+                Path.of("/opt/zimbra/backup"),
+                Path.of("/opt/zimbra/log/zmbackup.log"),
+                Path.of("/etc/zmbackup/blockedlist.conf"),
+                1,
+                0,
+                true,
+                EMAIL_NOTIFY);
+
+        assertEquals(1, config.maxParallelProcesses());
+        assertEquals(0, config.rotateDays());
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/config/EmailNotifyConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/EmailNotifyConfigTest.java
@@ -1,0 +1,38 @@
+package io.zmbackup.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class EmailNotifyConfigTest {
+
+    @Test
+    void rejectsNullLevel() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new EmailNotifyConfig(null, "admin@example.com", "root@example.com"));
+    }
+
+    @Test
+    void rejectsNullRecipient() {
+        assertThrows(
+                NullPointerException.class, () -> new EmailNotifyConfig(EmailNotifyLevel.ALL, null, "root@example.com"));
+    }
+
+    @Test
+    void rejectsNullSender() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", null));
+    }
+
+    @Test
+    void storesConfiguredFields() {
+        EmailNotifyConfig config = new EmailNotifyConfig(EmailNotifyLevel.ERROR, "admin@example.com", "root@example.com");
+
+        assertEquals(EmailNotifyLevel.ERROR, config.level());
+        assertEquals("admin@example.com", config.recipient());
+        assertEquals("root@example.com", config.sender());
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
@@ -28,7 +28,6 @@ class YamlConfigLoaderTest {
               trustAllCertificates: true
             zimbraMailbox:
               backupUser: zimbra
-              zmmailboxPath: /opt/zimbra/bin/zmmailbox
               restBaseUrl: https://127.0.0.1:7071
               adminUser: zimbra
               adminPassword: secret
@@ -44,6 +43,7 @@ class YamlConfigLoaderTest {
                 level: ERROR
                 recipient: admin@example.com
                 sender: root@example.com
+            allowInsecure: true
             """;
 
     private static final String MINIMAL_YAML =
@@ -54,7 +54,6 @@ class YamlConfigLoaderTest {
               bindPassword: secret
             zimbraMailbox:
               backupUser: zimbra
-              zmmailboxPath: /opt/zimbra/bin/zmmailbox
               restBaseUrl: https://127.0.0.1:7071
               adminUser: zimbra
               adminPassword: secret
@@ -79,7 +78,6 @@ class YamlConfigLoaderTest {
         assertEquals(true, config.zimbraLdap().trustAllCertificates());
 
         assertEquals("zimbra", config.zimbraMailbox().backupUser());
-        assertEquals(Path.of("/opt/zimbra/bin/zmmailbox"), config.zimbraMailbox().zmmailboxPath());
         assertEquals(false, config.zimbraMailbox().backupInactiveAccounts());
         assertEquals("https://127.0.0.1:7071", config.zimbraMailbox().restBaseUrl());
         assertEquals("zimbra", config.zimbraMailbox().adminUser());
@@ -94,6 +92,7 @@ class YamlConfigLoaderTest {
         assertEquals(EmailNotifyLevel.ERROR, config.backup().emailNotify().level());
         assertEquals("admin@example.com", config.backup().emailNotify().recipient());
         assertEquals("root@example.com", config.backup().emailNotify().sender());
+        assertEquals(true, config.allowInsecure());
     }
 
     private static void assertFalseSsl(AppConfig config) {
@@ -112,6 +111,7 @@ class YamlConfigLoaderTest {
         assertEquals(30, config.backup().rotateDays());
         assertTrue(config.backup().lockBackup());
         assertEquals(EmailNotifyLevel.ALL, config.backup().emailNotify().level());
+        assertEquals(false, config.allowInsecure());
     }
 
     @Test
@@ -145,7 +145,6 @@ class YamlConfigLoaderTest {
                 """
                 zimbraMailbox:
                   backupUser: zimbra
-                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
                   adminPassword: secret
@@ -170,7 +169,6 @@ class YamlConfigLoaderTest {
                 zimbraLdap: not-a-mapping
                 zimbraMailbox:
                   backupUser: zimbra
-                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
                   adminPassword: secret
@@ -199,7 +197,6 @@ class YamlConfigLoaderTest {
                   sslEnabled: not-a-boolean
                 zimbraMailbox:
                   backupUser: zimbra
-                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
                   adminPassword: secret
@@ -227,7 +224,6 @@ class YamlConfigLoaderTest {
                   bindPassword: secret
                 zimbraMailbox:
                   backupUser: zimbra
-                  zmmailboxPath: /opt/zimbra/bin/zmmailbox
                   restBaseUrl: https://127.0.0.1:7071
                   adminUser: zimbra
                   adminPassword: secret

--- a/app/src/test/java/io/zmbackup/app/config/ZimbraMailboxConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/ZimbraMailboxConfigTest.java
@@ -3,20 +3,14 @@ package io.zmbackup.app.config;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
 class ZimbraMailboxConfigTest {
 
     @Test
     void toStringRedactsAdminPassword() {
-        ZimbraMailboxConfig config = new ZimbraMailboxConfig(
-                "zimbra",
-                Path.of("/opt/zimbra/bin/zmmailbox"),
-                false,
-                "https://mail.example.com:7071",
-                "zimbra",
-                "s3cr3t");
+        ZimbraMailboxConfig config =
+                new ZimbraMailboxConfig("zimbra", false, "https://mail.example.com:7071", "zimbra", "s3cr3t");
 
         String result = config.toString();
 

--- a/app/src/test/java/io/zmbackup/app/cucumber/BackupIntegrationSteps.java
+++ b/app/src/test/java/io/zmbackup/app/cucumber/BackupIntegrationSteps.java
@@ -97,7 +97,8 @@ public class BackupIntegrationSteps {
                 "dc=example,dc=com", new Attribute("objectClass", "domain"), new Attribute("dc", "example"));
 
         UnboundIdLdapAdapter ldapAdapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false,
+                true);
 
         mailboxServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
         mailboxServer.start();
@@ -113,7 +114,9 @@ public class BackupIntegrationSteps {
 
         storageProvider = new LocalStorageProvider(tempDir);
 
-        backupService = new BackupService(ldapAdapter, ldapAdapter, mailboxExporter, storageProvider, metadataStore);
+        backupService =
+                BackupService.builder(ldapAdapter, ldapAdapter, mailboxExporter, storageProvider, metadataStore)
+                        .build();
         restoreService = new RestoreService(ldapAdapter, mailboxExporter, storageProvider, metadataStore);
         housekeepService = new HousekeepService(storageProvider, metadataStore);
         sessionService = new SessionService(storageProvider, metadataStore);

--- a/core/src/main/java/io/zmbackup/core/domain/BackupType.java
+++ b/core/src/main/java/io/zmbackup/core/domain/BackupType.java
@@ -1,5 +1,8 @@
 package io.zmbackup.core.domain;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * The kind of backup a session performs, mirroring the bash tool's session-name prefixes
  * (e.g. {@code full-20260101120000}) so existing session IDs stay parseable.
@@ -37,6 +40,18 @@ public enum BackupType {
     /** Whether this backup type exports mailbox content. */
     public boolean includesMailbox() {
         return includesMailbox;
+    }
+
+    /**
+     * The {@link #sessionPrefix()} of every type with {@link #includesMailbox()}, for callers
+     * (e.g. incremental-cutoff queries) that need to recognize a session ID as one that could
+     * carry a mailbox-account backup without hardcoding the current set of prefixes.
+     */
+    public static List<String> mailboxSessionPrefixes() {
+        return Arrays.stream(values())
+                .filter(BackupType::includesMailbox)
+                .map(BackupType::sessionPrefix)
+                .toList();
     }
 
     /** Resolves the type matching a value previously produced by {@link #sessionPrefix()}. */

--- a/core/src/main/java/io/zmbackup/core/service/BackupService.java
+++ b/core/src/main/java/io/zmbackup/core/service/BackupService.java
@@ -86,101 +86,6 @@ public class BackupService {
     private final int maxParallelProcesses;
     private final boolean lockBackup;
 
-    public BackupService(
-            AccountDiscovery accountDiscovery,
-            ZimbraLdapExporter ldapExporter,
-            ZimbraMailboxExporter mailboxExporter,
-            StorageProvider storageProvider,
-            MetadataStore metadataStore) {
-        this(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                NO_BLOCKLIST,
-                NO_NOTIFIER,
-                1);
-    }
-
-    /**
-     * @param maxParallelProcesses how many accounts to back up concurrently, mirroring the bash
-     *     tool's {@code MAX_PARALLEL_PROCESS}; values below 1 are treated as 1
-     */
-    public BackupService(
-            AccountDiscovery accountDiscovery,
-            ZimbraLdapExporter ldapExporter,
-            ZimbraMailboxExporter mailboxExporter,
-            StorageProvider storageProvider,
-            MetadataStore metadataStore,
-            int maxParallelProcesses) {
-        this(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                NO_BLOCKLIST,
-                NO_NOTIFIER,
-                maxParallelProcesses);
-    }
-
-    /**
-     * @param blocklist            discovered accounts (or domains) found here are skipped rather
-     *                             than backed up, mirroring {@code ldap_filter}'s blocklist check
-     * @param maxParallelProcesses how many accounts to back up concurrently, mirroring the bash
-     *                             tool's {@code MAX_PARALLEL_PROCESS}; values below 1 are treated
-     *                             as 1
-     */
-    public BackupService(
-            AccountDiscovery accountDiscovery,
-            ZimbraLdapExporter ldapExporter,
-            ZimbraMailboxExporter mailboxExporter,
-            StorageProvider storageProvider,
-            MetadataStore metadataStore,
-            Blocklist blocklist,
-            int maxParallelProcesses) {
-        this(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                blocklist,
-                NO_NOTIFIER,
-                maxParallelProcesses);
-    }
-
-    /**
-     * @param blocklist            discovered accounts (or domains) found here are skipped rather
-     *                             than backed up, mirroring {@code ldap_filter}'s blocklist check
-     * @param notifier             notified when a session starts and finishes, mirroring {@code
-     *                             notify_begin}/{@code notify_finish}
-     * @param maxParallelProcesses how many accounts to back up concurrently, mirroring the bash
-     *                             tool's {@code MAX_PARALLEL_PROCESS}; values below 1 are treated
-     *                             as 1
-     */
-    public BackupService(
-            AccountDiscovery accountDiscovery,
-            ZimbraLdapExporter ldapExporter,
-            ZimbraMailboxExporter mailboxExporter,
-            StorageProvider storageProvider,
-            MetadataStore metadataStore,
-            Blocklist blocklist,
-            Notifier notifier,
-            int maxParallelProcesses) {
-        this(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                blocklist,
-                notifier,
-                maxParallelProcesses,
-                false);
-    }
-
     /**
      * @param blocklist            discovered accounts (or domains) found here are skipped rather
      *                             than backed up, mirroring {@code ldap_filter}'s blocklist check
@@ -194,7 +99,7 @@ public class BackupService {
      *                             the last 24 hours are skipped, mirroring {@code ldap_filter}'s
      *                             {@code LOCK_BACKUP} dedup check
      */
-    public BackupService(
+    private BackupService(
             AccountDiscovery accountDiscovery,
             ZimbraLdapExporter ldapExporter,
             ZimbraMailboxExporter mailboxExporter,
@@ -213,6 +118,97 @@ public class BackupService {
         this.notifier = Objects.requireNonNull(notifier, "notifier must not be null");
         this.maxParallelProcesses = maxParallelProcesses;
         this.lockBackup = lockBackup;
+    }
+
+    /**
+     * Starts building a {@link BackupService} from its required collaborators, with {@link
+     * Builder#blocklist}, {@link Builder#notifier}, {@link Builder#maxParallelProcesses}, and
+     * {@link Builder#lockBackup} all optional and defaulted - replacing what used to be five
+     * telescoping constructors covering every combination of those four optional settings.
+     */
+    public static Builder builder(
+            AccountDiscovery accountDiscovery,
+            ZimbraLdapExporter ldapExporter,
+            ZimbraMailboxExporter mailboxExporter,
+            StorageProvider storageProvider,
+            MetadataStore metadataStore) {
+        return new Builder(accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore);
+    }
+
+    /** Builds a {@link BackupService}; see {@link BackupService#builder} for how to obtain one. */
+    public static final class Builder {
+        private final AccountDiscovery accountDiscovery;
+        private final ZimbraLdapExporter ldapExporter;
+        private final ZimbraMailboxExporter mailboxExporter;
+        private final StorageProvider storageProvider;
+        private final MetadataStore metadataStore;
+        private Blocklist blocklist = NO_BLOCKLIST;
+        private Notifier notifier = NO_NOTIFIER;
+        private int maxParallelProcesses = 1;
+        private boolean lockBackup = false;
+
+        private Builder(
+                AccountDiscovery accountDiscovery,
+                ZimbraLdapExporter ldapExporter,
+                ZimbraMailboxExporter mailboxExporter,
+                StorageProvider storageProvider,
+                MetadataStore metadataStore) {
+            this.accountDiscovery = accountDiscovery;
+            this.ldapExporter = ldapExporter;
+            this.mailboxExporter = mailboxExporter;
+            this.storageProvider = storageProvider;
+            this.metadataStore = metadataStore;
+        }
+
+        /**
+         * Discovered accounts (or domains) found here are skipped rather than backed up,
+         * mirroring {@code ldap_filter}'s blocklist check. Defaults to backing up everything.
+         */
+        public Builder blocklist(Blocklist blocklist) {
+            this.blocklist = blocklist;
+            return this;
+        }
+
+        /**
+         * Notified when a session starts and finishes, mirroring {@code notify_begin}/{@code
+         * notify_finish}. Defaults to sending no notifications.
+         */
+        public Builder notifier(Notifier notifier) {
+            this.notifier = notifier;
+            return this;
+        }
+
+        /**
+         * How many accounts to back up concurrently, mirroring the bash tool's {@code
+         * MAX_PARALLEL_PROCESS}; values below 1 are treated as 1. Defaults to 1 (sequential).
+         */
+        public Builder maxParallelProcesses(int maxParallelProcesses) {
+            this.maxParallelProcesses = maxParallelProcesses;
+            return this;
+        }
+
+        /**
+         * When true, discovered identifiers (not explicit {@code --account} lists) with an
+         * account-level backup completed within the last 24 hours are skipped, mirroring {@code
+         * ldap_filter}'s {@code LOCK_BACKUP} dedup check. Defaults to false.
+         */
+        public Builder lockBackup(boolean lockBackup) {
+            this.lockBackup = lockBackup;
+            return this;
+        }
+
+        public BackupService build() {
+            return new BackupService(
+                    accountDiscovery,
+                    ldapExporter,
+                    mailboxExporter,
+                    storageProvider,
+                    metadataStore,
+                    blocklist,
+                    notifier,
+                    maxParallelProcesses,
+                    lockBackup);
+        }
     }
 
     /** Backs up every object of {@code type} found across the whole directory. */

--- a/core/src/main/java/io/zmbackup/core/service/MigrationService.java
+++ b/core/src/main/java/io/zmbackup/core/service/MigrationService.java
@@ -17,7 +17,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -117,8 +119,19 @@ public final class MigrationService {
             metadataStore.save(new BackupSession(sessionId, type, status, startedAt, completedAt, size));
             imported++;
 
+            // save() above is an upsert keyed on sessionId, so a retry after a partial failure
+            // re-reaches this point safely, but recordAccountBackup() below is a plain insert with
+            // no such key - skip accounts a previous, interrupted run already recorded for this
+            // session so a retry can't duplicate their rows.
+            Set<String> alreadyRecorded = metadataStore.findAccountsForSession(sessionId).stream()
+                    .map(BackupAccountRecord::email)
+                    .collect(Collectors.toSet());
+
             for (String[] accountLine : accountLinesBySession.getOrDefault(sessionId, List.of())) {
                 String email = accountLine[0];
+                if (alreadyRecorded.contains(email)) {
+                    continue;
+                }
                 Instant accountAt = parseAccountDate(accountLine[1], startedAt);
                 String accountSize = storageProvider.sizeOfAccount(sessionId, email);
                 metadataStore.recordAccountBackup(

--- a/core/src/main/java/io/zmbackup/core/service/Parallel.java
+++ b/core/src/main/java/io/zmbackup/core/service/Parallel.java
@@ -49,6 +49,9 @@ final class Parallel {
             executor.shutdownNow();
             throw new IOException("Interrupted while running parallel tasks", e);
         } finally {
+            // The sole cleanup for every exit path except the interrupted one above, which already
+            // shut the pool down via shutdownNow(); shutdown() on an already-shutdown executor is a
+            // documented no-op, so calling it again here is safe rather than redundant.
             executor.shutdown();
         }
     }

--- a/core/src/test/java/io/zmbackup/core/domain/BackupTypeTest.java
+++ b/core/src/test/java/io/zmbackup/core/domain/BackupTypeTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class BackupTypeTest {
@@ -46,5 +47,10 @@ class BackupTypeTest {
         assertEquals("distlist", BackupType.DISTRIBUTION_LIST.sessionPrefix());
         assertEquals("signature", BackupType.SIGNATURE.sessionPrefix());
         assertEquals("domain", BackupType.DOMAIN.sessionPrefix());
+    }
+
+    @Test
+    void mailboxSessionPrefixesListsOnlyTypesThatIncludeMailbox() {
+        assertEquals(List.of("full", "inc", "mbox"), BackupType.mailboxSessionPrefixes());
     }
 }

--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -40,8 +40,9 @@ class BackupServiceTest {
     private final FakeZimbraMailboxExporter mailboxExporter = new FakeZimbraMailboxExporter();
     private final InMemoryStorageProvider storageProvider = new InMemoryStorageProvider();
     private final InMemoryMetadataStore metadataStore = new InMemoryMetadataStore();
-    private final BackupService backupService = new BackupService(
-            accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore);
+    private final BackupService backupService = BackupService.builder(
+                    accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore)
+            .build();
 
     @Test
     void backsUpDiscoveredAccountsForLdapType() throws IOException {
@@ -107,14 +108,11 @@ class BackupServiceTest {
     @Test
     void discoveredAccountOnBlocklistIsSkipped() throws IOException {
         accountDiscovery.wholeDirectory.put(LdapObjectType.ACCOUNT, List.of("alice@example.com", "bob@example.com"));
-        BackupService blocklisted = new BackupService(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                identifier -> identifier.equals("bob@example.com"),
-                1);
+        BackupService blocklisted = BackupService.builder(
+                        accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore)
+                .blocklist(identifier -> identifier.equals("bob@example.com"))
+                .maxParallelProcesses(1)
+                .build();
 
         Optional<BackupSession> result = blocklisted.backup(BackupType.LDAP);
 
@@ -126,14 +124,11 @@ class BackupServiceTest {
     @Test
     void discoveredDomainOnBlocklistIsSkipped() throws IOException {
         accountDiscovery.wholeDirectory.put(LdapObjectType.DOMAIN, List.of("example.com", "blocked.example.com"));
-        BackupService blocklisted = new BackupService(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                identifier -> identifier.equals("blocked.example.com"),
-                1);
+        BackupService blocklisted = BackupService.builder(
+                        accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore)
+                .blocklist(identifier -> identifier.equals("blocked.example.com"))
+                .maxParallelProcesses(1)
+                .build();
 
         Optional<BackupSession> result = blocklisted.backup(BackupType.DOMAIN);
 
@@ -191,14 +186,11 @@ class BackupServiceTest {
         accountDiscovery.byDomain.put(
                 Map.entry(LdapObjectType.ACCOUNT, "example.com"),
                 List.of("alice@example.com", "bob@example.com"));
-        BackupService blocklisted = new BackupService(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                identifier -> identifier.equals("bob@example.com"),
-                1);
+        BackupService blocklisted = BackupService.builder(
+                        accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore)
+                .blocklist(identifier -> identifier.equals("bob@example.com"))
+                .maxParallelProcesses(1)
+                .build();
 
         Optional<BackupSession> result = blocklisted.backup(BackupType.LDAP, List.of(), "example.com");
 
@@ -210,8 +202,11 @@ class BackupServiceTest {
     @Test
     void backupIsSkippedEntirelyWhenEveryDiscoveredAccountIsBlocked() throws IOException {
         accountDiscovery.wholeDirectory.put(LdapObjectType.ACCOUNT, List.of("alice@example.com"));
-        BackupService blocklisted = new BackupService(
-                accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore, identifier -> true, 1);
+        BackupService blocklisted = BackupService.builder(
+                        accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore)
+                .blocklist(identifier -> true)
+                .maxParallelProcesses(1)
+                .build();
 
         Optional<BackupSession> result = blocklisted.backup(BackupType.LDAP);
 
@@ -224,16 +219,13 @@ class BackupServiceTest {
         accountDiscovery.wholeDirectory.put(LdapObjectType.ACCOUNT, List.of("alice@example.com", "bob@example.com"));
         metadataStore.recordAccountBackup(new BackupAccountRecord(
                 null, "ldap-earlier", "bob@example.com", "1B", Instant.now(), Instant.now()));
-        BackupService lockedBackup = new BackupService(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                identifier -> false,
-                new RecordingNotifier(),
-                1,
-                true);
+        BackupService lockedBackup = BackupService.builder(
+                        accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore)
+                .blocklist(identifier -> false)
+                .notifier(new RecordingNotifier())
+                .maxParallelProcesses(1)
+                .lockBackup(true)
+                .build();
 
         Optional<BackupSession> result = lockedBackup.backup(BackupType.LDAP);
 
@@ -252,16 +244,13 @@ class BackupServiceTest {
                 "1B",
                 Instant.now().minus(Duration.ofHours(30)),
                 Instant.now().minus(Duration.ofHours(30))));
-        BackupService lockedBackup = new BackupService(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                identifier -> false,
-                new RecordingNotifier(),
-                1,
-                true);
+        BackupService lockedBackup = BackupService.builder(
+                        accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore)
+                .blocklist(identifier -> false)
+                .notifier(new RecordingNotifier())
+                .maxParallelProcesses(1)
+                .lockBackup(true)
+                .build();
 
         Optional<BackupSession> result = lockedBackup.backup(BackupType.LDAP);
 
@@ -287,16 +276,13 @@ class BackupServiceTest {
     void explicitAccountBypassesLockBackup() throws IOException {
         metadataStore.recordAccountBackup(new BackupAccountRecord(
                 null, "ldap-earlier", "alice@example.com", "1B", Instant.now(), Instant.now()));
-        BackupService lockedBackup = new BackupService(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                identifier -> false,
-                new RecordingNotifier(),
-                1,
-                true);
+        BackupService lockedBackup = BackupService.builder(
+                        accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore)
+                .blocklist(identifier -> false)
+                .notifier(new RecordingNotifier())
+                .maxParallelProcesses(1)
+                .lockBackup(true)
+                .build();
 
         Optional<BackupSession> result = lockedBackup.backup(BackupType.LDAP, List.of("alice@example.com"));
 
@@ -306,14 +292,11 @@ class BackupServiceTest {
 
     @Test
     void explicitAccountBypassesBlocklist() throws IOException {
-        BackupService blocklisted = new BackupService(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                identifier -> true,
-                1);
+        BackupService blocklisted = BackupService.builder(
+                        accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore)
+                .blocklist(identifier -> true)
+                .maxParallelProcesses(1)
+                .build();
 
         Optional<BackupSession> result = blocklisted.backup(BackupType.LDAP, List.of("alice@example.com"));
 
@@ -358,8 +341,10 @@ class BackupServiceTest {
                 throw new UnsupportedOperationException();
             }
         };
-        BackupService parallelBackup = new BackupService(
-                accountDiscovery, trackingExporter, mailboxExporter, storageProvider, metadataStore, 2);
+        BackupService parallelBackup = BackupService.builder(
+                        accountDiscovery, trackingExporter, mailboxExporter, storageProvider, metadataStore)
+                .maxParallelProcesses(2)
+                .build();
 
         Optional<BackupSession> result = parallelBackup.backup(BackupType.LDAP);
 
@@ -372,15 +357,12 @@ class BackupServiceTest {
     @Test
     void notifiesBeginAndFinishForASession() throws IOException {
         RecordingNotifier notifier = new RecordingNotifier();
-        BackupService notified = new BackupService(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                identifier -> false,
-                notifier,
-                1);
+        BackupService notified = BackupService.builder(
+                        accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore)
+                .blocklist(identifier -> false)
+                .notifier(notifier)
+                .maxParallelProcesses(1)
+                .build();
 
         Optional<BackupSession> result = notified.backup(BackupType.LDAP, List.of("alice@example.com"));
 
@@ -395,15 +377,12 @@ class BackupServiceTest {
     @Test
     void doesNotNotifyWhenNothingToBackUp() throws IOException {
         RecordingNotifier notifier = new RecordingNotifier();
-        BackupService notified = new BackupService(
-                accountDiscovery,
-                ldapExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                identifier -> false,
-                notifier,
-                1);
+        BackupService notified = BackupService.builder(
+                        accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore)
+                .blocklist(identifier -> false)
+                .notifier(notifier)
+                .maxParallelProcesses(1)
+                .build();
 
         notified.backup(BackupType.SIGNATURE);
 
@@ -460,15 +439,12 @@ class BackupServiceTest {
                 throw new UnsupportedOperationException();
             }
         };
-        BackupService interrupted = new BackupService(
-                accountDiscovery,
-                interruptingExporter,
-                mailboxExporter,
-                storageProvider,
-                metadataStore,
-                identifier -> false,
-                notifier,
-                1);
+        BackupService interrupted = BackupService.builder(
+                        accountDiscovery, interruptingExporter, mailboxExporter, storageProvider, metadataStore)
+                .blocklist(identifier -> false)
+                .notifier(notifier)
+                .maxParallelProcesses(1)
+                .build();
 
         assertThrows(IOException.class, () -> interrupted.backup(BackupType.LDAP));
 

--- a/core/src/test/java/io/zmbackup/core/service/MigrationServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/MigrationServiceTest.java
@@ -1,6 +1,7 @@
 package io.zmbackup.core.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.zmbackup.core.domain.BackupAccountRecord;
@@ -96,6 +97,27 @@ class MigrationServiceTest {
         assertEquals(0, imported);
     }
 
+    @Test
+    void retryingAfterAPartialFailureDoesNotDuplicateAlreadyImportedAccounts() throws IOException {
+        List<String> lines = List.of(
+                "SESSION: full-20260101120000 started on Thu Jan  1 12:00:00 UTC 2026",
+                "full-20260101120000:alice@example.com:01/01/26",
+                "full-20260101120000:bob@example.com:01/01/26",
+                "SESSION: full-20260101120000 completed in Thu Jan  1 12:05:00 UTC 2026");
+
+        metadataStore.failNextRecordFor("bob@example.com");
+        assertThrows(IOException.class, () -> migrationService.importSessionsText(lines));
+        assertEquals(1, metadataStore.accounts.get("full-20260101120000").size());
+
+        int imported = migrationService.importSessionsText(lines);
+
+        assertEquals(1, imported);
+        List<BackupAccountRecord> accounts = metadataStore.accounts.get("full-20260101120000");
+        assertEquals(2, accounts.size());
+        assertEquals("alice@example.com", accounts.get(0).email());
+        assertEquals("bob@example.com", accounts.get(1).email());
+    }
+
     /** In-memory {@link StorageProvider} fake returning canned sizes, keyed like the real dir layout. */
     private static final class InMemoryStorageProvider implements StorageProvider {
         final Map<String, String> sessionSizes = new LinkedHashMap<>();
@@ -141,6 +163,12 @@ class MigrationServiceTest {
     private static final class InMemoryMetadataStore implements MetadataStore {
         final Map<String, BackupSession> sessions = new LinkedHashMap<>();
         final Map<String, List<BackupAccountRecord>> accounts = new LinkedHashMap<>();
+        private String failNextRecordForEmail;
+
+        /** Makes the next {@link #recordAccountBackup} for {@code email} throw, to simulate a mid-import failure. */
+        void failNextRecordFor(String email) {
+            failNextRecordForEmail = email;
+        }
 
         @Override
         public void save(BackupSession session) {
@@ -173,7 +201,11 @@ class MigrationServiceTest {
         }
 
         @Override
-        public void recordAccountBackup(BackupAccountRecord record) {
+        public void recordAccountBackup(BackupAccountRecord record) throws IOException {
+            if (record.email().equals(failNextRecordForEmail)) {
+                failNextRecordForEmail = null;
+                throw new IOException("simulated failure recording " + record.email());
+            }
             accounts.computeIfAbsent(record.sessionId(), key -> new ArrayList<>()).add(record);
         }
 

--- a/local/src/main/java/io/zmbackup/local/LocalStorageProvider.java
+++ b/local/src/main/java/io/zmbackup/local/LocalStorageProvider.java
@@ -48,15 +48,26 @@ public class LocalStorageProvider implements StorageProvider {
         Path sessionDir = sessionDir(sessionId);
         long totalBytes = 0;
         if (Files.isDirectory(sessionDir)) {
-            String prefix = account + ".";
             try (DirectoryStream<Path> entries =
-                    Files.newDirectoryStream(sessionDir, path -> path.getFileName().toString().startsWith(prefix))) {
+                    Files.newDirectoryStream(sessionDir, path -> isAccountFile(path, account))) {
                 for (Path entry : entries) {
                     totalBytes += Files.size(entry);
                 }
             }
         }
         return HumanReadableSize.format(totalBytes);
+    }
+
+    /**
+     * Whether {@code path}'s filename is {@code account + "." + suffix} for some dot-free
+     * {@code suffix} (e.g. {@code "tgz"}, {@code "ldiff"}) - a plain prefix match would also match
+     * an unrelated account whose address is itself a dot-extension of {@code account}, e.g.
+     * {@code alice@example.com.au.tgz} when looking up {@code alice@example.com}.
+     */
+    private static boolean isAccountFile(Path path, String account) {
+        String prefix = account + ".";
+        String fileName = path.getFileName().toString();
+        return fileName.startsWith(prefix) && fileName.indexOf('.', prefix.length()) < 0;
     }
 
     @Override

--- a/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
+++ b/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * JDBC-backed {@link MetadataStore} using SQLite, with DDL identical to the bash tool's
@@ -248,6 +249,10 @@ public class SqliteMetadataStore implements MetadataStore {
 
     @Override
     public Optional<Instant> lastSuccessfulBackupTime(String email) throws IOException {
+        List<String> mailboxPrefixes = BackupType.mailboxSessionPrefixes();
+        String prefixClause = mailboxPrefixes.stream()
+                .map(prefix -> "ba.sessionID like ?")
+                .collect(Collectors.joining(" or "));
         String sql =
                 """
                 select max(ba.conclusion_date) as last_backup
@@ -255,12 +260,17 @@ public class SqliteMetadataStore implements MetadataStore {
                 join backup_session bs on ba.sessionID = bs.sessionID
                 where ba.email = ?
                   and bs.status = ?
-                  and (ba.sessionID like 'full%' or ba.sessionID like 'inc%' or ba.sessionID like 'mbox%')
-                """;
+                  and (%s)
+                """
+                        .formatted(prefixClause);
         try (Connection connection = connect();
                 PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, email);
             statement.setString(2, SessionStatus.FINISHED.dbValue());
+            int paramIndex = 3;
+            for (String prefix : mailboxPrefixes) {
+                statement.setString(paramIndex++, prefix + "%");
+            }
             try (ResultSet rs = statement.executeQuery()) {
                 return rs.next() ? Optional.ofNullable(fromDb(rs.getString("last_backup"))) : Optional.empty();
             }

--- a/local/src/test/java/io/zmbackup/local/LocalStorageProviderTest.java
+++ b/local/src/test/java/io/zmbackup/local/LocalStorageProviderTest.java
@@ -91,6 +91,14 @@ class LocalStorageProviderTest {
     }
 
     @Test
+    void sizeOfAccountDoesNotCountAnUnrelatedAccountWhoseAddressExtendsIt() throws IOException {
+        write("session1", "alice@example.com", "ldiff", "a".repeat(1024));
+        write("session1", "alice@example.com.au", "tgz", "b".repeat(4096));
+
+        assertEquals("1K", provider.sizeOfAccount("session1", "alice@example.com"));
+    }
+
+    @Test
     void sizeOfAccountIsZeroWhenSessionDoesNotExist() throws IOException {
         assertEquals("0B", provider.sizeOfAccount("missing-session", "user@example.com"));
     }

--- a/local/src/test/java/io/zmbackup/local/PosixFileHardeningTest.java
+++ b/local/src/test/java/io/zmbackup/local/PosixFileHardeningTest.java
@@ -1,0 +1,117 @@
+package io.zmbackup.local;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Exercises {@link PosixFileHardening}, the sole guard against backup content, the metadata
+ * database, and log files being left world-readable by a permissive umask.
+ */
+class PosixFileHardeningTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void assumePosix() {
+        Assumptions.assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+    }
+
+    @Test
+    void createDirectoriesRestrictsEveryCreatedDirectoryToOwnerOnlyAccess() throws IOException {
+        Path nested = tempDir.resolve("a").resolve("b").resolve("c");
+
+        PosixFileHardening.createDirectories(nested);
+
+        assertEquals("rwx------", permissionsOf(nested));
+        assertEquals("rwx------", permissionsOf(tempDir.resolve("a").resolve("b")));
+        assertEquals("rwx------", permissionsOf(tempDir.resolve("a")));
+    }
+
+    @Test
+    void createDirectoriesIsANoopWhenDirectoryAlreadyExists() throws IOException {
+        Path dir = tempDir.resolve("existing");
+        PosixFileHardening.createDirectories(dir);
+
+        PosixFileHardening.createDirectories(dir);
+
+        assertEquals("rwx------", permissionsOf(dir));
+    }
+
+    @Test
+    void createFileCreatesAnEmptyOwnerOnlyFile() throws IOException {
+        Path file = tempDir.resolve("session.sqlite3");
+
+        PosixFileHardening.createFile(file);
+
+        assertTrue(Files.exists(file));
+        assertEquals(0, Files.size(file));
+        assertEquals("rw-------", permissionsOf(file));
+    }
+
+    @Test
+    void createFileFailsWhenFileAlreadyExists() throws IOException {
+        Path file = tempDir.resolve("session.sqlite3");
+        PosixFileHardening.createFile(file);
+
+        assertThrows(FileAlreadyExistsException.class, () -> PosixFileHardening.createFile(file));
+    }
+
+    @Test
+    void restrictExistingFileNarrowsPermissionsOnAFileCreatedWithoutHardening() throws IOException {
+        Path file = Files.createFile(tempDir.resolve("preexisting.db"));
+        Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-r--r--"));
+
+        PosixFileHardening.restrictExistingFile(file);
+
+        assertEquals("rw-------", permissionsOf(file));
+    }
+
+    @Test
+    void newRestrictedOutputStreamWritesContentAndRestrictsANewFile() throws IOException {
+        Path file = tempDir.resolve("alice@example.com.tgz");
+
+        try (OutputStream out = PosixFileHardening.newRestrictedOutputStream(
+                file, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+            out.write("content".getBytes(StandardCharsets.UTF_8));
+        }
+
+        assertEquals("content", Files.readString(file));
+        assertEquals("rw-------", permissionsOf(file));
+    }
+
+    @Test
+    void newRestrictedOutputStreamRestrictsAFileThatAlreadyExistedWithLooserPermissions() throws IOException {
+        Path file = Files.createFile(tempDir.resolve("alice@example.com.tgz"));
+        Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-r--r--"));
+
+        try (OutputStream out = PosixFileHardening.newRestrictedOutputStream(
+                file, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
+            out.write("new content".getBytes(StandardCharsets.UTF_8));
+        }
+
+        assertEquals("new content", Files.readString(file));
+        assertEquals("rw-------", permissionsOf(file));
+    }
+
+    private static String permissionsOf(Path path) throws IOException {
+        Set<java.nio.file.attribute.PosixFilePermission> permissions = Files.getPosixFilePermissions(path);
+        return PosixFilePermissions.toString(permissions);
+    }
+}

--- a/project/config/zmbackup.yaml
+++ b/project/config/zmbackup.yaml
@@ -24,10 +24,8 @@ zimbraLdap:
   trustAllCertificates: false
 
 zimbraMailbox:
-  # Zimbra service account used to start/stop the service and run zmmailbox.
+  # Zimbra service account used to start/stop the service.
   backupUser: {OSE_USER}
-  # Location of the zmmailbox binary.
-  zmmailboxPath: {OSE_INSTALL_DIR}/bin/zmmailbox
   # Whether to include disabled accounts. Optional, defaults to true.
   backupInactiveAccounts: true
   # Zimbra server's REST base URL, used to export mailbox content.
@@ -57,3 +55,9 @@ backup:
     recipient: {ZMBKP_MAIL_ALERT}
     # Address the report is sent from.
     sender: {ZMBKP_MAIL_SENDER}
+
+# Explicit opt-in required to start with a setting that sends credentials in cleartext or skips
+# certificate verification (sslEnabled: false, trustAllCertificates: true with no
+# caCertificatePath, or a non-https:// restBaseUrl). zmbackup refuses to start with such a
+# setting unless this is true. Optional, defaults to false.
+allowInsecure: false

--- a/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
@@ -4,6 +4,7 @@ import com.unboundid.ldap.sdk.Entry;
 import com.unboundid.ldap.sdk.ExtendedResult;
 import com.unboundid.ldap.sdk.Filter;
 import com.unboundid.ldap.sdk.LDAPConnection;
+import com.unboundid.ldap.sdk.LDAPConnectionOptions;
 import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldap.sdk.LDAPURL;
 import com.unboundid.ldap.sdk.ResultCode;
@@ -36,6 +37,23 @@ import javax.net.ssl.SSLContext;
  */
 public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporter {
 
+    /**
+     * How long {@link #connect} waits to establish the TCP connection before giving up. Without
+     * this, an unresponsive directory would hang the calling {@code Parallel.run} worker
+     * indefinitely, mirroring the timeout already applied to {@link
+     * io.zmbackup.local.EmailNotifier}'s SMTP connection for the same reason.
+     */
+    private static final long CONNECT_TIMEOUT_MILLIS = 30_000;
+
+    /**
+     * How long a single LDAP operation (bind, search, add, delete) is allowed to take once
+     * connected. Generous relative to {@link #CONNECT_TIMEOUT_MILLIS} since {@link
+     * #discover(LdapObjectType)} can legitimately take a while to enumerate every object across a
+     * large directory; the point is only to bound an otherwise-unbounded hang against a
+     * connected-but-unresponsive server.
+     */
+    private static final long RESPONSE_TIMEOUT_MILLIS = 600_000;
+
     private final String host;
     private final int port;
     private final String bindDn;
@@ -43,20 +61,24 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
     private final boolean startTls;
     private final String caCertificatePath;
     private final boolean trustAllCertificates;
+    private final boolean backupInactiveAccounts;
 
     /**
-     * @param url                   the LDAP server URL, e.g. {@code "ldap://127.0.0.1:389"}
-     * @param bindDn                the admin distinguished name used to bind
-     * @param bindPassword          the admin password used to bind
-     * @param startTls              whether to upgrade the connection with StartTLS before binding
-     * @param caCertificatePath     path to a PEM-encoded CA certificate (bundle) used to verify the server's
-     *                              certificate during StartTLS negotiation, or {@code null} to fall back to
-     *                              the JVM's default trust manager (or, if {@code trustAllCertificates} is
-     *                              set, to trusting any certificate)
-     * @param trustAllCertificates  whether to accept any server certificate during StartTLS negotiation when
-     *                              {@code caCertificatePath} is not set; must be explicitly enabled, e.g. for
-     *                              self-signed Zimbra certificates in dev/test environments, since it offers
-     *                              no protection against an active MITM attack
+     * @param url                     the LDAP server URL, e.g. {@code "ldap://127.0.0.1:389"}
+     * @param bindDn                  the admin distinguished name used to bind
+     * @param bindPassword            the admin password used to bind
+     * @param startTls                whether to upgrade the connection with StartTLS before binding
+     * @param caCertificatePath       path to a PEM-encoded CA certificate (bundle) used to verify the server's
+     *                                certificate during StartTLS negotiation, or {@code null} to fall back to
+     *                                the JVM's default trust manager (or, if {@code trustAllCertificates} is
+     *                                set, to trusting any certificate)
+     * @param trustAllCertificates    whether to accept any server certificate during StartTLS negotiation when
+     *                                {@code caCertificatePath} is not set; must be explicitly enabled, e.g. for
+     *                                self-signed Zimbra certificates in dev/test environments, since it offers
+     *                                no protection against an active MITM attack
+     * @param backupInactiveAccounts  whether {@link LdapObjectType#ACCOUNT} discovery includes disabled
+     *                                accounts, mirroring the bash tool's {@code BACKUP_INACTIVE_ACCOUNTS}:
+     *                                when {@code false}, discovery is narrowed to {@code zimbraAccountStatus=active}
      */
     public UnboundIdLdapAdapter(
             String url,
@@ -64,7 +86,8 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
             String bindPassword,
             boolean startTls,
             String caCertificatePath,
-            boolean trustAllCertificates) {
+            boolean trustAllCertificates,
+            boolean backupInactiveAccounts) {
         LDAPURL parsedUrl;
         try {
             parsedUrl = new LDAPURL(url);
@@ -78,6 +101,7 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
         this.startTls = startTls;
         this.caCertificatePath = caCertificatePath;
         this.trustAllCertificates = trustAllCertificates;
+        this.backupInactiveAccounts = backupInactiveAccounts;
     }
 
     /**
@@ -239,6 +263,20 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
         }
     }
 
+    /**
+     * {@code type}'s object filter, narrowed to active accounts only when {@code type} is
+     * {@link LdapObjectType#ACCOUNT} and {@link #backupInactiveAccounts} is disabled - mirroring
+     * the bash tool's {@code constant()}, which swaps {@code ACOBJECT} to {@code
+     * (&(objectclass=zimbraAccount)(zimbraAccountStatus=active))} when {@code
+     * BACKUP_INACTIVE_ACCOUNTS} is not {@code true}.
+     */
+    private String searchFilter(LdapObjectType type) {
+        if (type == LdapObjectType.ACCOUNT && !backupInactiveAccounts) {
+            return "(&" + type.objectFilter() + "(zimbraAccountStatus=active))";
+        }
+        return type.objectFilter();
+    }
+
     private static String domainBaseDn(String domain) {
         StringBuilder baseDn = new StringBuilder();
         for (String label : domain.split("\\.")) {
@@ -252,8 +290,8 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
 
     private List<String> search(String baseDn, LdapObjectType type) throws IOException {
         try (LDAPConnection connection = connect()) {
-            SearchRequest searchRequest = new SearchRequest(
-                    baseDn, SearchScope.SUB, type.objectFilter(), type.attributeName());
+            SearchRequest searchRequest =
+                    new SearchRequest(baseDn, SearchScope.SUB, searchFilter(type), type.attributeName());
             SearchResult searchResult = connection.search(searchRequest);
             List<String> values = new ArrayList<>();
             for (Entry entry : searchResult.getSearchEntries()) {
@@ -276,7 +314,10 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
     LDAPConnection connect() throws IOException {
         LDAPConnection connection = null;
         try {
-            connection = new LDAPConnection(host, port);
+            LDAPConnectionOptions options = new LDAPConnectionOptions();
+            options.setConnectTimeoutMillis((int) CONNECT_TIMEOUT_MILLIS);
+            options.setResponseTimeoutMillis(RESPONSE_TIMEOUT_MILLIS);
+            connection = new LDAPConnection(options, host, port);
             if (startTls) {
                 SSLContext sslContext = startTlsSslContext();
                 ExtendedResult startTlsResult =

--- a/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
@@ -12,6 +12,7 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -45,6 +46,22 @@ public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
     private static final Pattern ACCOUNT_PATTERN =
             Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
 
+    /**
+     * How long {@link #httpClient} waits to establish the TCP/TLS connection before giving up.
+     * Without this, a Zimbra host that accepts the connection but never responds would hang
+     * {@link #export}/{@link #restore} - and, since a single account's export/restore runs
+     * synchronously inside a {@code Parallel.run} worker, that worker - indefinitely.
+     */
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(30);
+
+    /**
+     * How long a single export/restore request is allowed to run end-to-end, once connected.
+     * Generous relative to {@link #CONNECT_TIMEOUT} since a mailbox archive can legitimately take
+     * a long time to transfer; the point is only to bound an otherwise-unbounded hang against a
+     * connected-but-unresponsive peer.
+     */
+    private static final Duration REQUEST_TIMEOUT = Duration.ofHours(6);
+
     private final URI baseUri;
     private final String adminUser;
     private final String adminPassword;
@@ -64,7 +81,10 @@ public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
         // WireMock (used in tests) and most Zimbra REST deployments only speak HTTP/1.1; pinning
         // the version avoids the client's default h2 upgrade attempt hitting an RST_STREAM/EOF on
         // unknown-length POST bodies (see restore()).
-        this.httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
+        this.httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(CONNECT_TIMEOUT)
+                .build();
     }
 
     /**
@@ -79,6 +99,7 @@ public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
     public boolean export(String account, OutputStream destination, Instant since) throws IOException {
         HttpRequest request = HttpRequest.newBuilder(exportUri(account, since))
                 .header("Authorization", basicAuthHeader())
+                .timeout(REQUEST_TIMEOUT)
                 .GET()
                 .build();
 
@@ -116,6 +137,7 @@ public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
     public void restore(String account, InputStream source) throws IOException {
         HttpRequest request = HttpRequest.newBuilder(restoreUri(account))
                 .header("Authorization", basicAuthHeader())
+                .timeout(REQUEST_TIMEOUT)
                 .POST(BodyPublishers.ofInputStream(() -> source))
                 .build();
 

--- a/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/UnboundIdLdapAdapterTest.java
@@ -61,7 +61,7 @@ class UnboundIdLdapAdapterTest {
     void connectsAndBindsWithoutStartTls() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         try (LDAPConnection connection = adapter.connect()) {
             assertTrue(connection.isConnected());
@@ -72,7 +72,7 @@ class UnboundIdLdapAdapterTest {
     void connectsAndBindsWithStartTlsWhenTrustAllCertificatesIsEnabled() throws Exception {
         directoryServer = startDirectoryServer(serverStartTlsSocketFactory());
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, true, null, true);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, true, null, true, true);
 
         try (LDAPConnection connection = adapter.connect()) {
             assertTrue(connection.isConnected());
@@ -88,7 +88,8 @@ class UnboundIdLdapAdapterTest {
                 BIND_PASSWORD,
                 true,
                 caCertificateFile.toString(),
-                false);
+                false,
+                true);
 
         try (LDAPConnection connection = adapter.connect()) {
             assertTrue(connection.isConnected());
@@ -99,7 +100,7 @@ class UnboundIdLdapAdapterTest {
     void startTlsRejectsUntrustedCertificateWhenNoTrustIsConfigured() throws Exception {
         directoryServer = startDirectoryServer(serverStartTlsSocketFactory());
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, true, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, true, null, false, true);
 
         assertThrows(IOException.class, adapter::connect);
     }
@@ -108,14 +109,14 @@ class UnboundIdLdapAdapterTest {
     void wrapsInvalidCredentialsInIOException() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, "wrong-password", false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, "wrong-password", false, null, false, true);
 
         assertThrows(IOException.class, adapter::connect);
     }
 
     @Test
     void wrapsUnreachableServerInIOException() {
-        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false, null, false);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         assertThrows(IOException.class, adapter::connect);
     }
@@ -124,7 +125,7 @@ class UnboundIdLdapAdapterTest {
     void rejectsInvalidUrl() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> new UnboundIdLdapAdapter("not-a-url", BIND_DN, BIND_PASSWORD, false, null, false));
+                () -> new UnboundIdLdapAdapter("not-a-url", BIND_DN, BIND_PASSWORD, false, null, false, true));
     }
 
     @Test
@@ -146,7 +147,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("cn", "engineering"),
                 new Attribute("mail", "engineering@example.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         List<String> accounts = adapter.discover(LdapObjectType.ACCOUNT);
 
@@ -154,10 +155,34 @@ class UnboundIdLdapAdapterTest {
     }
 
     @Test
+    void discoverExcludesInactiveAccountsWhenBackupInactiveAccountsIsDisabled() throws Exception {
+        directoryServer = startDirectoryServer(null);
+        directoryServer.add(
+                "uid=alice,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "alice"),
+                new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
+                new Attribute("zimbraAccountStatus", "active"));
+        directoryServer.add(
+                "uid=bob,dc=example,dc=com",
+                new Attribute("objectClass", "zimbraAccount"),
+                new Attribute("uid", "bob"),
+                new Attribute("zimbraMailDeliveryAddress", "bob@example.com"),
+                new Attribute("zimbraAccountStatus", "closed"));
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false,
+                false);
+
+        List<String> accounts = adapter.discover(LdapObjectType.ACCOUNT);
+
+        assertEquals(List.of("alice@example.com"), accounts);
+    }
+
+    @Test
     void discoverReturnsEmptyListWhenNoEntriesMatch() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         assertEquals(List.of(), adapter.discover(LdapObjectType.ACCOUNT));
     }
@@ -178,7 +203,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("uid", "carol"),
                 new Attribute("zimbraMailDeliveryAddress", "carol@other.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         List<String> accounts = adapter.discoverForDomain(LdapObjectType.ACCOUNT, "example.com");
 
@@ -189,7 +214,7 @@ class UnboundIdLdapAdapterTest {
     void discoverForDomainReturnsEmptyListWhenDomainHasNoMatches() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         assertEquals(List.of(), adapter.discoverForDomain(LdapObjectType.ACCOUNT, "example.com"));
     }
@@ -198,7 +223,7 @@ class UnboundIdLdapAdapterTest {
     void discoverForDomainWrapsUnknownBaseDnInIOException() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         assertThrows(IOException.class, () -> adapter.discoverForDomain(LdapObjectType.ACCOUNT, "nowhere.invalid"));
     }
@@ -217,7 +242,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("uid", "alice"),
                 new Attribute("zimbraMailDeliveryAddress", "alice@example.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         List<String> domains = adapter.listDomains();
 
@@ -228,7 +253,7 @@ class UnboundIdLdapAdapterTest {
     void listDomainsReturnsEmptyListWhenNoDomainsMatch() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         assertEquals(List.of(), adapter.listDomains());
     }
@@ -243,7 +268,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("zimbraMailDeliveryAddress", "alice@example.com"),
                 new Attribute("mail", "alice@example.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         ByteArrayOutputStream destination = new ByteArrayOutputStream();
         adapter.export("alice@example.com", LdapObjectType.ACCOUNT, destination);
@@ -262,7 +287,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("cn", "engineering"),
                 new Attribute("uid", "engineering@example.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         ByteArrayOutputStream destination = new ByteArrayOutputStream();
         adapter.export("engineering@example.com", LdapObjectType.DISTRIBUTION_LIST, destination);
@@ -274,7 +299,7 @@ class UnboundIdLdapAdapterTest {
     void exportWritesNothingWhenNoEntryMatches() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         ByteArrayOutputStream destination = new ByteArrayOutputStream();
         adapter.export("nobody@example.com", LdapObjectType.ACCOUNT, destination);
@@ -286,7 +311,7 @@ class UnboundIdLdapAdapterTest {
     void exportRejectsDomainObjectType() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         assertThrows(
                 UnsupportedOperationException.class,
@@ -295,7 +320,7 @@ class UnboundIdLdapAdapterTest {
 
     @Test
     void exportWrapsUnreachableServerInIOException() {
-        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false, null, false);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         assertThrows(
                 IOException.class,
@@ -311,7 +336,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("dc", "other"),
                 new Attribute("zimbraDomainName", "other.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         ByteArrayOutputStream destination = new ByteArrayOutputStream();
         adapter.exportDomain("other.com", destination);
@@ -325,14 +350,14 @@ class UnboundIdLdapAdapterTest {
     void exportDomainWrapsUnknownDomainInIOException() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         assertThrows(IOException.class, () -> adapter.exportDomain("nowhere.invalid", new ByteArrayOutputStream()));
     }
 
     @Test
     void exportDomainWrapsUnreachableServerInIOException() {
-        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false, null, false);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         assertThrows(
                 IOException.class, () -> adapter.exportDomain("example.com", new ByteArrayOutputStream()));
@@ -349,7 +374,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("mail", "alice@example.com"),
                 new Attribute("description", "stale"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
         String ldif =
                 "dn: uid=alice,dc=example,dc=com\n"
                         + "objectClass: zimbraAccount\n"
@@ -368,7 +393,7 @@ class UnboundIdLdapAdapterTest {
     void restoreAddsEntryThatDidNotPreviouslyExist() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
         String ldif =
                 "dn: uid=alice,dc=example,dc=com\n"
                         + "objectClass: zimbraAccount\n"
@@ -385,7 +410,7 @@ class UnboundIdLdapAdapterTest {
     void restoreThrowsIOExceptionWhenLdifHasNoEntry() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
 
         assertThrows(
                 IOException.class,
@@ -396,7 +421,7 @@ class UnboundIdLdapAdapterTest {
     void restoreDomainAddsEntryThatDidNotPreviouslyExist() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
         String ldif =
                 "dn: dc=other,dc=com\n"
                         + "objectClass: zimbraDomain\n"
@@ -418,7 +443,7 @@ class UnboundIdLdapAdapterTest {
                 new Attribute("dc", "other"),
                 new Attribute("zimbraDomainName", "other.com"));
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
         String ldif =
                 "dn: dc=other,dc=com\n"
                         + "objectClass: zimbraDomain\n"
@@ -432,7 +457,7 @@ class UnboundIdLdapAdapterTest {
     void restoreDomainThrowsIOExceptionOnOtherFailures() throws Exception {
         directoryServer = startDirectoryServer(null);
         UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter(
-                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false);
+                "ldap://127.0.0.1:" + directoryServer.getListenPort(), BIND_DN, BIND_PASSWORD, false, null, false, true);
         String ldif = "dn: dc=other,dc=nowhere,dc=missing\nobjectClass: zimbraDomain\ndc: other\n";
 
         assertThrows(
@@ -442,7 +467,7 @@ class UnboundIdLdapAdapterTest {
 
     @Test
     void restoreWrapsUnreachableServerInIOException() {
-        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false, null, false);
+        UnboundIdLdapAdapter adapter = new UnboundIdLdapAdapter("ldap://127.0.0.1:1", BIND_DN, BIND_PASSWORD, false, null, false, true);
         String ldif = "dn: uid=alice,dc=example,dc=com\nobjectClass: zimbraAccount\nuid: alice\n";
 
         assertThrows(


### PR DESCRIPTION
## Summary

This addresses 13 findings from a full read-through of `core`, `local`, `zimbra`, and `app`.

**Correctness / security**
- `LocalStorageProvider.sizeOfAccount` matched files by raw string prefix, so `alice@example.com` would also pick up files belonging to `alice@example.com.au`. Now matches the exact account segment.
- `MigrationService.importSessionsText` wasn't safe to retry after a partial failure — `recordAccountBackup` has no unique key, so a retry could duplicate `backup_account` rows. It now skips accounts a previous run already recorded for the session.
- `zimbraMailbox.backupInactiveAccounts` was parsed and validated but never consumed anywhere. It's now wired into LDAP account discovery, narrowing the search to `zimbraAccountStatus=active` when disabled.
- Neither the LDAP connection nor the mailbox REST client set a connect/response timeout, unlike `EmailNotifier`. An unresponsive server could hang a `Parallel.run` worker (and eventually the whole session) forever. Both now have timeouts.
- Insecure settings (`sslEnabled=false`, `trustAllCertificates=true` with no CA cert, non-`https://` REST URL) previously only logged a warning and proceeded. `AppContext` now refuses to start unless a new `allowInsecure: true` config field explicitly opts in.

**Design / cleanup**
- The incremental-cutoff SQL hardcoded `'full%'/'inc%'/'mbox%'` session-ID prefixes; now derived from `BackupType.mailboxSessionPrefixes()`.
- `BackupService` had five telescoping constructors (up to 9 params); replaced with a `BackupService.builder(...)` and all call sites migrated.
- Removed `zmmailboxPath`, a required config field nothing reads now that mailbox export goes through the REST exporter.
- Clarified the `finally`-block `shutdown()` call in `Parallel.run` that runs after `shutdownNow()` already ran on the interrupted path.
- Centralized the `--into`/session-prefix validation duplicated across `RestoreCommand` and `RestoreMailboxCommand` into `CliValidation`.

**Testing**
- Added tests for `PosixFileHardening` (previously untested despite being the only guard against world-readable backup content), `AppConfig`, `BackupConfig`, and `EmailNotifyConfig`.
- Added a regression test for the migration idempotency fix.

## Test plan
- [x] `./gradlew build` — full build (compile + all unit/integration tests) passes across every module (`core`, `local`, `zimbra`, `app`)
- [x] New/updated tests cover each fix (account-size matching, migration retry, active-only LDAP filter, insecure-config refusal, `BackupType.mailboxSessionPrefixes()`, `PosixFileHardening`, config record validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYaP5N1p6HARpB3AmapL3y

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYaP5N1p6HARpB3AmapL3y)_