### PR TITLE
Add static analysis, coverage, dependency tooling, and fix a restore exit-code bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Run Java tests
-          command: ./gradlew test
+          name: Run Java tests and static analysis
+          command: ./gradlew check
       - run:
           name: Collect JUnit test results
           command: |
@@ -38,9 +38,51 @@ jobs:
           path: ~/test-results/junit
       - store_artifacts:
           path: ~/test-results/junit
+      - run:
+          name: Collect JaCoCo coverage reports
+          command: |
+            mkdir -p ~/reports/jacoco
+            for html_dir in */build/reports/jacoco/test/html; do
+              [ -d "$html_dir" ] || continue
+              module="${html_dir%%/build/*}"
+              mkdir -p ~/reports/jacoco/"$module"
+              cp -R "$html_dir"/. ~/reports/jacoco/"$module"/
+            done
+          when: always
+      - store_artifacts:
+          path: ~/reports/jacoco
+      - run:
+          name: Collect SpotBugs reports
+          command: |
+            mkdir -p ~/reports/spotbugs
+            for report_dir in */build/reports/spotbugs; do
+              [ -d "$report_dir" ] || continue
+              module="${report_dir%%/build/*}"
+              mkdir -p ~/reports/spotbugs/"$module"
+              cp -R "$report_dir"/. ~/reports/spotbugs/"$module"/
+            done
+          when: always
+      - store_artifacts:
+          path: ~/reports/spotbugs
+
+  shellcheck:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - run:
+          name: Install ShellCheck
+          command: sudo apt-get update -qq && sudo apt-get install -y shellcheck
+      - run:
+          name: Run ShellCheck on the bash tool's entrypoints
+          command: |
+            shellcheck -x --check-sourced -P project project/zmbackup
+            shellcheck -x --check-sourced install.sh
+            shellcheck -x --check-sourced install-java.sh
 
 workflows:
   test-workflow:
     jobs:
       - test
       - test-java
+      - shellcheck

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gradle-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -257,7 +257,9 @@ The installer script automatically creates a cron config file in `/etc/cron.d/zm
 
 ## Want to contribute to the project?
 
-- Please help us contributing the Waddles project instead - Zmbackup will be deprecated and the only thing we will do here will be bugfixes.
+The bash tool (1.2.x) is in maintenance mode - it only receives bugfixes now. All new
+development happens on the Java rewrite (2.0, see [Installation (Java version)](#installation-java-version)
+above), which has full feature parity with the bash tool. Please target contributions there.
 
 ## License
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,22 +1,22 @@
 plugins {
-    id("com.gradleup.shadow") version "8.3.6"
+    alias(libs.plugins.shadow)
 }
 
 dependencies {
     implementation(project(":core"))
     implementation(project(":zimbra"))
     implementation(project(":local"))
-    implementation("org.yaml:snakeyaml:2.6")
-    implementation("info.picocli:picocli:4.7.6")
+    implementation(libs.snakeyaml)
+    implementation(libs.picocli)
     // The standard SLF4J/Logback logging stack, fed by core's java.util.logging calls through the
     // jul-to-slf4j bridge (core stays dependency-free; see core/build.gradle.kts).
-    implementation("ch.qos.logback:logback-classic:1.5.16")
-    implementation("org.slf4j:jul-to-slf4j:2.0.16")
-    testImplementation("com.unboundid:unboundid-ldapsdk:7.0.5")
-    testImplementation("org.wiremock:wiremock:3.13.1")
-    testImplementation("io.cucumber:cucumber-java:7.34.7")
-    testImplementation("io.cucumber:cucumber-junit-platform-engine:7.34.7")
-    testImplementation("org.junit.platform:junit-platform-suite:1.11.4")
+    implementation(libs.logback.classic)
+    implementation(libs.slf4j.jul.to.slf4j)
+    testImplementation(libs.unboundid.ldapsdk)
+    testImplementation(libs.wiremock)
+    testImplementation(libs.cucumber.java)
+    testImplementation(libs.cucumber.junit.platform.engine)
+    testImplementation(libs.junit.platform.suite)
 }
 
 // Bundle the repo-root VERSION file into the jar so VersionProvider can read it at runtime,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,13 @@
+import com.github.spotbugs.snom.Confidence
+import com.github.spotbugs.snom.Effort
+import com.github.spotbugs.snom.SpotBugsExtension
+import com.github.spotbugs.snom.SpotBugsTask
+import org.gradle.api.artifacts.VersionCatalogsExtension
+
+plugins {
+    alias(libs.plugins.spotbugs) apply false
+}
+
 allprojects {
     group = "io.zmbackup"
     version = file(rootDir.resolve("VERSION")).readText().trim()
@@ -5,6 +15,12 @@ allprojects {
 
 subprojects {
     apply(plugin = "java")
+    apply(plugin = "jacoco")
+    apply(plugin = "com.github.spotbugs")
+
+    // The `libs` type-safe accessor is only generated for a project's own build script; this
+    // block configures every *other* subproject, so the catalog is looked up explicitly instead.
+    val libs = rootProject.extensions.getByType<VersionCatalogsExtension>().named("libs")
 
     configure<JavaPluginExtension> {
         toolchain {
@@ -17,12 +33,45 @@ subprojects {
     }
 
     dependencies {
-        "testImplementation"(platform("org.junit:junit-bom:5.11.4"))
-        "testImplementation"("org.junit.jupiter:junit-jupiter")
-        "testRuntimeOnly"("org.junit.platform:junit-platform-launcher")
+        "testImplementation"(platform(libs.findLibrary("junit-bom").get()))
+        "testImplementation"(libs.findLibrary("junit-jupiter").get())
+        "testRuntimeOnly"(libs.findLibrary("junit-platform-launcher").get())
+        "compileOnly"(libs.findLibrary("spotbugs-annotations").get())
+        "testCompileOnly"(libs.findLibrary("spotbugs-annotations").get())
     }
 
     tasks.withType<Test> {
         useJUnitPlatform()
+        finalizedBy(tasks.named("jacocoTestReport"))
     }
+
+    configure<JacocoPluginExtension> {
+        toolVersion = "0.8.12"
+    }
+
+    tasks.named<JacocoReport>("jacocoTestReport") {
+        dependsOn(tasks.named("test"))
+        reports {
+            xml.required.set(true)
+            html.required.set(true)
+        }
+    }
+
+    // Effort/reportLevel tuned for signal over noise: MAX effort catches more, but only findings
+    // at MEDIUM confidence or higher are reported so `check` doesn't fail on speculative low-
+    // confidence guesses.
+    configure<SpotBugsExtension> {
+        effort.set(Effort.MAX)
+        reportLevel.set(Confidence.MEDIUM)
+        excludeFilter.set(rootProject.file("gradle/spotbugs-exclude.xml"))
+    }
+
+    tasks.withType<SpotBugsTask>().configureEach {
+        reports.create("html") { required.set(true) }
+        reports.create("xml") { required.set(true) }
+    }
+
+    // Gate production code only - test sources are mocks/fixtures/assertions, not a place where
+    // SpotBugs' bug patterns (null derefs, resource leaks, etc.) carry the same weight.
+    tasks.named("spotbugsTest") { enabled = false }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,36 @@
+[versions]
+junit = "5.11.4"
+junit-platform = "1.11.4"
+unboundid-ldapsdk = "7.0.5"
+wiremock = "3.13.1"
+snakeyaml = "2.6"
+picocli = "4.7.6"
+logback = "1.5.16"
+slf4j = "2.0.16"
+sqlite-jdbc = "3.49.1.0"
+cucumber = "7.34.7"
+shadow = "8.3.6"
+foojay-resolver = "1.0.0"
+spotbugs-plugin = "6.0.26"
+spotbugs-annotations = "4.8.6"
+
+[libraries]
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+junit-platform-suite = { module = "org.junit.platform:junit-platform-suite", version.ref = "junit-platform" }
+unboundid-ldapsdk = { module = "com.unboundid:unboundid-ldapsdk", version.ref = "unboundid-ldapsdk" }
+wiremock = { module = "org.wiremock:wiremock", version.ref = "wiremock" }
+snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
+picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+slf4j-jul-to-slf4j = { module = "org.slf4j:jul-to-slf4j", version.ref = "slf4j" }
+sqlite-jdbc = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite-jdbc" }
+cucumber-java = { module = "io.cucumber:cucumber-java", version.ref = "cucumber" }
+cucumber-junit-platform-engine = { module = "io.cucumber:cucumber-junit-platform-engine", version.ref = "cucumber" }
+spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugs-annotations" }
+
+[plugins]
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
+foojay-resolver-convention = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojay-resolver" }
+spotbugs = { id = "com.github.spotbugs", version.ref = "spotbugs-plugin" }

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Findings excluded here were reviewed and judged not to be bugs for this codebase - each entry
+  says why. Everything else SpotBugs reports at MEDIUM+ confidence is expected to fail the build.
+-->
+<FindBugsFilter>
+
+  <!--
+    This codebase deliberately validates constructor arguments and throws (e.g. Objects.requireNonNull
+    in BackupService, port adapters, SqliteMetadataStore) to fail fast on misconfiguration. None of
+    the flagged classes override finalize() (finalizers are deprecated for removal since Java 18),
+    so the "finalizer attack" this check guards against does not apply.
+  -->
+  <Match>
+    <Bug pattern="CT_CONSTRUCTOR_THROW"/>
+  </Match>
+
+  <!--
+    AppContext is the app's composition root: its accessors intentionally hand out the shared
+    service/port instances (MetadataStore, StorageProvider, SessionService, HousekeepService) it
+    wires up once at startup. They are stateless collaborators, not mutable data to defensively
+    copy - exposing them is the whole point of the class.
+  -->
+  <Match>
+    <Class name="io.zmbackup.app.AppContext"/>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+  </Match>
+
+  <!--
+    Flags String.formatted()/String.format() calls whose format string embeds a literal "\n"
+    instead of "%n". That distinction matters for user-facing text, not for programmatically
+    composed SQL (SqliteMetadataStore's multi-line text-block queries): SQL needs a plain '\n',
+    and swapping in %n would risk injecting a platform-specific "\r\n" into the statement instead.
+  -->
+  <Match>
+    <Class name="io.zmbackup.local.SqliteMetadataStore"/>
+    <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE"/>
+  </Match>
+
+</FindBugsFilter>

--- a/installScript/deploy.sh
+++ b/installScript/deploy.sh
@@ -136,6 +136,7 @@ function deploy_upgrade(){
 ################################################################################
 function uninstall() {
   echo "Removing... Please wait while we made some changes."
+  # shellcheck disable=SC1091  # install-time config path, not resolvable statically
   source "$ZMBKP_CONF"/zmbackup.conf
   echo -ne '                     (0%)\r'
   rm -rf "$ZMBKP_SHARE" "$ZMBKP_SRC"/zmbhousekeep > /dev/null 2>&1

--- a/installScript/vars.sh
+++ b/installScript/vars.sh
@@ -3,16 +3,18 @@
 # SET INTERNAL VARIABLE
 ################################################################################
 
-# Exit codes
+# Exit codes - a documented namespace of error codes; not every one is currently thrown.
 ERR_OK="0"  		         # No error (normal exit)
+# shellcheck disable=SC2034  # reserved, not thrown yet
 ERR_NOBKPDIR="1"  	     # No backup directory could be found
 ERR_NOROOT="2"  		     # Running without root privileges
 ERR_DEPNOTFOUND="3"  	   # Missing dependency
 ERR_NO_CONNECTION="4"    # Missing connection to install packages
+# shellcheck disable=SC2034  # reserved, not thrown yet
 ERR_CREATE_USER="5"      # Can't create the user for some reason
 
 # ZMBACKUP INSTALLATION PATH
-MYDIR=`dirname $0`                       # The directory where the install script is
+MYDIR=$(dirname "$0")                    # The directory where the install script is
 ZMBKP_SRC="/usr/local/bin"               # The main script stay here
 ZMBKP_CONF="/etc/zmbackup"               # The config/blocked list directory
 ZMBKP_SHARE="/usr/local/share/zmbackup"  # Keep for upgrade routine
@@ -22,11 +24,10 @@ ZMBKP_LIB="/usr/local/lib/zmbackup"      # The new path for the libs
 OSE_USER="zimbra"                                                                                                                              # Zimbra's unix user
 OSE_INSTALL_DIR="/opt/zimbra"                                                                                                                  # The Zimbra's installation path
 OSE_DEFAULT_BKP_DIR="/opt/zimbra/backup"                                                                                                       # Where you will store your backup
-OSE_INSTALL_DOMAIN=`su -s /bin/bash -c "$OSE_INSTALL_DIR/bin/zmprov gad | head -1" $OSE_USER`                                                  # Zimbra's Domain
-OSE_INSTALL_HOSTNAME=`hostname --fqdn`
-OSE_INSTALL_PORT=`cat /opt/zimbra/conf/zmztozmig.conf | grep SourceAdminPort | cut -d"=" -f2`
-OSE_INSTALL_ADDRESS=`ping -c1 $OSE_INSTALL_HOSTNAME | head -1 | cut -d" " -f3|sed 's#(##g'|sed 's#)##g'`                                                                   # Zimbra's Server Address
-OSE_INSTALL_LDAPPASS=`su -s /bin/bash -c "$OSE_INSTALL_DIR/bin/zmlocalconfig -s zimbra_ldap_password" $OSE_USER |awk '{print $3}'`             # Zimbra's LDAP Password
+OSE_INSTALL_DOMAIN=$(su -s /bin/bash -c "$OSE_INSTALL_DIR/bin/zmprov gad | head -1" "$OSE_USER")                                               # Zimbra's Domain
+OSE_INSTALL_HOSTNAME=$(hostname --fqdn)
+OSE_INSTALL_ADDRESS=$(ping -c1 "$OSE_INSTALL_HOSTNAME" | head -1 | cut -d" " -f3|sed 's#(##g'|sed 's#)##g')                                                                   # Zimbra's Server Address
+OSE_INSTALL_LDAPPASS=$(su -s /bin/bash -c "$OSE_INSTALL_DIR/bin/zmlocalconfig -s zimbra_ldap_password" "$OSE_USER" |awk '{print $3}')          # Zimbra's LDAP Password
 ZMBKP_MAIL_ALERT="admin@"$OSE_INSTALL_DOMAIN                                                                                                   # Zmbackup's mail alert account
 MAX_PARALLEL_PROCESS="3"                                                                                                                       # Zmbackup's number of threads
 ROTATE_TIME="30"                                                                                                                               # Zmbackup's max of days before housekeeper

--- a/installScriptJava/vars.sh
+++ b/installScriptJava/vars.sh
@@ -7,13 +7,14 @@
 ERR_OK="0"                  # No error (normal exit)
 ERR_NOROOT="2"               # Running without root privileges
 ERR_DEPNOTFOUND="3"          # Missing dependency
+# shellcheck disable=SC2034  # reserved, not thrown yet
 ERR_NO_CONNECTION="4"        # Missing connection to install packages
 ERR_BUILD_FAILED="6"         # Gradle build of the jar failed
 
 # JAVA ZMBACKUP INSTALLATION PATH
 # These match the paths already hard coded in app/src/main/scripts/zmbackup (the thin
 # launcher) and YamlConfigLoader.DEFAULT_CONFIG_PATH - they are not free to change here.
-MYDIR=`dirname $0`                       # The directory where the install script is
+MYDIR=$(dirname "$0")                    # The directory where the install script is
 ZMBKP_SRC="/usr/local/bin"               # The thin "zmbackup" launcher goes here
 ZMBKP_CONF="/etc/zmbackup"               # The zmbackup.yaml/blockedlist directory
 ZMBKP_LIB="/usr/local/lib/zmbackup"      # Where zmbackup.jar is installed
@@ -27,10 +28,10 @@ JAVA_MIN_VERSION="21"
 OSE_USER="zimbra"                                                                                                                              # Zimbra's unix user
 OSE_INSTALL_DIR="/opt/zimbra"                                                                                                                  # The Zimbra's installation path
 OSE_DEFAULT_BKP_DIR="/opt/zimbra/backup"                                                                                                       # Where you will store your backup
-OSE_INSTALL_DOMAIN=`su -s /bin/bash -c "$OSE_INSTALL_DIR/bin/zmprov gad | head -1" $OSE_USER`                                                  # Zimbra's Domain
-OSE_INSTALL_HOSTNAME=`hostname --fqdn`
-OSE_INSTALL_ADDRESS=`ping -c1 $OSE_INSTALL_HOSTNAME | head -1 | cut -d" " -f3|sed 's#(##g'|sed 's#)##g'`                                                                   # Zimbra's Server Address
-OSE_INSTALL_LDAPPASS=`su -s /bin/bash -c "$OSE_INSTALL_DIR/bin/zmlocalconfig -s zimbra_ldap_password" $OSE_USER |awk '{print $3}'`             # Zimbra's LDAP/admin Password
+OSE_INSTALL_DOMAIN=$(su -s /bin/bash -c "$OSE_INSTALL_DIR/bin/zmprov gad | head -1" "$OSE_USER")                                               # Zimbra's Domain
+OSE_INSTALL_HOSTNAME=$(hostname --fqdn)
+OSE_INSTALL_ADDRESS=$(ping -c1 "$OSE_INSTALL_HOSTNAME" | head -1 | cut -d" " -f3|sed 's#(##g'|sed 's#)##g')                                                                   # Zimbra's Server Address
+OSE_INSTALL_LDAPPASS=$(su -s /bin/bash -c "$OSE_INSTALL_DIR/bin/zmlocalconfig -s zimbra_ldap_password" "$OSE_USER" |awk '{print $3}')          # Zimbra's LDAP/admin Password
 ZMBKP_MAIL_ALERT="admin@"$OSE_INSTALL_DOMAIN                                                                                                   # Zmbackup's mail alert recipient
 ZMBKP_MAIL_SENDER="root@"$OSE_INSTALL_DOMAIN                                                                                                   # Zmbackup's mail alert sender
 MAX_PARALLEL_PROCESS="3"                                                                                                                       # Zmbackup's number of parallel workers

--- a/local/build.gradle.kts
+++ b/local/build.gradle.kts
@@ -1,4 +1,4 @@
 dependencies {
     implementation(project(":core"))
-    implementation("org.xerial:sqlite-jdbc:3.49.1.0")
+    implementation(libs.sqlite.jdbc)
 }

--- a/local/src/main/java/io/zmbackup/local/HumanReadableSize.java
+++ b/local/src/main/java/io/zmbackup/local/HumanReadableSize.java
@@ -24,10 +24,10 @@ final class HumanReadableSize {
             value /= 1024;
             unitIndex++;
         }
-        double rounded = Math.round(value * 10) / 10.0;
-        if (rounded == Math.floor(rounded)) {
-            return (long) rounded + UNITS[unitIndex];
+        long tenths = Math.round(value * 10);
+        if (tenths % 10 == 0) {
+            return (tenths / 10) + UNITS[unitIndex];
         }
-        return rounded + UNITS[unitIndex];
+        return (tenths / 10.0) + UNITS[unitIndex];
     }
 }

--- a/local/src/main/java/io/zmbackup/local/LocalStorageProvider.java
+++ b/local/src/main/java/io/zmbackup/local/LocalStorageProvider.java
@@ -11,6 +11,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.FileVisitResult;
+import java.util.Objects;
 
 /**
  * Filesystem-backed {@link StorageProvider} storing content under
@@ -28,7 +29,8 @@ public class LocalStorageProvider implements StorageProvider {
     @Override
     public OutputStream openWrite(String sessionId, String account, String suffix) throws IOException {
         Path file = accountFile(sessionId, account, suffix);
-        PosixFileHardening.createDirectories(file.getParent());
+        Path parent = Objects.requireNonNull(file.getParent(), "accountFile always resolves within a parent directory");
+        PosixFileHardening.createDirectories(parent);
         return PosixFileHardening.newRestrictedOutputStream(
                 file, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
     }
@@ -66,7 +68,9 @@ public class LocalStorageProvider implements StorageProvider {
      */
     private static boolean isAccountFile(Path path, String account) {
         String prefix = account + ".";
-        String fileName = path.getFileName().toString();
+        String fileName =
+                Objects.requireNonNull(path.getFileName(), "directory stream entries always have a file name")
+                        .toString();
         return fileName.startsWith(prefix) && fileName.indexOf('.', prefix.length()) < 0;
     }
 

--- a/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
+++ b/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
@@ -5,6 +5,7 @@ import io.zmbackup.core.domain.BackupSession;
 import io.zmbackup.core.domain.BackupType;
 import io.zmbackup.core.domain.SessionStatus;
 import io.zmbackup.core.port.MetadataStore;
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -18,13 +19,26 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 /**
  * JDBC-backed {@link MetadataStore} using SQLite, with DDL identical to the bash tool's
  * {@code sessions.sqlite3} schema so existing backup databases remain readable.
+ *
+ * <p>Holds a single JDBC connection for the process's lifetime rather than opening and closing
+ * one per call: backup and restore sessions run accounts through a thread pool (see {@link
+ * io.zmbackup.core.service.Parallel}), so a fresh connection per call meant many short-lived
+ * connections all contending for SQLite's single-writer file lock. All access is serialized
+ * through {@link #lock} instead, since a JDBC {@link Connection} isn't safe for concurrent use
+ * from multiple threads.
+ *
+ * <p>Implements {@link Closeable} for tests (e.g. against a shared-cache in-memory database,
+ * which is only destroyed once its last connection closes); the CLI itself is a short-lived
+ * process and relies on the JVM closing the connection at exit rather than calling {@link
+ * #close()} itself.
  */
-public class SqliteMetadataStore implements MetadataStore {
+public class SqliteMetadataStore implements MetadataStore, Closeable {
 
     private static final String CREATE_BACKUP_SESSION =
             """
@@ -57,17 +71,19 @@ public class SqliteMetadataStore implements MetadataStore {
      */
     private static final String SQLITE_URI_PREFIX = "file:";
 
-    private final String jdbcUrl;
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Connection connection;
 
     public SqliteMetadataStore(Path databaseFile) throws IOException {
-        this.jdbcUrl = "jdbc:sqlite:" + databaseFile;
         if (!databaseFile.toString().startsWith(SQLITE_URI_PREFIX)) {
             hardenDatabaseFile(databaseFile);
         }
-        try (Connection connection = connect();
-                Statement statement = connection.createStatement()) {
-            statement.execute(CREATE_BACKUP_SESSION);
-            statement.execute(CREATE_BACKUP_ACCOUNT);
+        try {
+            this.connection = openConnection("jdbc:sqlite:" + databaseFile);
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(CREATE_BACKUP_SESSION);
+                statement.execute(CREATE_BACKUP_ACCOUNT);
+            }
         } catch (SQLException e) {
             throw new IOException(e);
         }
@@ -97,8 +113,8 @@ public class SqliteMetadataStore implements MetadataStore {
                 insert or replace into backup_session(sessionID, initial_date, conclusion_date, size, type, status)
                 values (?, ?, ?, ?, ?, ?)
                 """;
-        try (Connection connection = connect();
-                PreparedStatement statement = connection.prepareStatement(sql)) {
+        lock.lock();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, session.sessionId());
             statement.setString(2, toDb(session.startedAt()));
             statement.setString(3, toDb(session.completedAt()));
@@ -108,6 +124,8 @@ public class SqliteMetadataStore implements MetadataStore {
             statement.executeUpdate();
         } catch (SQLException e) {
             throw new IOException(e);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -116,22 +134,24 @@ public class SqliteMetadataStore implements MetadataStore {
         String sql =
                 "select sessionID, initial_date, conclusion_date, size, type, status "
                         + "from backup_session where sessionID = ?";
-        try (Connection connection = connect();
-                PreparedStatement statement = connection.prepareStatement(sql)) {
+        lock.lock();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, sessionId);
             try (ResultSet rs = statement.executeQuery()) {
                 return rs.next() ? Optional.of(mapSession(rs)) : Optional.empty();
             }
         } catch (SQLException e) {
             throw new IOException(e);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public List<BackupSession> listSessions() throws IOException {
         String sql = "select sessionID, initial_date, conclusion_date, size, type, status from backup_session";
-        try (Connection connection = connect();
-                Statement statement = connection.createStatement();
+        lock.lock();
+        try (Statement statement = connection.createStatement();
                 ResultSet rs = statement.executeQuery(sql)) {
             List<BackupSession> sessions = new ArrayList<>();
             while (rs.next()) {
@@ -140,6 +160,8 @@ public class SqliteMetadataStore implements MetadataStore {
             return sessions;
         } catch (SQLException e) {
             throw new IOException(e);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -148,8 +170,8 @@ public class SqliteMetadataStore implements MetadataStore {
         String sql =
                 "select sessionID, initial_date, conclusion_date, size, type, status from backup_session "
                         + "where conclusion_date is not null and conclusion_date < ?";
-        try (Connection connection = connect();
-                PreparedStatement statement = connection.prepareStatement(sql)) {
+        lock.lock();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, toDb(cutoff));
             try (ResultSet rs = statement.executeQuery()) {
                 List<BackupSession> sessions = new ArrayList<>();
@@ -160,12 +182,15 @@ public class SqliteMetadataStore implements MetadataStore {
             }
         } catch (SQLException e) {
             throw new IOException(e);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void deleteSession(String sessionId) throws IOException {
-        try (Connection connection = connect()) {
+        lock.lock();
+        try {
             try (PreparedStatement deleteAccounts =
                     connection.prepareStatement("delete from backup_account where sessionID = ?")) {
                 deleteAccounts.setString(1, sessionId);
@@ -178,13 +203,15 @@ public class SqliteMetadataStore implements MetadataStore {
             }
         } catch (SQLException e) {
             throw new IOException(e);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public int truncate() throws IOException {
-        try (Connection connection = connect();
-                Statement statement = connection.createStatement()) {
+        lock.lock();
+        try (Statement statement = connection.createStatement()) {
             int removed;
             try (ResultSet rs = statement.executeQuery("select count(*) from backup_session")) {
                 rs.next();
@@ -196,16 +223,20 @@ public class SqliteMetadataStore implements MetadataStore {
             return removed;
         } catch (SQLException e) {
             throw new IOException(e);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void vacuum() throws IOException {
-        try (Connection connection = connect();
-                Statement statement = connection.createStatement()) {
+        lock.lock();
+        try (Statement statement = connection.createStatement()) {
             statement.execute("VACUUM");
         } catch (SQLException e) {
             throw new IOException(e);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -214,8 +245,8 @@ public class SqliteMetadataStore implements MetadataStore {
         String sql =
                 "insert into backup_account (sessionID, account_size, email, initial_date, conclusion_date) "
                         + "values (?, ?, ?, ?, ?)";
-        try (Connection connection = connect();
-                PreparedStatement statement = connection.prepareStatement(sql)) {
+        lock.lock();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, record.sessionId());
             statement.setString(2, record.size());
             statement.setString(3, record.email());
@@ -224,6 +255,8 @@ public class SqliteMetadataStore implements MetadataStore {
             statement.executeUpdate();
         } catch (SQLException e) {
             throw new IOException(e);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -232,8 +265,8 @@ public class SqliteMetadataStore implements MetadataStore {
         String sql =
                 "select id, sessionID, email, account_size, initial_date, conclusion_date "
                         + "from backup_account where sessionID = ?";
-        try (Connection connection = connect();
-                PreparedStatement statement = connection.prepareStatement(sql)) {
+        lock.lock();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, sessionId);
             try (ResultSet rs = statement.executeQuery()) {
                 List<BackupAccountRecord> records = new ArrayList<>();
@@ -244,6 +277,8 @@ public class SqliteMetadataStore implements MetadataStore {
             }
         } catch (SQLException e) {
             throw new IOException(e);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -263,8 +298,8 @@ public class SqliteMetadataStore implements MetadataStore {
                   and (%s)
                 """
                         .formatted(prefixClause);
-        try (Connection connection = connect();
-                PreparedStatement statement = connection.prepareStatement(sql)) {
+        lock.lock();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, email);
             statement.setString(2, SessionStatus.FINISHED.dbValue());
             int paramIndex = 3;
@@ -276,14 +311,16 @@ public class SqliteMetadataStore implements MetadataStore {
             }
         } catch (SQLException e) {
             throw new IOException(e);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public boolean backedUpSince(String identifier, Instant since) throws IOException {
         String sql = "select 1 from backup_account where email = ? and conclusion_date > ? limit 1";
-        try (Connection connection = connect();
-                PreparedStatement statement = connection.prepareStatement(sql)) {
+        lock.lock();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, identifier);
             statement.setString(2, toDb(since));
             try (ResultSet rs = statement.executeQuery()) {
@@ -291,17 +328,34 @@ public class SqliteMetadataStore implements MetadataStore {
             }
         } catch (SQLException e) {
             throw new IOException(e);
+        } finally {
+            lock.unlock();
         }
     }
 
-    private Connection connect() throws SQLException {
+    @Override
+    public void close() throws IOException {
+        lock.lock();
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            throw new IOException(e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Opens the single connection this store uses for its lifetime, with {@code busy_timeout} set
+     * so a write from another zmbackup process (a separate JVM, or the bash tool) is retried
+     * instead of failing immediately with {@code SQLITE_BUSY}, and WAL journaling enabled so
+     * readers (e.g. {@code zmbackup -l} while a backup is running) don't block on it.
+     */
+    private static Connection openConnection(String jdbcUrl) throws SQLException {
         Connection connection = DriverManager.getConnection(jdbcUrl);
-        // Backup and restore sessions now run accounts through a thread pool (see
-        // io.zmbackup.core.service.Parallel), so concurrent connections from the same process can
-        // momentarily contend for SQLite's file lock; retry instead of failing immediately with
-        // SQLITE_BUSY.
         try (Statement statement = connection.createStatement()) {
             statement.execute("PRAGMA busy_timeout = 5000");
+            statement.execute("PRAGMA journal_mode = WAL");
         }
         return connection;
     }

--- a/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
+++ b/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
@@ -7,15 +7,11 @@ import io.zmbackup.core.domain.BackupAccountRecord;
 import io.zmbackup.core.domain.BackupSession;
 import io.zmbackup.core.domain.BackupType;
 import io.zmbackup.core.domain.SessionStatus;
-import io.zmbackup.core.port.MetadataStore;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -28,26 +24,21 @@ import org.junit.jupiter.api.io.TempDir;
 
 class SqliteMetadataStoreTest {
 
-    private static final String IN_MEMORY_URL = "jdbc:sqlite:file::memory:?cache=shared";
-
-    /**
-     * A shared-cache in-memory SQLite database is destroyed once its last connection closes.
-     * {@link SqliteMetadataStore} opens and closes a fresh connection per call, so this anchor
-     * connection is held open for the test's duration to keep the database alive between calls.
-     */
-    private Connection anchor;
-
-    private MetadataStore store;
+    private SqliteMetadataStore store;
 
     @BeforeEach
-    void setUp() throws SQLException, IOException {
-        anchor = DriverManager.getConnection(IN_MEMORY_URL);
+    void setUp() throws IOException {
         store = new SqliteMetadataStore(Path.of("file::memory:?cache=shared"));
     }
 
+    /**
+     * A shared-cache in-memory SQLite database is destroyed once its last connection closes;
+     * {@link SqliteMetadataStore} now holds a single connection for its lifetime, so closing it
+     * here is what resets the database between tests.
+     */
     @AfterEach
-    void tearDown() throws SQLException {
-        anchor.close();
+    void tearDown() throws IOException {
+        store.close();
     }
 
     @Test
@@ -271,7 +262,7 @@ class SqliteMetadataStoreTest {
         Path sessionDir = workDir.resolve("sessions");
         Path databaseFile = sessionDir.resolve("sessions.sqlite3");
 
-        new SqliteMetadataStore(databaseFile);
+        new SqliteMetadataStore(databaseFile).close();
 
         assertEquals("rwx------", PosixFilePermissions.toString(Files.getPosixFilePermissions(sessionDir)));
         assertEquals("rw-------", PosixFilePermissions.toString(Files.getPosixFilePermissions(databaseFile)));

--- a/project/lib/bash/BackupAction.sh
+++ b/project/lib/bash/BackupAction.sh
@@ -118,7 +118,7 @@ function backup_main()
   if [[ -z $3 ]] || [[ "$3" == "-d" ]] || [[ "$3" == "--domain" ]]; then
     build_listBKP "$1" "$2" "$3" "$4"
   elif  [[ "$3" == "-a" ]] || [[ "$3" == "--account" ]]; then
-    for i in $(echo "$4" | sed 's/,/ /g'); do
+    for i in ${4//,/ }; do
       echo "$i" >> "$TEMPACCOUNT"
     done
   else

--- a/project/lib/bash/MigrationAction.sh
+++ b/project/lib/bash/MigrationAction.sh
@@ -66,15 +66,16 @@ function importaccountsSQL(){
 ###############################################################################
 function importsessionTXT(){
   sqlite3 "$WORKDIR"/sessions.sqlite3 "select sessionID,conclusion_date from backup_session" | while read -r ROW; do
+    local SESSIONID SESSION_MONTH SESSION_DAY SESSION_YEAR SESSION_HOUR SESSION_MINUTE
     SESSIONID=$(echo "$ROW" | cut -d'|' -f1)
-    MONTH=$(echo "$ROW" | cut -d'|' -f2 | cut -d'-' -f2)
-    DAY=$(echo "$ROW" | cut -d'|' -f2 | cut -d'-' -f3 | cut -d'T' -f1)
-    YEAR=$(echo "$ROW" | cut -d'|' -f2 | cut -d'-' -f1)
-    HOUR=$(echo "$ROW" | cut -d'|' -f2 | cut -d'T' -f2 | cut -d':' -f1)
-    MINUTE=$(echo "$ROW" | cut -d'|' -f2 | cut -d'T' -f2 | cut -d':' -f2)
-    echo "SESSION: $SESSIONID started on $(date -d "$MONTH/$DAY/$YEAR $HOUR:$MINUTE")" >> "$WORKDIR"/sessions.txt
+    SESSION_MONTH=$(echo "$ROW" | cut -d'|' -f2 | cut -d'-' -f2)
+    SESSION_DAY=$(echo "$ROW" | cut -d'|' -f2 | cut -d'-' -f3 | cut -d'T' -f1)
+    SESSION_YEAR=$(echo "$ROW" | cut -d'|' -f2 | cut -d'-' -f1)
+    SESSION_HOUR=$(echo "$ROW" | cut -d'|' -f2 | cut -d'T' -f2 | cut -d':' -f1)
+    SESSION_MINUTE=$(echo "$ROW" | cut -d'|' -f2 | cut -d'T' -f2 | cut -d':' -f2)
+    echo "SESSION: $SESSIONID started on $(date -d "$SESSION_MONTH/$SESSION_DAY/$SESSION_YEAR $SESSION_HOUR:$SESSION_MINUTE")" >> "$WORKDIR"/sessions.txt
     sqlite3 "$WORKDIR"/sessions.sqlite3 "select email from backup_account where sessionID='$SESSIONID'" | while read -r ACCOUNT; do
-      echo "$SESSIONID:$ACCOUNT:$MONTH/$DAY/$YEAR" >> "$WORKDIR"/sessions.txt
+      echo "$SESSIONID:$ACCOUNT:$SESSION_MONTH/$SESSION_DAY/$SESSION_YEAR" >> "$WORKDIR"/sessions.txt
     done
   done
 }

--- a/project/lib/bash/MiscAction.sh
+++ b/project/lib/bash/MiscAction.sh
@@ -157,6 +157,7 @@ function load_config(){
   local bashrc="${ZIMBRA_BASHRC:-/opt/zimbra/.bashrc}"
   local ldaprc="${ZIMBRA_LDAPRC:-/opt/zimbra/.ldaprc}"
   if [ -f "$conf" ]; then
+    # shellcheck disable=SC1090  # install-time config path, not resolvable statically
     source "$conf" 2> /dev/null
     ZMBACKUP_BLOCKEDLIST="${ZMBACKUP_BLOCKEDLIST:-/etc/zmbackup/blockedlist.conf}"
     export ZMBACKUP_BLOCKEDLIST
@@ -166,6 +167,7 @@ function load_config(){
     exit 1
   fi
   if [ -f "$bashrc" ]; then
+    # shellcheck disable=SC1090  # zimbra user's bashrc path, not resolvable statically
     source "$bashrc" 2> /dev/null
   else
     zmlog local7.err "Zmbackup: zimbra user's .bashrc not found."

--- a/project/lib/bash/ParallelAction.sh
+++ b/project/lib/bash/ParallelAction.sh
@@ -152,7 +152,7 @@ function ldap_restore()
     printf "\n%s: %s" "$2" "$ERR"
     [[ -n "${LDAP_FAILFILE:-}" ]] && echo "$2" >> "$LDAP_FAILFILE"
   fi
-  return $BASHERRCODE
+  return "$BASHERRCODE"
 }
 
 ###############################################################################
@@ -190,7 +190,7 @@ function mailbox_restore()
     [[ -n "${MAIL_FAILFILE:-}" ]] && echo "$2" >> "$MAIL_FAILFILE"
   fi
   rm -rf "${TEMP_CLI_OUTPUT:?}"
-  return $BASHERRCODE
+  return "$BASHERRCODE"
 }
 
 
@@ -244,7 +244,7 @@ function domain_restore()
     printf "\nError during the restore process for domain %s. Error message below:" "$2"
     printf "\n%s: %s" "$2" "$ERR"
   fi
-  return $BASHERRCODE
+  return "$BASHERRCODE"
 }
 
 

--- a/project/zmbackup
+++ b/project/zmbackup
@@ -47,15 +47,25 @@
 ################################################################################
 # LOADING ZMBACKUP LIBRARIES
 ################################################################################
+# shellcheck source=lib/bash/HelpAction.sh
 source /usr/local/lib/zmbackup/bash/HelpAction.sh
+# shellcheck source=lib/bash/MiscAction.sh
 source /usr/local/lib/zmbackup/bash/MiscAction.sh
+# shellcheck source=lib/bash/NotifyAction.sh
 source /usr/local/lib/zmbackup/bash/NotifyAction.sh
+# shellcheck source=lib/bash/ParallelAction.sh
 source /usr/local/lib/zmbackup/bash/ParallelAction.sh
+# shellcheck source=lib/bash/ListAction.sh
 source /usr/local/lib/zmbackup/bash/ListAction.sh
+# shellcheck source=lib/bash/BackupAction.sh
 source /usr/local/lib/zmbackup/bash/BackupAction.sh
+# shellcheck source=lib/bash/RestoreAction.sh
 source /usr/local/lib/zmbackup/bash/RestoreAction.sh
+# shellcheck source=lib/bash/DeleteAction.sh
 source /usr/local/lib/zmbackup/bash/DeleteAction.sh
+# shellcheck source=lib/bash/MigrationAction.sh
 source /usr/local/lib/zmbackup/bash/MigrationAction.sh
+# shellcheck source=lib/bash/SessionAction.sh
 source /usr/local/lib/zmbackup/bash/SessionAction.sh
 
 ################################################################################
@@ -198,7 +208,8 @@ case "$1" in
           restore_main_ldap "$2" "$3" "$4"
           ERRCODE=$?
           restore_main_mailbox "$2" "$3" "$4"
-          [[ $? -ne 0 ]] && ERRCODE=$?
+          MAILBOX_ERRCODE=$?
+          [[ $MAILBOX_ERRCODE -ne 0 ]] && ERRCODE=$MAILBOX_ERRCODE
           rm -rf "$PID"
         else
           show_help

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
+// gradle/libs.versions.toml is picked up automatically as the "libs" version catalog by convention.
 rootProject.name = "zmbackup"
 
 include("core", "zimbra", "local", "app")

--- a/tests/unit/installer/test_vars.bats
+++ b/tests/unit/installer/test_vars.bats
@@ -5,7 +5,6 @@ load '../../setup'
 setup() {
   setup_mock_path
   # vars.sh runs commands at source time; mocks suppress failures
-  # Disable OSE_INSTALL_PORT which reads a Zimbra config file
   source "${INSTALLER_DIR}/vars.sh" 2>/dev/null || true
 }
 

--- a/zimbra/build.gradle.kts
+++ b/zimbra/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
     implementation(project(":core"))
-    implementation("com.unboundid:unboundid-ldapsdk:7.0.5")
-    testImplementation("org.wiremock:wiremock:3.13.1")
+    implementation(libs.unboundid.ldapsdk)
+    testImplementation(libs.wiremock)
 }


### PR DESCRIPTION
## Summary

Follow-up to a codebase review: closes the tooling gaps that review surfaced (no static analysis, no coverage reporting, no dependency-update automation, no shellcheck) and fixes what those tools actually found once wired up.

- **Gradle version catalog** (`gradle/libs.versions.toml`) — dependency versions were duplicated as string literals across `build.gradle.kts` files (e.g. `unboundid-ldapsdk` in both `zimbra` and `app`); now declared once.
- **SpotBugs** on every module's production sources (MAX effort, MEDIUM+ confidence), with a small justified exclude filter (`gradle/spotbugs-exclude.xml`) for patterns that don't apply to this codebase's design — fail-fast validating constructors, `AppContext`'s composition-root getters, and SQL text blocks. It surfaced two real findings, both fixed:
  - `HumanReadableSize.format`: a `double == Math.floor(double)` check rewritten to work in integer tenths instead, sidestepping the float-equality pattern entirely.
  - `LocalStorageProvider`: two `Path` results (`getFileName()`, `getParent()`) that are always non-null by construction here, now documented with `Objects.requireNonNull`.
- **JaCoCo** coverage reporting per module, collected as CircleCI artifacts alongside new SpotBugs report artifacts.
- **Dependabot** (`.github/dependabot.yml`) for the `gradle` and `npm` ecosystems.
- **ShellCheck** CI job covering the bash tool's three real entrypoints (`project/zmbackup`, `install.sh`, `install-java.sh`) via `--check-sourced` (so cross-file `source`d variables resolve instead of producing false positives). Fixing what it found turned up a real bug:
  - `project/zmbackup`: `[[ $? -ne 0 ]] && ERRCODE=$?` re-read `$?` from the `[[ ]]` test itself rather than from the preceding `restore_main_mailbox` call, silently resetting `ERRCODE` to 0 whenever a mailbox restore failed in the full/incremental restore path — the script's own exit code was lying about success.
  - `MigrationAction.sh`: `importsessionTXT`'s `MONTH`/`DAY`/`YEAR` loop variables collided with `SessionAction.sh`'s globals of the same name; scoped them `local` and renamed to remove the collision.
  - Quoting, backtick-to-`$()`, and one dead-code (`OSE_INSTALL_PORT`, unused anywhere) cleanup across `ParallelAction.sh`, `BackupAction.sh`, and both installers' `vars.sh`/`deploy.sh`.
- **`SqliteMetadataStore`**: now holds one JDBC connection for the process's lifetime (guarded by a lock) instead of opening and closing a fresh connection on every call, and enables WAL journaling. Backups run accounts through a thread pool, so the old per-call pattern meant many short-lived connections contending for SQLite's file lock on every `save`/`recordAccountBackup` call.
- **README**: replaced a stale, contextless "Waddles project" contribution note with an accurate description of the bash tool's bugfix-only status and the Java rewrite as where new work belongs.

## Test plan

- [x] `./gradlew clean check` — compiles, all unit tests, SpotBugs, and JaCoCo pass across every module
- [x] `shellcheck -x --check-sourced` clean on `project/zmbackup` (via `-P project`), `install.sh`, and `install-java.sh`
- [x] `npx bats tests/unit/` — same 432/488 passing as on the unmodified branch (the other 56 fail only because the `sqlite3` CLI isn't installed in this sandbox; confirmed identical via `git stash`) — no regressions from these changes
- [x] Verified the `SqliteMetadataStore` connection-lifecycle change against its full test suite, including the shared-cache in-memory database test that depends on connection close timing for isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194ULbAQ7jam64qRXbP95nW

---
_Generated by [Claude Code](https://claude.ai/code/session_0194ULbAQ7jam64qRXbP95nW)_