### PR TITLE
Fix incremental cutoff loss on partial batch failure; document Java CLI; configurable LDAP timeout/disabled notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,11 @@ dependencies). Run `./install-java.sh --remove` to uninstall, or `./install-java
 to rebuild and redeploy the jar without touching your existing configuration. See
 `./install-java.sh --help` for details.
 
-## Usage
+## Usage (bash tool, 1.2.x)
+
+This section documents the bash tool's flag syntax. It's in maintenance mode - see
+[Usage (Java, 2.0)](#usage-java-20) below for the actively developed tool, which uses a different,
+subcommand-based syntax.
 
 To check all the options available to Zmbackup, just execute **zmbackup -h** or **zmbackup --help**. This will return for you a list with all the options, what each one of them does, and the syntax.
 
@@ -250,6 +254,62 @@ $ zmbackup -m
 ```
 
 **REMEMBER:** at this moment, this migration activity is a only one way road. There is no rollback, and, if you try to do a rollback, you will lost your sessions file.
+
+## Usage (Java, 2.0)
+
+The Java build's CLI is subcommand-based, unlike the bash tool's flags above. Run **zmbackup -h**
+or **zmbackup --help** for the full, current option list; a summary of the top-level commands:
+
+```
+$ zmbackup --help
+Usage: zmbackup [-hv] [--config=<configFile>]
+                 [COMMAND]
+Commands:
+  backup     Back up accounts, aliases, distribution lists, LDAP entries, or domains.
+  restore    Restore a backup session (LDAP + mailbox).
+  list       List stored backup sessions.
+  delete     Delete a stored backup session.
+  housekeep  Prune old and empty backup sessions.
+  accounts   List Zimbra accounts from LDAP (diagnostic; not a backup operation).
+  migrate    Import a bash-tool sessions.txt into the SQLite metadata store.
+  truncate   Empty the backup metadata database. TEST/DEV USE ONLY.
+```
+
+`backup` has one subcommand per object type - `full`, `incremental`, `mailbox`, `ldap`, `alias`,
+`distlist`, `signature`, `domain` - each taking a repeatable `--account` (or, for `domain`,
+`--domain`) to restrict which objects are backed up, and (except `domain`) a `--domain` to
+restrict discovery to one Zimbra domain. With no `--account`/`--domain`, every discovered object
+is backed up.
+
+```
+$ zmbackup backup full
+$ zmbackup backup full --account user@domain.com
+$ zmbackup backup mailbox --domain domain.com
+$ zmbackup backup ldap --account user@domain.com
+$ zmbackup backup incremental
+```
+
+`restore` takes `--session <sessionId>` (check available IDs with `zmbackup list` first) and,
+optionally, a repeatable `--account`/`--domain` to restrict which objects are restored; with no
+subcommand it restores both LDAP and mailbox content, or use the `ldap`, `domain`, or `mailbox`
+subcommands to restore one kind of content on its own. `--into <account>` restores a mailbox into
+a different destination account (requires exactly one `--account`).
+
+```
+$ zmbackup list
+$ zmbackup restore --session full-20170621201603
+$ zmbackup restore mailbox --session full-20170621201603 --account user@domain.com
+$ zmbackup restore mailbox --session full-20170621201603 --account origin@domain.com --into dest@domain.com
+```
+
+`delete` and `housekeep` mirror the bash tool's `-d`/`-hp`:
+
+```
+$ zmbackup delete --session full-20170621201603
+$ zmbackup housekeep
+```
+
+See [Installation (Java version)](#installation-java-version) above for `migrate` and `truncate`.
 
 ## Scheduling backups
 

--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -4,6 +4,8 @@ import io.zmbackup.app.config.AppConfig;
 import io.zmbackup.app.config.ConfigException;
 import io.zmbackup.app.config.EmailNotifyLevel;
 import io.zmbackup.app.config.YamlConfigLoader;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
 import io.zmbackup.core.port.AccountDiscovery;
 import io.zmbackup.core.port.Blocklist;
 import io.zmbackup.core.port.MetadataStore;
@@ -51,6 +53,16 @@ public final class AppContext {
 
     private static final int NOTIFY_SMTP_PORT = 25;
 
+    /** Used for {@link EmailNotifyLevel#NONE}, where every lifecycle event is a silent no-op. */
+    private static final Notifier NO_NOTIFIER = new Notifier() {
+        @Override
+        public void notifyBegin(String sessionId, BackupType type) {}
+
+        @Override
+        public void notifyFinish(
+                String sessionId, BackupType type, SessionStatus status, String size, int accountCount) {}
+    };
+
     /** Root logger name every zmbackup class logs under, so one appender pair covers all of them. */
     private static final String ROOT_LOGGER_NAME = "io.zmbackup";
 
@@ -88,7 +100,8 @@ public final class AppContext {
                     config.zimbraLdap().sslEnabled(),
                     config.zimbraLdap().caCertificatePath(),
                     config.zimbraLdap().trustAllCertificates(),
-                    config.zimbraMailbox().backupInactiveAccounts());
+                    config.zimbraMailbox().backupInactiveAccounts(),
+                    config.zimbraLdap().responseTimeoutSeconds() * 1000L);
             this.accountDiscovery = ldapAdapter;
             this.ldapExporter = ldapAdapter;
             this.mailboxExporter = new ZimbraRestMailboxExporter(
@@ -227,11 +240,17 @@ public final class AppContext {
     }
 
     /**
-     * Builds an {@link EmailNotifier} from {@code config}'s {@code backup.emailNotify} section,
-     * translating {@link EmailNotifyLevel} into which lifecycle events it notifies on.
+     * Builds a {@link Notifier} from {@code config}'s {@code backup.emailNotify} section,
+     * translating {@link EmailNotifyLevel} into which lifecycle events it notifies on. {@code
+     * NONE} never sends anything, and its recipient/sender are therefore allowed to be unset
+     * ({@link EmailNotifyConfig}) - so it's handled separately here rather than passed through to
+     * {@link EmailNotifier}, which requires both to be non-null.
      */
-    private static EmailNotifier emailNotifier(AppConfig config) {
+    private static Notifier emailNotifier(AppConfig config) {
         EmailNotifyLevel level = config.backup().emailNotify().level();
+        if (level == EmailNotifyLevel.NONE) {
+            return NO_NOTIFIER;
+        }
         boolean notifyOnBegin = level == EmailNotifyLevel.ALL || level == EmailNotifyLevel.START;
         boolean notifyOnFinishSuccess = level == EmailNotifyLevel.ALL || level == EmailNotifyLevel.FINISH;
         boolean notifyOnFinishError = level == EmailNotifyLevel.ALL || level == EmailNotifyLevel.ERROR;

--- a/app/src/main/java/io/zmbackup/app/config/EmailNotifyConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/EmailNotifyConfig.java
@@ -7,14 +7,19 @@ import java.util.Objects;
  * {@code EMAIL_SENDER} fields of the bash tool's {@code zmbackup.conf}.
  *
  * @param level     which lifecycle events to notify on
- * @param recipient the address a report is sent to after each run
- * @param sender    the address the report is sent from, e.g. {@code "root@domain"}
+ * @param recipient the address a report is sent to after each run; required unless
+ *                  {@code level} is {@link EmailNotifyLevel#NONE}, since no notification is ever
+ *                  sent in that case
+ * @param sender    the address the report is sent from, e.g. {@code "root@domain"}; required
+ *                  unless {@code level} is {@link EmailNotifyLevel#NONE}
  */
 public record EmailNotifyConfig(EmailNotifyLevel level, String recipient, String sender) {
 
     public EmailNotifyConfig {
         Objects.requireNonNull(level, "level must not be null");
-        Objects.requireNonNull(recipient, "recipient must not be null");
-        Objects.requireNonNull(sender, "sender must not be null");
+        if (level != EmailNotifyLevel.NONE) {
+            Objects.requireNonNull(recipient, "recipient must not be null unless level is NONE");
+            Objects.requireNonNull(sender, "sender must not be null unless level is NONE");
+        }
     }
 }

--- a/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
+++ b/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
@@ -70,7 +70,11 @@ public final class YamlConfigLoader {
                 requireString(root, "zimbraLdap.bindPassword"),
                 optionalBoolean(root, "zimbraLdap.sslEnabled", true),
                 optionalString(root, "zimbraLdap.caCertificatePath"),
-                optionalBoolean(root, "zimbraLdap.trustAllCertificates", false));
+                optionalBoolean(root, "zimbraLdap.trustAllCertificates", false),
+                optionalInt(
+                        root,
+                        "zimbraLdap.responseTimeoutSeconds",
+                        ZimbraLdapConfig.DEFAULT_RESPONSE_TIMEOUT_SECONDS));
     }
 
     private static ZimbraMailboxConfig parseZimbraMailbox(Map<String, Object> root) {
@@ -96,10 +100,18 @@ public final class YamlConfigLoader {
     }
 
     private static EmailNotifyConfig parseEmailNotify(Map<String, Object> root) {
+        EmailNotifyLevel level = optionalEmailNotifyLevel(root, "backup.emailNotify.level", EmailNotifyLevel.ALL);
+        // No notification is ever sent when level is NONE, so recipient/sender are pointless to
+        // require in that case - unlike every other level, where they're needed to send one.
+        boolean notifyDisabled = level == EmailNotifyLevel.NONE;
         return new EmailNotifyConfig(
-                optionalEmailNotifyLevel(root, "backup.emailNotify.level", EmailNotifyLevel.ALL),
-                requireString(root, "backup.emailNotify.recipient"),
-                requireString(root, "backup.emailNotify.sender"));
+                level,
+                notifyDisabled
+                        ? optionalString(root, "backup.emailNotify.recipient")
+                        : requireString(root, "backup.emailNotify.recipient"),
+                notifyDisabled
+                        ? optionalString(root, "backup.emailNotify.sender")
+                        : requireString(root, "backup.emailNotify.sender"));
     }
 
     /**

--- a/app/src/main/java/io/zmbackup/app/config/ZimbraLdapConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/ZimbraLdapConfig.java
@@ -18,6 +18,11 @@ import java.util.Objects;
  * @param trustAllCertificates whether to accept any server certificate when {@code caCertificatePath}
  *                             is not set; must be explicitly enabled, since it offers no protection
  *                             against an active MITM attack
+ * @param responseTimeoutSeconds how long a single LDAP operation (bind, search, add, delete) is
+ *                             allowed to take once connected, before it's abandoned as hung against
+ *                             a connected-but-unresponsive server; discovery over a very large
+ *                             directory can legitimately take a while, so this is exposed rather
+ *                             than fixed
  */
 public record ZimbraLdapConfig(
         String url,
@@ -25,12 +30,19 @@ public record ZimbraLdapConfig(
         String bindPassword,
         boolean sslEnabled,
         String caCertificatePath,
-        boolean trustAllCertificates) {
+        boolean trustAllCertificates,
+        int responseTimeoutSeconds) {
+
+    /** The default {@link #responseTimeoutSeconds()} when {@code zimbraLdap.responseTimeoutSeconds} is unset. */
+    public static final int DEFAULT_RESPONSE_TIMEOUT_SECONDS = 600;
 
     public ZimbraLdapConfig {
         Objects.requireNonNull(url, "url must not be null");
         Objects.requireNonNull(bindDn, "bindDn must not be null");
         Objects.requireNonNull(bindPassword, "bindPassword must not be null");
+        if (responseTimeoutSeconds < 1) {
+            throw new IllegalArgumentException("responseTimeoutSeconds must be at least 1");
+        }
     }
 
     /**
@@ -46,6 +58,7 @@ public record ZimbraLdapConfig(
                 + ", sslEnabled=" + sslEnabled
                 + ", caCertificatePath=" + caCertificatePath
                 + ", trustAllCertificates=" + trustAllCertificates
+                + ", responseTimeoutSeconds=" + responseTimeoutSeconds
                 + "]";
     }
 }

--- a/app/src/test/java/io/zmbackup/app/AppContextTest.java
+++ b/app/src/test/java/io/zmbackup/app/AppContextTest.java
@@ -77,6 +77,34 @@ class AppContextTest {
     }
 
     @Test
+    void wiresComponentsWhenEmailNotifyLevelIsNoneWithNoRecipientOrSender() throws IOException {
+        AppConfig config = new AppConfig(
+                new ZimbraLdapConfig(
+                        "ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true, null, false, 600),
+                new ZimbraMailboxConfig(
+                        System.getProperty("user.name"),
+                        true,
+                        "https://127.0.0.1:7071",
+                        "zimbra",
+                        "secret",
+                        null,
+                        false),
+                new BackupConfig(
+                        tempDir,
+                        tempDir.resolve("zmbackup.log"),
+                        tempDir.resolve("blockedlist.conf"),
+                        3,
+                        30,
+                        true,
+                        new EmailNotifyConfig(EmailNotifyLevel.NONE, null, null)),
+                false);
+
+        AppContext context = new AppContext(config);
+
+        assertEquals(config, context.config());
+    }
+
+    @Test
     void constructorRejectsMismatchedBackupUser() {
         AppConfig config = configWithWorkDir(tempDir, "not-the-real-user");
 
@@ -128,7 +156,7 @@ class AppContextTest {
     private static AppConfig configWithWorkDir(Path workDir, String backupUser) {
         return new AppConfig(
                 new ZimbraLdapConfig(
-                        "ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true, null, false),
+                        "ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true, null, false, 600),
                 new ZimbraMailboxConfig(backupUser, true, "https://127.0.0.1:7071", "zimbra", "secret", null, false),
                 new BackupConfig(
                         workDir,
@@ -149,7 +177,8 @@ class AppContextTest {
                         "secret",
                         sslEnabled,
                         null,
-                        false),
+                        false,
+                        600),
                 new ZimbraMailboxConfig(
                         System.getProperty("user.name"),
                         true,
@@ -172,7 +201,7 @@ class AppContextTest {
     private static AppConfig configWithMailboxTrustAllCertificates(Path workDir, boolean allowInsecure) {
         return new AppConfig(
                 new ZimbraLdapConfig(
-                        "ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true, null, false),
+                        "ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true, null, false, 600),
                 new ZimbraMailboxConfig(
                         System.getProperty("user.name"),
                         true,

--- a/app/src/test/java/io/zmbackup/app/config/AppConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/AppConfigTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 class AppConfigTest {
 
     private static final ZimbraLdapConfig LDAP_CONFIG = new ZimbraLdapConfig(
-            "ldap://ldap.example.com:389", "uid=zimbra,cn=admins,cn=zimbra", "ldap-s3cr3t", true, null, false);
+            "ldap://ldap.example.com:389", "uid=zimbra,cn=admins,cn=zimbra", "ldap-s3cr3t", true, null, false, 600);
 
     private static final ZimbraMailboxConfig MAILBOX_CONFIG = new ZimbraMailboxConfig(
             "zimbra", true, "https://mail.example.com:7071", "zimbra", "mailbox-s3cr3t", null, false);

--- a/app/src/test/java/io/zmbackup/app/config/EmailNotifyConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/EmailNotifyConfigTest.java
@@ -28,6 +28,15 @@ class EmailNotifyConfigTest {
     }
 
     @Test
+    void allowsNullRecipientAndSenderWhenLevelIsNone() {
+        EmailNotifyConfig config = new EmailNotifyConfig(EmailNotifyLevel.NONE, null, null);
+
+        assertEquals(EmailNotifyLevel.NONE, config.level());
+        assertEquals(null, config.recipient());
+        assertEquals(null, config.sender());
+    }
+
+    @Test
     void storesConfiguredFields() {
         EmailNotifyConfig config = new EmailNotifyConfig(EmailNotifyLevel.ERROR, "admin@example.com", "root@example.com");
 

--- a/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
@@ -26,6 +26,7 @@ class YamlConfigLoaderTest {
               sslEnabled: false
               caCertificatePath: /etc/zmbackup/ldap-ca.pem
               trustAllCertificates: true
+              responseTimeoutSeconds: 120
             zimbraMailbox:
               backupUser: zimbra
               restBaseUrl: https://127.0.0.1:7071
@@ -78,6 +79,7 @@ class YamlConfigLoaderTest {
         assertFalseSsl(config);
         assertEquals("/etc/zmbackup/ldap-ca.pem", config.zimbraLdap().caCertificatePath());
         assertEquals(true, config.zimbraLdap().trustAllCertificates());
+        assertEquals(120, config.zimbraLdap().responseTimeoutSeconds());
 
         assertEquals("zimbra", config.zimbraMailbox().backupUser());
         assertEquals(false, config.zimbraMailbox().backupInactiveAccounts());
@@ -110,6 +112,8 @@ class YamlConfigLoaderTest {
         assertTrue(config.zimbraLdap().sslEnabled());
         assertEquals(null, config.zimbraLdap().caCertificatePath());
         assertEquals(false, config.zimbraLdap().trustAllCertificates());
+        assertEquals(
+                ZimbraLdapConfig.DEFAULT_RESPONSE_TIMEOUT_SECONDS, config.zimbraLdap().responseTimeoutSeconds());
         assertTrue(config.zimbraMailbox().backupInactiveAccounts());
         assertEquals(null, config.zimbraMailbox().caCertificatePath());
         assertEquals(false, config.zimbraMailbox().trustAllCertificates());
@@ -118,6 +122,34 @@ class YamlConfigLoaderTest {
         assertTrue(config.backup().lockBackup());
         assertEquals(EmailNotifyLevel.ALL, config.backup().emailNotify().level());
         assertEquals(false, config.allowInsecure());
+    }
+
+    @Test
+    void emailNotifyRecipientAndSenderAreOptionalWhenLevelIsNone() {
+        String yaml =
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:389
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                zimbraMailbox:
+                  backupUser: zimbra
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
+                backup:
+                  workDir: /opt/zimbra/backup
+                  logFile: /opt/zimbra/log/zmbackup.log
+                  blockedListFile: /etc/zmbackup/blockedlist.conf
+                  emailNotify:
+                    level: NONE
+                """;
+
+        AppConfig config = YamlConfigLoader.load(new StringReader(yaml));
+
+        assertEquals(EmailNotifyLevel.NONE, config.backup().emailNotify().level());
+        assertEquals(null, config.backup().emailNotify().recipient());
+        assertEquals(null, config.backup().emailNotify().sender());
     }
 
     @Test

--- a/app/src/test/java/io/zmbackup/app/config/ZimbraLdapConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/ZimbraLdapConfigTest.java
@@ -15,7 +15,8 @@ class ZimbraLdapConfigTest {
                 "s3cr3t",
                 true,
                 "/etc/zmbackup/ldap-ca.pem",
-                false);
+                false,
+                600);
 
         String result = config.toString();
 

--- a/core/src/main/java/io/zmbackup/core/port/MetadataStore.java
+++ b/core/src/main/java/io/zmbackup/core/port/MetadataStore.java
@@ -48,6 +48,10 @@ public interface MetadataStore {
      * When {@code email} was last successfully backed up — the latest
      * {@link BackupAccountRecord#completedAt()} across all of its sessions — or empty if it was
      * never backed up. Used to compute the "after" cutoff for incremental mailbox backups.
+     * Considers accounts recorded under a {@code FAILED} session too - a session only fails
+     * overall because some other account in the same batch failed, and that doesn't undo this
+     * account's own already-recorded successful export; only sessions still {@code IN_PROGRESS}
+     * (whose outcome isn't durable yet) are excluded.
      */
     Optional<Instant> lastSuccessfulBackupTime(String email) throws IOException;
 

--- a/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
+++ b/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
@@ -288,20 +288,26 @@ public class SqliteMetadataStore implements MetadataStore, Closeable {
         String prefixClause = mailboxPrefixes.stream()
                 .map(prefix -> "ba.sessionID like ?")
                 .collect(Collectors.joining(" or "));
+        // A backup_account row only exists once that account's own export completed, regardless
+        // of whether other accounts in the same batch later failed the session as a whole - so
+        // only IN_PROGRESS sessions (still running, outcome for this account not yet durable) are
+        // excluded here, not FAILED ones. Requiring FINISHED at the session level would make one
+        // account's failure silently discard every other account's successful cutoff, forcing
+        // them all back to a full re-export on the next incremental run.
         String sql =
                 """
                 select max(ba.conclusion_date) as last_backup
                 from backup_account ba
                 join backup_session bs on ba.sessionID = bs.sessionID
                 where ba.email = ?
-                  and bs.status = ?
+                  and bs.status != ?
                   and (%s)
                 """
                         .formatted(prefixClause);
         lock.lock();
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, email);
-            statement.setString(2, SessionStatus.FINISHED.dbValue());
+            statement.setString(2, SessionStatus.IN_PROGRESS.dbValue());
             int paramIndex = 3;
             for (String prefix : mailboxPrefixes) {
                 statement.setString(paramIndex++, prefix + "%");

--- a/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
+++ b/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
@@ -196,6 +196,15 @@ class SqliteMetadataStoreTest {
     }
 
     @Test
+    void lastSuccessfulBackupTimeCountsAccountRecordedUnderFailedSession() throws IOException {
+        Instant now = Instant.now();
+        store.save(session("full-1", BackupType.FULL, SessionStatus.FAILED, now));
+        store.recordAccountBackup(accountRecord("full-1", "user@example.com", now));
+
+        assertEquals(Optional.of(now), store.lastSuccessfulBackupTime("user@example.com"));
+    }
+
+    @Test
     void lastSuccessfulBackupTimeIgnoresNonMailboxSessionTypes() throws IOException {
         Instant now = Instant.now();
         store.save(session("ldap-1", BackupType.LDAP, SessionStatus.FINISHED, now));

--- a/project/config/zmbackup.yaml
+++ b/project/config/zmbackup.yaml
@@ -22,6 +22,10 @@ zimbraLdap:
   # NOT protect against an active MITM attack; only enable it for self-signed Zimbra certs in
   # dev/test environments. Optional, defaults to false.
   trustAllCertificates: false
+  # How long a single LDAP operation (bind, search, add, delete) may take once connected before
+  # it's abandoned as hung. Discovery searches the whole directory in one request, so a very
+  # large directory may need more than the default. Optional, defaults to 600 (10 minutes).
+  # responseTimeoutSeconds: 600
 
 zimbraMailbox:
   # Zimbra service account used to start/stop the service.

--- a/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
@@ -47,13 +47,13 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
     private static final long CONNECT_TIMEOUT_MILLIS = 30_000;
 
     /**
-     * How long a single LDAP operation (bind, search, add, delete) is allowed to take once
-     * connected. Generous relative to {@link #CONNECT_TIMEOUT_MILLIS} since {@link
+     * Default for {@link #responseTimeoutMillis} when a caller uses the constructor that doesn't
+     * take one explicitly. Generous relative to {@link #CONNECT_TIMEOUT_MILLIS} since {@link
      * #discover(LdapObjectType)} can legitimately take a while to enumerate every object across a
      * large directory; the point is only to bound an otherwise-unbounded hang against a
      * connected-but-unresponsive server.
      */
-    private static final long RESPONSE_TIMEOUT_MILLIS = 600_000;
+    private static final long DEFAULT_RESPONSE_TIMEOUT_MILLIS = 600_000;
 
     private final String host;
     private final int port;
@@ -63,6 +63,7 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
     private final String caCertificatePath;
     private final boolean trustAllCertificates;
     private final boolean backupInactiveAccounts;
+    private final long responseTimeoutMillis;
 
     /**
      * @param url                     the LDAP server URL, e.g. {@code "ldap://127.0.0.1:389"}
@@ -89,6 +90,35 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
             String caCertificatePath,
             boolean trustAllCertificates,
             boolean backupInactiveAccounts) {
+        this(
+                url,
+                bindDn,
+                bindPassword,
+                startTls,
+                caCertificatePath,
+                trustAllCertificates,
+                backupInactiveAccounts,
+                DEFAULT_RESPONSE_TIMEOUT_MILLIS);
+    }
+
+    /**
+     * Same as {@link #UnboundIdLdapAdapter(String, String, String, boolean, String, boolean,
+     * boolean)}, with an explicit {@code responseTimeoutMillis} instead of {@link
+     * #DEFAULT_RESPONSE_TIMEOUT_MILLIS} - how long a single LDAP operation (bind, search, add,
+     * delete) is allowed to take once connected, before it's abandoned as hung against a
+     * connected-but-unresponsive server. Exposed separately since {@link
+     * #discover(LdapObjectType)} searches the whole directory in one unpaginated request, so a
+     * very large directory may need more than the default budget.
+     */
+    public UnboundIdLdapAdapter(
+            String url,
+            String bindDn,
+            String bindPassword,
+            boolean startTls,
+            String caCertificatePath,
+            boolean trustAllCertificates,
+            boolean backupInactiveAccounts,
+            long responseTimeoutMillis) {
         LDAPURL parsedUrl;
         try {
             parsedUrl = new LDAPURL(url);
@@ -102,6 +132,7 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
         this.startTls = startTls;
         this.caCertificatePath = caCertificatePath;
         this.trustAllCertificates = trustAllCertificates;
+        this.responseTimeoutMillis = responseTimeoutMillis;
         this.backupInactiveAccounts = backupInactiveAccounts;
     }
 
@@ -331,7 +362,7 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
         try {
             LDAPConnectionOptions options = new LDAPConnectionOptions();
             options.setConnectTimeoutMillis((int) CONNECT_TIMEOUT_MILLIS);
-            options.setResponseTimeoutMillis(RESPONSE_TIMEOUT_MILLIS);
+            options.setResponseTimeoutMillis(responseTimeoutMillis);
             connection = new LDAPConnection(options, host, port);
             if (startTls) {
                 SSLContext sslContext = startTlsSslContext();


### PR DESCRIPTION
## Summary

Addresses four issues found in a code review of the Java (2.0) rewrite, focused on what was still open after the prior review rounds already landed (path traversal, LDAP/SQL injection, TLS trust, credential redaction, permissions, etc.):

- **Incremental backups silently balloon after any partial batch failure.** `BackupService` marks a whole session `FAILED` if even one account's export throws, but `SqliteMetadataStore.lastSuccessfulBackupTime()` required the owning session to be `FINISHED` before counting an account's backup as "last successful." So one transient failure among thousands of accounts discarded every other account's incremental cutoff too, silently forcing all of them back to a full re-export on the next run. Now only sessions still `IN_PROGRESS` (outcome not yet durable) are excluded — a `FAILED` session's individually-successful account records still count.
- **README documented only the retired bash CLI.** The Usage section showed `zmbackup -f`/`-i`/`-r` flag syntax exclusively, but the Java 2.0 CLI (the one under active development, per the README's own "Want to contribute?" section) is subcommand-based (`zmbackup backup full`, `zmbackup restore --session ...`, etc.) and rejects every example in that section. Added a `Usage (Java, 2.0)` section documenting the real commands; relabeled the old section as bash-tool-specific.
- **LDAP discovery timeout was a hardcoded, unconfigurable 10 minutes.** Directory discovery is a single non-paginated whole-tree search, not split across the worker pool like account exports, so a very large/slow directory had no way to widen the budget. Exposed it as `zimbraLdap.responseTimeoutSeconds` (default unchanged at 600s).
- **Config required an email recipient/sender even with notifications fully disabled.** `backup.emailNotify.level: NONE` exists specifically to suppress notifications, but config loading still demanded `recipient`/`sender`. They're now optional when `level: NONE`; `AppContext` uses a no-op `Notifier` in that case instead of constructing an `EmailNotifier` that would reject the missing values.

## Test plan

- [x] `./gradlew build` (full build: compile, spotbugs, tests, coverage gate) — green
- [x] Added/updated unit tests for each fix:
  - `SqliteMetadataStoreTest`: new case asserting a `FAILED` session's account record still counts
  - `YamlConfigLoaderTest` / `ZimbraLdapConfigTest` / `AppConfigTest`: `responseTimeoutSeconds` parsing, default, and `toString()`
  - `YamlConfigLoaderTest` / `EmailNotifyConfigTest` / `AppContextTest`: `level: NONE` with no `recipient`/`sender` loads and wires successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qMz6AEFQXyF69Nzd3nWaG

---
_Generated by [Claude Code](https://claude.ai/code/session_013qMz6AEFQXyF69Nzd3nWaG)_