### PR TITLE
Gate coverage, trust custom certs for mailbox REST, quiet CLI errors, tighten Parallel's deadline

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -94,7 +94,9 @@ public final class AppContext {
             this.mailboxExporter = new ZimbraRestMailboxExporter(
                     config.zimbraMailbox().restBaseUrl(),
                     config.zimbraMailbox().adminUser(),
-                    config.zimbraMailbox().adminPassword());
+                    config.zimbraMailbox().adminPassword(),
+                    config.zimbraMailbox().caCertificatePath(),
+                    config.zimbraMailbox().trustAllCertificates());
             Blocklist blocklist = new FileBlocklist(config.backup().blockedListFile());
             Notifier notifier = emailNotifier(config);
             this.sessionService = new SessionService(storageProvider, metadataStore);
@@ -161,6 +163,13 @@ public final class AppContext {
                     "zimbraMailbox.restBaseUrl does not start with https://: mailbox REST requests,"
                             + " including the admin Basic-auth credentials, will be sent in cleartext."
                             + " Configure an https:// URL for production use.");
+        } else if (config.zimbraMailbox().caCertificatePath() == null
+                && config.zimbraMailbox().trustAllCertificates()) {
+            refuseUnlessAllowInsecure(
+                    config,
+                    "zimbraMailbox.trustAllCertificates is true: the mailbox REST connection will accept any"
+                            + " server certificate, which does not protect against an active MITM attack."
+                            + " Configure zimbraMailbox.caCertificatePath instead for production use.");
         }
     }
 

--- a/app/src/main/java/io/zmbackup/app/cli/Main.java
+++ b/app/src/main/java/io/zmbackup/app/cli/Main.java
@@ -38,6 +38,9 @@ public final class Main implements Callable<Integer> {
     @Option(names = "--config", description = "Path to zmbackup.yaml (default: ${DEFAULT-VALUE})")
     private Path configFile = YamlConfigLoader.DEFAULT_CONFIG_PATH;
 
+    @Option(names = "--stacktrace", description = "Show the full stack trace when a command fails.")
+    private boolean stacktraceRequested;
+
     @Spec
     private CommandSpec spec;
 
@@ -48,16 +51,27 @@ public final class Main implements Callable<Integer> {
     /**
      * Builds the {@link CommandLine} with a handler that reports {@link PrivilegeException}
      * cleanly (message + the usage exit code, mirroring the bash tool's {@code validate_config}
-     * {@code exit 2}) instead of picocli's default stack-trace dump.
+     * {@code exit 2}) instead of picocli's default stack-trace dump, and otherwise prints just the
+     * failure's message rather than its full stack trace - which, for an admin-facing CLI run
+     * normally rather than under a debugger, is noise that can also expose internal class/file
+     * detail with no actionable value. {@code --stacktrace} (mirroring Gradle's own flag of the
+     * same name/purpose) opts back into the full trace for diagnosing an unexpected failure.
      */
     static CommandLine commandLine() {
-        CommandLine cmd = new CommandLine(new Main());
+        Main main = new Main();
+        CommandLine cmd = new CommandLine(main);
         cmd.setExecutionExceptionHandler((ex, commandLine, parseResult) -> {
             if (ex instanceof PrivilegeException) {
                 commandLine.getErr().println(ex.getMessage());
                 return CommandLine.ExitCode.USAGE;
             }
-            ex.printStackTrace(commandLine.getErr());
+            if (main.stacktraceRequested) {
+                ex.printStackTrace(commandLine.getErr());
+            } else {
+                commandLine.getErr().println(ex.getClass().getName()
+                        + (ex.getMessage() != null ? ": " + ex.getMessage() : ""));
+                commandLine.getErr().println("(Run with --stacktrace to get the full stack trace.)");
+            }
             return CommandLine.ExitCode.SOFTWARE;
         });
         return cmd;

--- a/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
+++ b/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
@@ -79,7 +79,9 @@ public final class YamlConfigLoader {
                 optionalBoolean(root, "zimbraMailbox.backupInactiveAccounts", true),
                 requireString(root, "zimbraMailbox.restBaseUrl"),
                 requireString(root, "zimbraMailbox.adminUser"),
-                requireString(root, "zimbraMailbox.adminPassword"));
+                requireString(root, "zimbraMailbox.adminPassword"),
+                optionalString(root, "zimbraMailbox.caCertificatePath"),
+                optionalBoolean(root, "zimbraMailbox.trustAllCertificates", false));
     }
 
     private static BackupConfig parseBackup(Map<String, Object> root) {

--- a/app/src/main/java/io/zmbackup/app/config/ZimbraMailboxConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/ZimbraMailboxConfig.java
@@ -14,13 +14,22 @@ import java.util.Objects;
  *                                {@code "https://mail.example.com:7071"}
  * @param adminUser               the Zimbra admin account used for REST HTTP Basic authentication
  * @param adminPassword           the admin account's password
+ * @param caCertificatePath       path to a PEM-encoded CA certificate (bundle) used to verify the
+ *                                REST server's certificate, or {@code null} to use the JVM's
+ *                                default trust manager (or, if {@code trustAllCertificates} is
+ *                                set, to trust any certificate)
+ * @param trustAllCertificates    whether to accept any REST server certificate when {@code
+ *                                caCertificatePath} is not set; must be explicitly enabled, since
+ *                                it offers no protection against an active MITM attack
  */
 public record ZimbraMailboxConfig(
         String backupUser,
         boolean backupInactiveAccounts,
         String restBaseUrl,
         String adminUser,
-        String adminPassword) {
+        String adminPassword,
+        String caCertificatePath,
+        boolean trustAllCertificates) {
 
     public ZimbraMailboxConfig {
         Objects.requireNonNull(backupUser, "backupUser must not be null");
@@ -41,6 +50,8 @@ public record ZimbraMailboxConfig(
                 + ", restBaseUrl=" + restBaseUrl
                 + ", adminUser=" + adminUser
                 + ", adminPassword=***"
+                + ", caCertificatePath=" + caCertificatePath
+                + ", trustAllCertificates=" + trustAllCertificates
                 + "]";
     }
 }

--- a/app/src/test/java/io/zmbackup/app/AppContextTest.java
+++ b/app/src/test/java/io/zmbackup/app/AppContextTest.java
@@ -103,6 +103,24 @@ class AppContextTest {
         assertEquals(config, context.config());
     }
 
+    @Test
+    void constructorRefusesMailboxTrustAllCertificatesWithoutAllowInsecure() {
+        AppConfig config = configWithMailboxTrustAllCertificates(tempDir, false);
+
+        ConfigException exception = assertThrows(ConfigException.class, () -> new AppContext(config));
+
+        assertTrue(exception.getMessage().startsWith("zimbraMailbox.trustAllCertificates is true"));
+    }
+
+    @Test
+    void constructorAllowsMailboxTrustAllCertificatesWhenAllowInsecureIsSet() throws IOException {
+        AppConfig config = configWithMailboxTrustAllCertificates(tempDir, true);
+
+        AppContext context = new AppContext(config);
+
+        assertEquals(config, context.config());
+    }
+
     private static AppConfig configWithWorkDir(Path workDir) {
         return configWithWorkDir(workDir, System.getProperty("user.name"));
     }
@@ -111,7 +129,7 @@ class AppContextTest {
         return new AppConfig(
                 new ZimbraLdapConfig(
                         "ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true, null, false),
-                new ZimbraMailboxConfig(backupUser, true, "https://127.0.0.1:7071", "zimbra", "secret"),
+                new ZimbraMailboxConfig(backupUser, true, "https://127.0.0.1:7071", "zimbra", "secret", null, false),
                 new BackupConfig(
                         workDir,
                         workDir.resolve("zmbackup.log"),
@@ -133,7 +151,36 @@ class AppContextTest {
                         null,
                         false),
                 new ZimbraMailboxConfig(
-                        System.getProperty("user.name"), true, "https://127.0.0.1:7071", "zimbra", "secret"),
+                        System.getProperty("user.name"),
+                        true,
+                        "https://127.0.0.1:7071",
+                        "zimbra",
+                        "secret",
+                        null,
+                        false),
+                new BackupConfig(
+                        workDir,
+                        workDir.resolve("zmbackup.log"),
+                        workDir.resolve("blockedlist.conf"),
+                        3,
+                        30,
+                        true,
+                        new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com")),
+                allowInsecure);
+    }
+
+    private static AppConfig configWithMailboxTrustAllCertificates(Path workDir, boolean allowInsecure) {
+        return new AppConfig(
+                new ZimbraLdapConfig(
+                        "ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true, null, false),
+                new ZimbraMailboxConfig(
+                        System.getProperty("user.name"),
+                        true,
+                        "https://127.0.0.1:7071",
+                        "zimbra",
+                        "secret",
+                        null,
+                        true),
                 new BackupConfig(
                         workDir,
                         workDir.resolve("zmbackup.log"),

--- a/app/src/test/java/io/zmbackup/app/cli/MainTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MainTest.java
@@ -1,6 +1,7 @@
 package io.zmbackup.app.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.zmbackup.core.domain.BackupSession;
@@ -168,6 +169,55 @@ class MainTest {
 
         assertEquals(CommandLine.ExitCode.USAGE, exitCode);
         assertTrue(err.toString().contains("You need to be not-the-real-user to run this software."));
+    }
+
+    @Test
+    void reportsConciseErrorByDefaultAndFullStackTraceWithStacktraceFlag() throws IOException {
+        // Not a PrivilegeException/ConfigException - an unrelated, generic failure: workDir's
+        // parent is an existing regular file, so PosixFileHardening.createDirectories() fails
+        // with a plain IOException, exercising the executionExceptionHandler's default branch.
+        Path notADirectory = tempDir.resolve("not-a-directory");
+        Files.writeString(notADirectory, "not a directory");
+        Path configFile = tempDir.resolve("zmbackup.yaml");
+        Files.writeString(
+                configFile,
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:389
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                zimbraMailbox:
+                  backupUser: %s
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
+                backup:
+                  workDir: %s
+                  logFile: %s
+                  blockedListFile: %s
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                """
+                        .formatted(
+                                System.getProperty("user.name"),
+                                notADirectory.resolve("subdir"),
+                                tempDir.resolve("zmbackup.log"),
+                                tempDir.resolve("blockedlist.conf")));
+
+        StringWriter err = new StringWriter();
+        int exitCode = commandLine(new StringWriter(), err).execute("--config", configFile.toString(), "list");
+
+        assertEquals(CommandLine.ExitCode.SOFTWARE, exitCode);
+        assertTrue(err.toString().contains("(Run with --stacktrace to get the full stack trace.)"));
+        assertFalse(err.toString().contains("\tat io.zmbackup"), "default output must not include stack frames");
+
+        StringWriter verboseErr = new StringWriter();
+        int verboseExitCode = commandLine(new StringWriter(), verboseErr)
+                .execute("--stacktrace", "--config", configFile.toString(), "list");
+
+        assertEquals(CommandLine.ExitCode.SOFTWARE, verboseExitCode);
+        assertTrue(verboseErr.toString().contains("\tat io.zmbackup"), "verbose output must include stack frames");
     }
 
     private Path writeConfig() throws IOException {

--- a/app/src/test/java/io/zmbackup/app/config/AppConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/AppConfigTest.java
@@ -12,8 +12,8 @@ class AppConfigTest {
     private static final ZimbraLdapConfig LDAP_CONFIG = new ZimbraLdapConfig(
             "ldap://ldap.example.com:389", "uid=zimbra,cn=admins,cn=zimbra", "ldap-s3cr3t", true, null, false);
 
-    private static final ZimbraMailboxConfig MAILBOX_CONFIG =
-            new ZimbraMailboxConfig("zimbra", true, "https://mail.example.com:7071", "zimbra", "mailbox-s3cr3t");
+    private static final ZimbraMailboxConfig MAILBOX_CONFIG = new ZimbraMailboxConfig(
+            "zimbra", true, "https://mail.example.com:7071", "zimbra", "mailbox-s3cr3t", null, false);
 
     private static final BackupConfig BACKUP_CONFIG = new BackupConfig(
             Path.of("/opt/zimbra/backup"),

--- a/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
@@ -32,6 +32,8 @@ class YamlConfigLoaderTest {
               adminUser: zimbra
               adminPassword: secret
               backupInactiveAccounts: false
+              caCertificatePath: /etc/zmbackup/rest-ca.pem
+              trustAllCertificates: true
             backup:
               workDir: /opt/zimbra/backup
               logFile: /opt/zimbra/log/zmbackup.log
@@ -82,6 +84,8 @@ class YamlConfigLoaderTest {
         assertEquals("https://127.0.0.1:7071", config.zimbraMailbox().restBaseUrl());
         assertEquals("zimbra", config.zimbraMailbox().adminUser());
         assertEquals("secret", config.zimbraMailbox().adminPassword());
+        assertEquals("/etc/zmbackup/rest-ca.pem", config.zimbraMailbox().caCertificatePath());
+        assertEquals(true, config.zimbraMailbox().trustAllCertificates());
 
         assertEquals(Path.of("/opt/zimbra/backup"), config.backup().workDir());
         assertEquals(Path.of("/opt/zimbra/log/zmbackup.log"), config.backup().logFile());
@@ -107,6 +111,8 @@ class YamlConfigLoaderTest {
         assertEquals(null, config.zimbraLdap().caCertificatePath());
         assertEquals(false, config.zimbraLdap().trustAllCertificates());
         assertTrue(config.zimbraMailbox().backupInactiveAccounts());
+        assertEquals(null, config.zimbraMailbox().caCertificatePath());
+        assertEquals(false, config.zimbraMailbox().trustAllCertificates());
         assertEquals(3, config.backup().maxParallelProcesses());
         assertEquals(30, config.backup().rotateDays());
         assertTrue(config.backup().lockBackup());

--- a/app/src/test/java/io/zmbackup/app/config/ZimbraMailboxConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/ZimbraMailboxConfigTest.java
@@ -9,8 +9,8 @@ class ZimbraMailboxConfigTest {
 
     @Test
     void toStringRedactsAdminPassword() {
-        ZimbraMailboxConfig config =
-                new ZimbraMailboxConfig("zimbra", false, "https://mail.example.com:7071", "zimbra", "s3cr3t");
+        ZimbraMailboxConfig config = new ZimbraMailboxConfig(
+                "zimbra", false, "https://mail.example.com:7071", "zimbra", "s3cr3t", null, false);
 
         String result = config.toString();
 
@@ -18,5 +18,22 @@ class ZimbraMailboxConfigTest {
         assertTrue(result.contains("adminPassword=***"));
         assertTrue(result.contains("https://mail.example.com:7071"));
         assertTrue(result.contains("backupUser=zimbra"));
+    }
+
+    @Test
+    void toStringIncludesTlsTrustSettings() {
+        ZimbraMailboxConfig config = new ZimbraMailboxConfig(
+                "zimbra",
+                false,
+                "https://mail.example.com:7071",
+                "zimbra",
+                "s3cr3t",
+                "/etc/zmbackup/rest-ca.pem",
+                true);
+
+        String result = config.toString();
+
+        assertTrue(result.contains("caCertificatePath=/etc/zmbackup/rest-ca.pem"));
+        assertTrue(result.contains("trustAllCertificates=true"));
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,25 @@ subprojects {
         }
     }
 
+    // Gates `check` on a coverage floor comfortably below every module's current line coverage
+    // (84.5%-97.4% as of writing) so a real regression - e.g. a new class landing with no tests -
+    // fails the build instead of only showing up as a smaller number in the HTML report artifact.
+    tasks.named<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
+        dependsOn(tasks.named("jacocoTestReport"))
+        violationRules {
+            rule {
+                limit {
+                    counter = "LINE"
+                    minimum = "0.80".toBigDecimal()
+                }
+            }
+        }
+    }
+
+    tasks.named("check") {
+        dependsOn(tasks.named("jacocoTestCoverageVerification"))
+    }
+
     // Effort/reportLevel tuned for signal over noise: MAX effort catches more, but only findings
     // at MEDIUM confidence or higher are reported so `check` doesn't fail on speculative low-
     // confidence guesses.

--- a/core/src/main/java/io/zmbackup/core/service/Parallel.java
+++ b/core/src/main/java/io/zmbackup/core/service/Parallel.java
@@ -2,6 +2,7 @@ package io.zmbackup.core.service;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -44,7 +45,10 @@ final class Parallel {
      *     or if any task exceeds {@link #TASK_TIMEOUT} (in which case it is cancelled); an {@link
      *     IOException} thrown by a task is rethrown as-is, anything else is wrapped in one. When
      *     more than one task fails or times out, the first one in {@code tasks}' order is the one
-     *     reported, but every task is still given up to {@link #TASK_TIMEOUT} to finish first.
+     *     reported, but every task is still given until a single shared deadline {@link
+     *     #TASK_TIMEOUT} after this call started to finish first - not {@link #TASK_TIMEOUT} each,
+     *     which could otherwise add up to {@code tasks.size() * TASK_TIMEOUT} of total wall time in
+     *     the worst case if every task hung.
      */
     static <T> List<T> run(int maxParallelProcesses, List<Callable<T>> tasks) throws IOException {
         return run(maxParallelProcesses, tasks, TASK_TIMEOUT);
@@ -63,11 +67,20 @@ final class Parallel {
                 futures.add(executor.submit(task));
             }
 
+            // A single deadline shared across every future.get() below, rather than re-measuring
+            // taskTimeout from scratch each time: futures run concurrently, so by the time a later
+            // future is checked, some of its budget has already elapsed alongside the earlier
+            // ones' - reusing the full timeout per future would let a pathological batch (every
+            // task hung) take up to tasks.size() * taskTimeout in total instead of bounding the
+            // whole batch by taskTimeout, as documented on this method.
+            Instant deadline = Instant.now().plus(taskTimeout);
+
             List<T> results = new ArrayList<>(futures.size());
             IOException firstFailure = null;
             for (Future<T> future : futures) {
                 try {
-                    T result = future.get(taskTimeout.toMillis(), TimeUnit.MILLISECONDS);
+                    long remainingMillis = Math.max(0, Duration.between(Instant.now(), deadline).toMillis());
+                    T result = future.get(remainingMillis, TimeUnit.MILLISECONDS);
                     if (firstFailure == null) {
                         results.add(result);
                     }

--- a/project/config/zmbackup.yaml
+++ b/project/config/zmbackup.yaml
@@ -34,6 +34,15 @@ zimbraMailbox:
   adminUser: {OSE_USER}
   # The admin account's password.
   adminPassword: {OSE_INSTALL_LDAPPASS}
+  # Path to a PEM-encoded CA certificate (bundle) used to verify the mailbox REST server's
+  # certificate, e.g. Zimbra's self-signed CA at /opt/zimbra/ssl/zimbra/ca/ca.pem. Optional; if
+  # unset, the JVM's default trust manager is used (or, if trustAllCertificates is true, any
+  # certificate is trusted).
+  # caCertificatePath: /opt/zimbra/ssl/zimbra/ca/ca.pem
+  # Whether to accept any mailbox REST server certificate when caCertificatePath is not set. This
+  # does NOT protect against an active MITM attack; only enable it for self-signed Zimbra certs in
+  # dev/test environments. Optional, defaults to false.
+  trustAllCertificates: false
 
 backup:
   # Directory backups and session metadata are stored under.

--- a/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
@@ -1,9 +1,14 @@
 package io.zmbackup.zimbra;
 
+import com.unboundid.util.ssl.PEMFileTrustManager;
+import com.unboundid.util.ssl.SSLUtil;
+import com.unboundid.util.ssl.TrustAllTrustManager;
 import io.zmbackup.core.port.ZimbraMailboxExporter;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -12,6 +17,9 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -19,6 +27,10 @@ import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.Objects;
 import java.util.regex.Pattern;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.X509ExtendedTrustManager;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Exports a single account's mailbox content as a {@code .tgz} archive over Zimbra's REST
@@ -74,6 +86,29 @@ public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
      * @param adminPassword the admin account's password
      */
     public ZimbraRestMailboxExporter(String baseUrl, String adminUser, String adminPassword) {
+        this(baseUrl, adminUser, adminPassword, null, false);
+    }
+
+    /**
+     * @param baseUrl               the Zimbra server's REST base URL, e.g. {@code
+     *                              "https://mail.example.com:7071"}
+     * @param adminUser             the Zimbra admin account used for HTTP Basic authentication
+     * @param adminPassword         the admin account's password
+     * @param caCertificatePath     path to a PEM-encoded CA certificate (bundle) used to verify
+     *                              the server's certificate, or {@code null} to fall back to the
+     *                              JVM's default trust manager (or, if {@code
+     *                              trustAllCertificates} is set, to trusting any certificate)
+     * @param trustAllCertificates  whether to accept any server certificate when {@code
+     *                              caCertificatePath} is not set; must be explicitly enabled, e.g.
+     *                              for self-signed Zimbra certificates in dev/test environments,
+     *                              since it offers no protection against an active MITM attack
+     */
+    public ZimbraRestMailboxExporter(
+            String baseUrl,
+            String adminUser,
+            String adminPassword,
+            String caCertificatePath,
+            boolean trustAllCertificates) {
         Objects.requireNonNull(baseUrl, "baseUrl must not be null");
         this.baseUri = URI.create(baseUrl);
         this.adminUser = Objects.requireNonNull(adminUser, "adminUser must not be null");
@@ -81,7 +116,7 @@ public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
         // WireMock (used in tests) and most Zimbra REST deployments only speak HTTP/1.1; pinning
         // the version avoids the client's default h2 upgrade attempt hitting an RST_STREAM/EOF on
         // unknown-length POST bodies (see restore()).
-        this.httpClient = HttpClient.newBuilder()
+        HttpClient.Builder builder = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_1_1)
                 .connectTimeout(CONNECT_TIMEOUT)
                 // restore()'s request body is a single-use InputStream wrapped in
@@ -91,8 +126,97 @@ public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
                 // restore. HttpClient.Redirect.NEVER is already the JDK default, but pinning it
                 // explicitly turns "the client happens not to resend" into a guarantee this class
                 // relies on, rather than something a future default change could silently break.
-                .followRedirects(HttpClient.Redirect.NEVER)
-                .build();
+                .followRedirects(HttpClient.Redirect.NEVER);
+        SSLContext sslContext = restSslContext(caCertificatePath, trustAllCertificates);
+        if (sslContext != null) {
+            builder.sslContext(sslContext);
+        }
+        this.httpClient = builder.build();
+    }
+
+    /**
+     * Builds the {@link SSLContext} used to verify the server's certificate, mirroring {@link
+     * io.zmbackup.zimbra.UnboundIdLdapAdapter}'s own {@code startTlsSslContext()}: a configured CA
+     * certificate takes precedence, then an explicit opt-in to trust any certificate (e.g. for
+     * self-signed Zimbra certs in dev/test environments). Returns {@code null} when neither is
+     * set, so the caller leaves {@link HttpClient.Builder#sslContext} unset and the JVM's default
+     * trust manager - which validates against real CAs and protects against an active MITM attack
+     * - applies instead.
+     */
+    private static SSLContext restSslContext(String caCertificatePath, boolean trustAllCertificates) {
+        try {
+            if (caCertificatePath != null) {
+                return new SSLUtil(new PEMFileTrustManager(new File(caCertificatePath))).createSSLContext();
+            }
+            if (trustAllCertificates) {
+                return new SSLUtil(new NoHostnameCheckTrustManager(new TrustAllTrustManager())).createSSLContext();
+            }
+            return null;
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("Failed to build SSL context for Zimbra REST client", e);
+        }
+    }
+
+    /**
+     * Wraps a plain {@link X509TrustManager} as an {@link X509ExtendedTrustManager}, working
+     * around a JDK compatibility behavior that would otherwise defeat {@link
+     * TrustAllTrustManager}'s purpose here: since JDK 8u31/9, {@link HttpClient} (like other JSSE
+     * consumers) automatically performs its own hostname verification against the peer certificate
+     * whenever the configured trust manager is a legacy {@link X509TrustManager} rather than an
+     * {@link X509ExtendedTrustManager} - a safety net for callers who can't otherwise access
+     * connection/hostname context from a plain {@code X509TrustManager}. That safety net is exactly
+     * what {@code trustAllCertificates} (mirroring {@code curl -k}: accept any certificate, for a
+     * self-signed Zimbra REST cert in dev/test) is opting out of, so without this wrapper the
+     * setting would still fail the handshake on a hostname mismatch against such a certificate,
+     * silently defeating the point of enabling it. {@link #caCertificatePath}'s {@link
+     * PEMFileTrustManager} path is unaffected and keeps real hostname verification: trusting a
+     * custom CA is not the same as trusting any hostname.
+     */
+    private static final class NoHostnameCheckTrustManager extends X509ExtendedTrustManager {
+        private final X509TrustManager delegate;
+
+        NoHostnameCheckTrustManager(X509TrustManager delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            delegate.checkClientTrusted(chain, authType);
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            delegate.checkServerTrusted(chain, authType);
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
+                throws CertificateException {
+            delegate.checkClientTrusted(chain, authType);
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
+                throws CertificateException {
+            delegate.checkServerTrusted(chain, authType);
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+                throws CertificateException {
+            delegate.checkClientTrusted(chain, authType);
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+                throws CertificateException {
+            delegate.checkServerTrusted(chain, authType);
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return delegate.getAcceptedIssuers();
+        }
     }
 
     /**

--- a/zimbra/src/test/java/io/zmbackup/zimbra/ZimbraRestMailboxExporterTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/ZimbraRestMailboxExporterTest.java
@@ -192,6 +192,60 @@ class ZimbraRestMailboxExporterTest {
         assertTrue(exception.getMessage().contains("Invalid Zimbra account identifier"));
     }
 
+    @Test
+    void exportOverHttpsFailsAgainstSelfSignedCertByDefault() throws Exception {
+        WireMockServer httpsServer = new WireMockServer(WireMockConfiguration.options().dynamicHttpsPort());
+        httpsServer.start();
+        try {
+            httpsServer.stubFor(get(urlPathEqualTo(EXPORT_PATH)).willReturn(aResponse().withStatus(200)));
+            ZimbraRestMailboxExporter exporter =
+                    new ZimbraRestMailboxExporter(httpsBaseUrl(httpsServer), ADMIN_USER, ADMIN_PASSWORD);
+
+            assertThrows(IOException.class, () -> exporter.export(ACCOUNT, new ByteArrayOutputStream(), null));
+        } finally {
+            httpsServer.stop();
+        }
+    }
+
+    @Test
+    void exportOverHttpsSucceedsWhenTrustAllCertificatesIsSet() throws Exception {
+        WireMockServer httpsServer = new WireMockServer(WireMockConfiguration.options().dynamicHttpsPort());
+        httpsServer.start();
+        try {
+            byte[] tgzFixture = Files.readAllBytes(fixturePath("mailbox-export.tgz"));
+            httpsServer.stubFor(
+                    get(urlPathEqualTo(EXPORT_PATH)).willReturn(aResponse().withStatus(200).withBody(tgzFixture)));
+            ZimbraRestMailboxExporter exporter = new ZimbraRestMailboxExporter(
+                    httpsBaseUrl(httpsServer), ADMIN_USER, ADMIN_PASSWORD, null, true);
+
+            ByteArrayOutputStream destination = new ByteArrayOutputStream();
+            boolean wroteContent = exporter.export(ACCOUNT, destination, null);
+
+            assertTrue(wroteContent);
+            assertArrayEquals(tgzFixture, destination.toByteArray());
+        } finally {
+            httpsServer.stop();
+        }
+    }
+
+    @Test
+    void constructorRejectsUnreadableCaCertificatePath() {
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> new ZimbraRestMailboxExporter(
+                        wireMockServer.baseUrl(),
+                        ADMIN_USER,
+                        ADMIN_PASSWORD,
+                        "/nonexistent/path/rest-ca.pem",
+                        false));
+
+        assertTrue(exception.getMessage().contains("SSL context"));
+    }
+
+    private static String httpsBaseUrl(WireMockServer server) {
+        return "https://localhost:" + server.httpsPort();
+    }
+
     private ZimbraRestMailboxExporter exporter() {
         return new ZimbraRestMailboxExporter(wireMockServer.baseUrl(), ADMIN_USER, ADMIN_PASSWORD);
     }


### PR DESCRIPTION
## Summary

Implements four improvements identified in a code review of the Java rewrite (`core`/`app`/`local`/`zimbra`):

- **CI coverage gate**: adds a `jacocoTestCoverageVerification` rule (80% line-coverage floor per module) wired into `check`. Previously JaCoCo only *reported* coverage as a CI artifact; a real regression (e.g. a new class landing untested) wouldn't fail the build. All modules currently sit at 84.5%-97.4% line coverage, well above the new floor.
- **Mailbox REST TLS trust parity**: `ZimbraRestMailboxExporter` gains the same `caCertificatePath`/`trustAllCertificates` config knobs `UnboundIdLdapAdapter` already has for LDAP, so a self-signed Zimbra REST admin cert can be trusted explicitly instead of requiring either the JVM's global truststore or an insecure `-k`-style bypass. Getting this working also required a small `X509ExtendedTrustManager` wrapper around `trustAllCertificates`'s trust-all manager - the JDK's `HttpClient` silently re-enables hostname verification whenever the configured `TrustManager` isn't an `X509ExtendedTrustManager`, which would otherwise defeat the setting's purpose against a typical self-signed cert. `AppContext` refuses `trustAllCertificates` without `allowInsecure`, mirroring the existing LDAP check.
- **Quieter CLI errors**: `Main`'s generic exception handler now prints a concise one-line error by default instead of dumping a full stack trace to an operator's terminal, with a new `--stacktrace` flag (mirroring Gradle's own) to opt back into the full trace for diagnosis.
- **Tighter `Parallel` timeout bound**: `Parallel.run` now measures a single shared deadline across all futures instead of re-applying the full per-task timeout on each `future.get()` call, so a pathological batch (every task hung) is bounded by `taskTimeout` total rather than `tasks.size() * taskTimeout`.

## Test plan

- [x] `./gradlew clean check` (all modules: tests, SpotBugs, JaCoCo coverage verification) - green
- [x] New/updated unit tests: `ZimbraMailboxConfigTest`, `YamlConfigLoaderTest`, `AppContextTest` (insecure-settings refusal for the new REST trust setting), `ZimbraRestMailboxExporterTest` (HTTPS against a self-signed WireMock server, both the default-rejects and `trustAllCertificates`-accepts cases, plus a bad-CA-path failure), `MainTest` (concise vs. `--stacktrace` output)
- [x] Manually verified the coverage gate actually fails the build when the threshold is set above real coverage, then restored it
- [x] `npx bats tests/unit/` - all pre-existing failures reproduce identically on the unmodified tree (missing `sqlite3` CLI in this sandbox, unrelated to this change); nothing newly broken
- [x] `tests/unit/test_installer_java_deploy.bats` (covers the templated `zmbackup.yaml`) - all 28 pass, including the "no unsubstituted placeholder tokens" check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MguHeEnJtGqQ9t5LvVvsb

---
_Generated by [Claude Code](https://claude.ai/code/session_017MguHeEnJtGqQ9t5LvVvsb)_