### PR TITLE
Fix misaligned zmbackup list table for sub-second timestamps

### DIFF
--- a/app/src/main/java/io/zmbackup/app/cli/ListCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/ListCommand.java
@@ -3,6 +3,10 @@ package io.zmbackup.app.cli;
 import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.BackupSession;
 import java.io.PrintWriter;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
@@ -15,6 +19,8 @@ public final class ListCommand implements Callable<Integer> {
     private static final String BORDER =
             "+-----------------------------+----------------------+----------------------+----------+--------------------+";
     private static final String ROW_FORMAT = "| %-27s | %-20s | %-20s | %-8s | %-18s |%n";
+    private static final DateTimeFormatter TIMESTAMP_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.ROOT).withZone(ZoneOffset.UTC);
 
     @ParentCommand
     private Main parent;
@@ -34,12 +40,16 @@ public final class ListCommand implements Callable<Integer> {
             out.printf(
                     ROW_FORMAT,
                     session.sessionId(),
-                    session.startedAt(),
-                    session.completedAt() == null ? "-" : session.completedAt(),
+                    formatTimestamp(session.startedAt()),
+                    formatTimestamp(session.completedAt()),
                     session.size() == null ? "-" : session.size(),
                     session.type());
         }
         out.println(BORDER);
         return 0;
+    }
+
+    private static String formatTimestamp(Instant instant) {
+        return instant == null ? "-" : TIMESTAMP_FORMAT.format(instant);
     }
 }

--- a/app/src/test/java/io/zmbackup/app/cli/MainTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MainTest.java
@@ -84,6 +84,33 @@ class MainTest {
     }
 
     @Test
+    void listKeepsTableAlignedForSubSecondPrecisionTimestamps() throws IOException {
+        Path configFile = writeConfig();
+        new SqliteMetadataStore(tempDir.resolve("sessions.sqlite3"))
+                .save(
+                        new BackupSession(
+                                "full-20260904221623",
+                                BackupType.FULL,
+                                SessionStatus.FINISHED,
+                                Instant.parse("2026-09-04T22:16:23.305397329Z"),
+                                Instant.parse("2026-09-04T22:17:34.609010890Z"),
+                                "1.7G"));
+        StringWriter out = new StringWriter();
+        CommandLine cmd = commandLine(out, new StringWriter());
+
+        int exitCode = cmd.execute("--config", configFile.toString(), "list");
+
+        assertEquals(0, exitCode);
+        String[] lines = out.toString().split("\\R");
+        int borderLength = lines[0].length();
+        for (String line : lines) {
+            assertEquals(borderLength, line.length(), "table line misaligned: " + line);
+        }
+        assertTrue(out.toString().contains("2026-09-04 22:16:23"));
+        assertTrue(out.toString().contains("2026-09-04 22:17:34"));
+    }
+
+    @Test
     void housekeepRemovesOldSessions() throws IOException {
         Path configFile = writeConfig();
         new SqliteMetadataStore(tempDir.resolve("sessions.sqlite3"))


### PR DESCRIPTION
## Summary
- `zmbackup list` renders a fixed-width table, but `Started`/`Completed` are formatted with `Instant#toString()`, which includes variable-precision fractional seconds (up to nanoseconds) — up to 30 characters against a 20-character column, which breaks the table's alignment.
- Format both timestamps to whole-second precision (`yyyy-MM-dd HH:mm:ss`, UTC) via `DateTimeFormatter`, which always fits the fixed column width.

## Test plan
- [x] Added `MainTest.listKeepsTableAlignedForSubSecondPrecisionTimestamps`, which stores a session with a nanosecond-precision `Instant` (reproducing the exact shape from the bug report) and asserts every line of the rendered table has the same length as the border.
- [x] `./gradlew :app:test :core:test` passes (11/11 in `MainTest`, including the new regression test).

Fixes #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWUWdweEL2LVbwJNZUpYWV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWUWdweEL2LVbwJNZUpYWV)_