### PR TITLE
Implement Phase 2 cloud backends: S3 storage, DynamoDB metadata, migrate-to-cloud

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":zimbra"))
     implementation(project(":local"))
+    implementation(project(":aws"))
     implementation(libs.snakeyaml)
     implementation(libs.picocli)
     implementation(libs.logback.classic)

--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -2,14 +2,22 @@ package io.zmbackup.app;
 
 import io.zmbackup.app.config.AppConfig;
 import io.zmbackup.app.config.ConfigException;
+import io.zmbackup.app.config.DynamoDbConfig;
 import io.zmbackup.app.config.EmailNotifyLevel;
+import io.zmbackup.app.config.MetadataBackend;
+import io.zmbackup.app.config.S3Config;
+import io.zmbackup.app.config.StorageBackend;
 import io.zmbackup.app.config.YamlConfigLoader;
+import io.zmbackup.aws.DynamoDBLock;
+import io.zmbackup.aws.DynamoDBMetadataStore;
+import io.zmbackup.aws.S3StorageProvider;
 import io.zmbackup.core.domain.BackupType;
 import io.zmbackup.core.domain.SessionStatus;
 import io.zmbackup.core.port.AccountDiscovery;
 import io.zmbackup.core.port.Blocklist;
 import io.zmbackup.core.port.MetadataStore;
 import io.zmbackup.core.port.Notifier;
+import io.zmbackup.core.port.RunLock;
 import io.zmbackup.core.port.StorageProvider;
 import io.zmbackup.core.port.ZimbraLdapExporter;
 import io.zmbackup.core.port.ZimbraMailboxExporter;
@@ -30,8 +38,11 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.FileAppender;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import java.io.Closeable;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Locale;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -39,6 +50,8 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 public final class AppContext {
 
     private static final String METADATA_STORE_FILENAME = "sessions.sqlite3";
+
+    private static final Duration DYNAMODB_LOCK_LEASE = Duration.ofHours(24);
 
     private static final String NOTIFY_SMTP_HOST = "localhost";
 
@@ -74,10 +87,9 @@ public final class AppContext {
         this.config = config;
         installLogging(config.backup().logFile());
         checkInsecureSettings(config);
-        this.storageProvider = new LocalStorageProvider(config.backup().workDir());
-        SqliteMetadataStore sqliteMetadataStore =
-                new SqliteMetadataStore(config.backup().workDir().resolve(METADATA_STORE_FILENAME));
-        this.metadataStore = sqliteMetadataStore;
+        this.storageProvider = buildStorageProvider(config);
+        MetadataStore builtMetadataStore = buildMetadataStore(config);
+        this.metadataStore = builtMetadataStore;
         try {
             UnboundIdLdapAdapter ldapAdapter = new UnboundIdLdapAdapter(
                     config.zimbraLdap().url(),
@@ -115,9 +127,41 @@ public final class AppContext {
             this.housekeepService = new HousekeepService(storageProvider, metadataStore);
             this.migrationService = new MigrationService(storageProvider, metadataStore);
         } catch (IOException | RuntimeException e) {
-            sqliteMetadataStore.close();
+            closeIfCloseable(builtMetadataStore);
             throw e;
         }
+    }
+
+    private static void closeIfCloseable(MetadataStore metadataStore) throws IOException {
+        if (metadataStore instanceof Closeable closeable) {
+            closeable.close();
+        }
+    }
+
+    private static StorageProvider buildStorageProvider(AppConfig config) {
+        if (config.storage().backend() == StorageBackend.S3) {
+            S3Config s3 = config.storage().s3();
+            return new S3StorageProvider(s3.bucket(), s3.region(), s3.prefix(), s3.endpointOverride());
+        }
+        return new LocalStorageProvider(config.backup().workDir());
+    }
+
+    private static MetadataStore buildMetadataStore(AppConfig config) throws IOException {
+        if (config.metadata().backend() == MetadataBackend.DYNAMODB) {
+            DynamoDbConfig dynamodb = config.metadata().dynamodb();
+            return new DynamoDBMetadataStore(
+                    dynamodb.region(), dynamodb.sessionTable(), dynamodb.accountTable(), dynamodb.endpointOverride());
+        }
+        return new SqliteMetadataStore(config.backup().workDir().resolve(METADATA_STORE_FILENAME));
+    }
+
+    public RunLock acquireRunLock() throws IOException {
+        if (config.metadata().backend() == MetadataBackend.DYNAMODB) {
+            DynamoDbConfig dynamodb = config.metadata().dynamodb();
+            return DynamoDBLock.acquire(
+                    dynamodb.region(), dynamodb.lockTable(), dynamodb.endpointOverride(), DYNAMODB_LOCK_LEASE);
+        }
+        return PidLock.acquire(config.backup().workDir());
     }
 
     private static void checkBackupUser(AppConfig config) {
@@ -155,6 +199,25 @@ public final class AppContext {
                             + " server certificate, which does not protect against an active MITM attack."
                             + " Configure zimbraMailbox.caCertificatePath instead for production use.");
         }
+        if (config.storage().backend() == StorageBackend.S3
+                && !isHttpsOrUnset(config.storage().s3().endpointOverride())) {
+            refuseUnlessAllowInsecure(
+                    config,
+                    "storage.s3.endpointOverride does not use https://: S3 requests will be sent in cleartext."
+                            + " Configure an https:// endpoint for production use.");
+        }
+        if (config.metadata().backend() == MetadataBackend.DYNAMODB
+                && !isHttpsOrUnset(config.metadata().dynamodb().endpointOverride())) {
+            refuseUnlessAllowInsecure(
+                    config,
+                    "metadata.dynamodb.endpointOverride does not use https://: DynamoDB requests will be sent in"
+                            + " cleartext. Configure an https:// endpoint for production use.");
+        }
+    }
+
+    private static boolean isHttpsOrUnset(URI endpointOverride) {
+        return endpointOverride == null
+                || "https".equalsIgnoreCase(endpointOverride.getScheme());
     }
 
     private static void refuseUnlessAllowInsecure(AppConfig config, String message) {

--- a/app/src/main/java/io/zmbackup/app/PidLock.java
+++ b/app/src/main/java/io/zmbackup/app/PidLock.java
@@ -1,5 +1,7 @@
 package io.zmbackup.app;
 
+import io.zmbackup.core.port.LockContentionException;
+import io.zmbackup.core.port.RunLock;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -9,7 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
-public final class PidLock implements AutoCloseable {
+public final class PidLock implements RunLock {
 
     private static final String LOCK_FILENAME = "zmbackup.pid";
 
@@ -64,7 +66,7 @@ public final class PidLock implements AutoCloseable {
         }
     }
 
-    public static final class AlreadyRunningException extends IOException {
+    public static final class AlreadyRunningException extends LockContentionException {
         private AlreadyRunningException(String message) {
             super(message);
         }

--- a/app/src/main/java/io/zmbackup/app/cli/LockedExecution.java
+++ b/app/src/main/java/io/zmbackup/app/cli/LockedExecution.java
@@ -1,7 +1,8 @@
 package io.zmbackup.app.cli;
 
 import io.zmbackup.app.AppContext;
-import io.zmbackup.app.PidLock;
+import io.zmbackup.core.port.LockContentionException;
+import io.zmbackup.core.port.RunLock;
 import java.io.PrintWriter;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
@@ -11,9 +12,9 @@ final class LockedExecution {
     private LockedExecution() {}
 
     static Integer run(AppContext context, PrintWriter err, Callable<Integer> body) throws Exception {
-        try (PidLock lock = PidLock.acquire(context.config().backup().workDir())) {
+        try (RunLock lock = context.acquireRunLock()) {
             return body.call();
-        } catch (PidLock.AlreadyRunningException e) {
+        } catch (LockContentionException e) {
             err.println(e.getMessage());
             return CommandLine.ExitCode.SOFTWARE;
         }

--- a/app/src/main/java/io/zmbackup/app/cli/Main.java
+++ b/app/src/main/java/io/zmbackup/app/cli/Main.java
@@ -21,6 +21,7 @@ import picocli.CommandLine.Spec;
             HousekeepCommand.class,
             AccountsCommand.class,
             MigrateCommand.class,
+            MigrateToCloudCommand.class,
             TruncateCommand.class
         })
 public final class Main implements Callable<Integer> {

--- a/app/src/main/java/io/zmbackup/app/cli/MigrateToCloudCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/MigrateToCloudCommand.java
@@ -1,0 +1,54 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.app.AppContext;
+import io.zmbackup.core.domain.CloudMigrationResult;
+import io.zmbackup.core.service.CloudMigrationService;
+import io.zmbackup.local.LocalStorageProvider;
+import io.zmbackup.local.SqliteMetadataStore;
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+@Command(
+        name = "migrate-to-cloud",
+        description = "Move an existing Phase 1 install's backup data into the configured cloud backend.")
+public final class MigrateToCloudCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private Main parent;
+
+    @Spec
+    private CommandSpec spec;
+
+    @Option(
+            names = "--source-dir",
+            required = true,
+            description = "Phase 1 local backup directory to migrate from.")
+    private Path sourceDir;
+
+    @Option(names = "--source-db", required = true, description = "Phase 1 sessions.sqlite3 file to migrate from.")
+    private Path sourceDb;
+
+    @Override
+    public Integer call() throws Exception {
+        AppContext context = AppContext.fromConfigFile(parent.configFile());
+        PrintWriter out = spec.commandLine().getOut();
+
+        return LockedExecution.run(context, spec.commandLine().getErr(), () -> {
+            try (SqliteMetadataStore sourceMetadata = new SqliteMetadataStore(sourceDb)) {
+                LocalStorageProvider sourceStorage = new LocalStorageProvider(sourceDir);
+                CloudMigrationService migrationService = new CloudMigrationService(
+                        sourceStorage, sourceMetadata, context.storageProvider(), context.metadataStore());
+                CloudMigrationResult result = migrationService.migrate();
+                out.println("Migrated " + result.sessionsMigrated() + " backup session(s) and "
+                        + result.accountsMigrated() + " account record(s) from " + sourceDir + " into the cloud.");
+                return 0;
+            }
+        });
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/config/AppConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/AppConfig.java
@@ -3,11 +3,18 @@ package io.zmbackup.app.config;
 import java.util.Objects;
 
 public record AppConfig(
-        ZimbraLdapConfig zimbraLdap, ZimbraMailboxConfig zimbraMailbox, BackupConfig backup, boolean allowInsecure) {
+        ZimbraLdapConfig zimbraLdap,
+        ZimbraMailboxConfig zimbraMailbox,
+        BackupConfig backup,
+        StorageConfig storage,
+        MetadataConfig metadata,
+        boolean allowInsecure) {
 
     public AppConfig {
         Objects.requireNonNull(zimbraLdap, "zimbraLdap must not be null");
         Objects.requireNonNull(zimbraMailbox, "zimbraMailbox must not be null");
         Objects.requireNonNull(backup, "backup must not be null");
+        Objects.requireNonNull(storage, "storage must not be null");
+        Objects.requireNonNull(metadata, "metadata must not be null");
     }
 }

--- a/app/src/main/java/io/zmbackup/app/config/DynamoDbConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/DynamoDbConfig.java
@@ -1,0 +1,19 @@
+package io.zmbackup.app.config;
+
+import java.net.URI;
+import java.util.Objects;
+
+public record DynamoDbConfig(
+        String region, String sessionTable, String accountTable, String lockTable, URI endpointOverride) {
+
+    public static final String DEFAULT_SESSION_TABLE = "zmbackup_session";
+    public static final String DEFAULT_ACCOUNT_TABLE = "zmbackup_account";
+    public static final String DEFAULT_LOCK_TABLE = "zmbackup_lock";
+
+    public DynamoDbConfig {
+        Objects.requireNonNull(region, "region must not be null");
+        Objects.requireNonNull(sessionTable, "sessionTable must not be null");
+        Objects.requireNonNull(accountTable, "accountTable must not be null");
+        Objects.requireNonNull(lockTable, "lockTable must not be null");
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/config/MetadataBackend.java
+++ b/app/src/main/java/io/zmbackup/app/config/MetadataBackend.java
@@ -1,0 +1,6 @@
+package io.zmbackup.app.config;
+
+public enum MetadataBackend {
+    SQLITE,
+    DYNAMODB
+}

--- a/app/src/main/java/io/zmbackup/app/config/MetadataConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/MetadataConfig.java
@@ -1,0 +1,13 @@
+package io.zmbackup.app.config;
+
+import java.util.Objects;
+
+public record MetadataConfig(MetadataBackend backend, DynamoDbConfig dynamodb) {
+
+    public MetadataConfig {
+        Objects.requireNonNull(backend, "backend must not be null");
+        if (backend == MetadataBackend.DYNAMODB) {
+            Objects.requireNonNull(dynamodb, "metadata.dynamodb must be set when metadata.backend is dynamodb");
+        }
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/config/S3Config.java
+++ b/app/src/main/java/io/zmbackup/app/config/S3Config.java
@@ -1,0 +1,15 @@
+package io.zmbackup.app.config;
+
+import java.net.URI;
+import java.util.Objects;
+
+public record S3Config(String bucket, String region, String prefix, URI endpointOverride) {
+
+    public static final String DEFAULT_PREFIX = "sessions/";
+
+    public S3Config {
+        Objects.requireNonNull(bucket, "bucket must not be null");
+        Objects.requireNonNull(region, "region must not be null");
+        Objects.requireNonNull(prefix, "prefix must not be null");
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/config/StorageBackend.java
+++ b/app/src/main/java/io/zmbackup/app/config/StorageBackend.java
@@ -1,0 +1,6 @@
+package io.zmbackup.app.config;
+
+public enum StorageBackend {
+    LOCAL,
+    S3
+}

--- a/app/src/main/java/io/zmbackup/app/config/StorageConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/StorageConfig.java
@@ -1,0 +1,13 @@
+package io.zmbackup.app.config;
+
+import java.util.Objects;
+
+public record StorageConfig(StorageBackend backend, S3Config s3) {
+
+    public StorageConfig {
+        Objects.requireNonNull(backend, "backend must not be null");
+        if (backend == StorageBackend.S3) {
+            Objects.requireNonNull(s3, "storage.s3 must be set when storage.backend is s3");
+        }
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
+++ b/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
@@ -3,6 +3,7 @@ package io.zmbackup.app.config;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -47,7 +48,39 @@ public final class YamlConfigLoader {
                 parseZimbraLdap(root),
                 parseZimbraMailbox(root),
                 parseBackup(root),
+                parseStorage(root),
+                parseMetadata(root),
                 optionalBoolean(root, "allowInsecure", false));
+    }
+
+    private static StorageConfig parseStorage(Map<String, Object> root) {
+        StorageBackend backend = optionalEnum(root, "storage.backend", StorageBackend.class, StorageBackend.LOCAL);
+        return new StorageConfig(backend, backend == StorageBackend.S3 ? parseS3(root) : null);
+    }
+
+    private static S3Config parseS3(Map<String, Object> root) {
+        return new S3Config(
+                requireString(root, "storage.s3.bucket"),
+                requireString(root, "storage.s3.region"),
+                optionalStringDefault(root, "storage.s3.prefix", S3Config.DEFAULT_PREFIX),
+                optionalUri(root, "storage.s3.endpointOverride"));
+    }
+
+    private static MetadataConfig parseMetadata(Map<String, Object> root) {
+        MetadataBackend backend =
+                optionalEnum(root, "metadata.backend", MetadataBackend.class, MetadataBackend.SQLITE);
+        return new MetadataConfig(backend, backend == MetadataBackend.DYNAMODB ? parseDynamoDb(root) : null);
+    }
+
+    private static DynamoDbConfig parseDynamoDb(Map<String, Object> root) {
+        return new DynamoDbConfig(
+                requireString(root, "metadata.dynamodb.region"),
+                optionalStringDefault(
+                        root, "metadata.dynamodb.sessionTable", DynamoDbConfig.DEFAULT_SESSION_TABLE),
+                optionalStringDefault(
+                        root, "metadata.dynamodb.accountTable", DynamoDbConfig.DEFAULT_ACCOUNT_TABLE),
+                optionalStringDefault(root, "metadata.dynamodb.lockTable", DynamoDbConfig.DEFAULT_LOCK_TABLE),
+                optionalUri(root, "metadata.dynamodb.endpointOverride"));
     }
 
     private static ZimbraLdapConfig parseZimbraLdap(Map<String, Object> root) {
@@ -135,6 +168,23 @@ public final class YamlConfigLoader {
         return value == null ? null : value.toString();
     }
 
+    private static String optionalStringDefault(Map<String, Object> root, String dottedPath, String defaultValue) {
+        String value = optionalString(root, dottedPath);
+        return value == null ? defaultValue : value;
+    }
+
+    private static URI optionalUri(Map<String, Object> root, String dottedPath) {
+        String value = optionalString(root, dottedPath);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return URI.create(value);
+        } catch (IllegalArgumentException e) {
+            throw new ConfigException("Invalid URI at '" + dottedPath + "': " + value, e);
+        }
+    }
+
     private static boolean optionalBoolean(Map<String, Object> root, String dottedPath, boolean defaultValue) {
         Object value = get(root, dottedPath);
         if (value == null) {
@@ -177,12 +227,17 @@ public final class YamlConfigLoader {
 
     private static EmailNotifyLevel optionalEmailNotifyLevel(
             Map<String, Object> root, String dottedPath, EmailNotifyLevel defaultValue) {
+        return optionalEnum(root, dottedPath, EmailNotifyLevel.class, defaultValue);
+    }
+
+    private static <E extends Enum<E>> E optionalEnum(
+            Map<String, Object> root, String dottedPath, Class<E> enumType, E defaultValue) {
         Object value = get(root, dottedPath);
         if (value == null) {
             return defaultValue;
         }
         try {
-            return EmailNotifyLevel.valueOf(value.toString().toUpperCase(Locale.ROOT));
+            return Enum.valueOf(enumType, value.toString().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
             throw new ConfigException("Invalid value for '" + dottedPath + "': " + value, e);
         }

--- a/app/src/test/java/io/zmbackup/app/AppContextTest.java
+++ b/app/src/test/java/io/zmbackup/app/AppContextTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -40,6 +41,12 @@ class AppContextTest {
     private static final StorageConfig LOCAL_STORAGE = new StorageConfig(StorageBackend.LOCAL, null);
 
     private static final MetadataConfig SQLITE_METADATA = new MetadataConfig(MetadataBackend.SQLITE, null);
+
+    @BeforeAll
+    static void setUpCredentials() {
+        System.setProperty("aws.accessKeyId", "test");
+        System.setProperty("aws.secretAccessKey", "test");
+    }
 
     @TempDir
     Path tempDir;

--- a/app/src/test/java/io/zmbackup/app/AppContextTest.java
+++ b/app/src/test/java/io/zmbackup/app/AppContextTest.java
@@ -5,24 +5,41 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.zmbackup.app.config.AppConfig;
 import io.zmbackup.app.config.BackupConfig;
 import io.zmbackup.app.config.ConfigException;
+import io.zmbackup.app.config.DynamoDbConfig;
 import io.zmbackup.app.config.EmailNotifyConfig;
 import io.zmbackup.app.config.EmailNotifyLevel;
+import io.zmbackup.app.config.MetadataBackend;
+import io.zmbackup.app.config.MetadataConfig;
+import io.zmbackup.app.config.S3Config;
+import io.zmbackup.app.config.StorageBackend;
+import io.zmbackup.app.config.StorageConfig;
 import io.zmbackup.app.config.ZimbraLdapConfig;
 import io.zmbackup.app.config.ZimbraMailboxConfig;
+import io.zmbackup.aws.DynamoDBLock;
+import io.zmbackup.aws.DynamoDBMetadataStore;
+import io.zmbackup.aws.S3StorageProvider;
+import io.zmbackup.core.port.RunLock;
 import io.zmbackup.local.LocalStorageProvider;
 import io.zmbackup.local.SqliteMetadataStore;
 import io.zmbackup.zimbra.UnboundIdLdapAdapter;
 import io.zmbackup.zimbra.ZimbraRestMailboxExporter;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class AppContextTest {
+
+    private static final StorageConfig LOCAL_STORAGE = new StorageConfig(StorageBackend.LOCAL, null);
+
+    private static final MetadataConfig SQLITE_METADATA = new MetadataConfig(MetadataBackend.SQLITE, null);
 
     @TempDir
     Path tempDir;
@@ -97,6 +114,8 @@ class AppContextTest {
                         30,
                         true,
                         new EmailNotifyConfig(EmailNotifyLevel.NONE, null, null)),
+                LOCAL_STORAGE,
+                SQLITE_METADATA,
                 false);
 
         AppContext context = new AppContext(config);
@@ -149,6 +168,80 @@ class AppContextTest {
         assertEquals(config, context.config());
     }
 
+    @Test
+    void wiresS3StorageProviderAndDynamoDBLockWhenCloudBackendsAreConfigured() throws Exception {
+        WireMockServer wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+        try {
+            wireMockServer.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post(
+                            com.github.tomakehurst.wiremock.client.WireMock.anyUrl())
+                    .withHeader(
+                            "X-Amz-Target",
+                            com.github.tomakehurst.wiremock.client.WireMock.equalTo("DynamoDB_20120810.PutItem"))
+                    .willReturn(com.github.tomakehurst.wiremock.client.WireMock.aResponse().withStatus(200)));
+            wireMockServer.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post(
+                            com.github.tomakehurst.wiremock.client.WireMock.anyUrl())
+                    .withHeader(
+                            "X-Amz-Target",
+                            com.github.tomakehurst.wiremock.client.WireMock.equalTo("DynamoDB_20120810.DeleteItem"))
+                    .willReturn(com.github.tomakehurst.wiremock.client.WireMock.aResponse().withStatus(200)));
+            AppConfig config = configWithCloudBackends(tempDir, URI.create(wireMockServer.baseUrl()), true);
+
+            AppContext context = new AppContext(config);
+
+            assertInstanceOf(S3StorageProvider.class, context.storageProvider());
+            assertInstanceOf(DynamoDBMetadataStore.class, context.metadataStore());
+            try (RunLock lock = context.acquireRunLock()) {
+                assertInstanceOf(DynamoDBLock.class, lock);
+            }
+        } finally {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    void constructorRefusesInsecureS3EndpointOverrideWithoutAllowInsecure() {
+        AppConfig config = configWithCloudBackends(tempDir, URI.create("http://127.0.0.1:1"), false);
+
+        ConfigException exception = assertThrows(ConfigException.class, () -> new AppContext(config));
+
+        assertTrue(exception.getMessage().startsWith("storage.s3.endpointOverride"));
+    }
+
+    private static AppConfig configWithCloudBackends(Path workDir, URI endpointOverride, boolean allowInsecure) {
+        return new AppConfig(
+                new ZimbraLdapConfig(
+                        "ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true, null, false, 600),
+                new ZimbraMailboxConfig(
+                        System.getProperty("user.name"),
+                        true,
+                        "https://127.0.0.1:7071",
+                        "zimbra",
+                        "secret",
+                        null,
+                        false),
+                new BackupConfig(
+                        workDir,
+                        workDir.resolve("zmbackup.log"),
+                        workDir.resolve("blockedlist.conf"),
+                        3,
+                        30,
+                        true,
+                        new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com")),
+                new StorageConfig(
+                        StorageBackend.S3,
+                        new S3Config("test-bucket", "us-east-1", S3Config.DEFAULT_PREFIX, endpointOverride)),
+                new MetadataConfig(
+                        MetadataBackend.DYNAMODB,
+                        new DynamoDbConfig(
+                                "us-east-1",
+                                DynamoDbConfig.DEFAULT_SESSION_TABLE,
+                                DynamoDbConfig.DEFAULT_ACCOUNT_TABLE,
+                                DynamoDbConfig.DEFAULT_LOCK_TABLE,
+                                endpointOverride)),
+                allowInsecure);
+    }
+
     private static AppConfig configWithWorkDir(Path workDir) {
         return configWithWorkDir(workDir, System.getProperty("user.name"));
     }
@@ -166,6 +259,8 @@ class AppContextTest {
                         30,
                         true,
                         new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com")),
+                LOCAL_STORAGE,
+                SQLITE_METADATA,
                 false);
     }
 
@@ -195,6 +290,8 @@ class AppContextTest {
                         30,
                         true,
                         new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com")),
+                LOCAL_STORAGE,
+                SQLITE_METADATA,
                 allowInsecure);
     }
 
@@ -218,6 +315,8 @@ class AppContextTest {
                         30,
                         true,
                         new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com")),
+                LOCAL_STORAGE,
+                SQLITE_METADATA,
                 allowInsecure);
     }
 }

--- a/app/src/test/java/io/zmbackup/app/cli/MigrateToCloudCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MigrateToCloudCommandTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -36,6 +37,12 @@ class MigrateToCloudCommandTest {
     Path tempDir;
 
     private WireMockServer wireMockServer;
+
+    @BeforeAll
+    static void setUpCredentials() {
+        System.setProperty("aws.accessKeyId", "test");
+        System.setProperty("aws.secretAccessKey", "test");
+    }
 
     @BeforeEach
     void setUp() {

--- a/app/src/test/java/io/zmbackup/app/cli/MigrateToCloudCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MigrateToCloudCommandTest.java
@@ -1,0 +1,161 @@
+package io.zmbackup.app.cli;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import io.zmbackup.local.LocalStorageProvider;
+import io.zmbackup.local.SqliteMetadataStore;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+class MigrateToCloudCommandTest {
+
+    @TempDir
+    Path tempDir;
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+        wireMockServer.stubFor(post(anyUrl())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.PutItem"))
+                .willReturn(jsonResponse("{}")));
+        wireMockServer.stubFor(post(anyUrl())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.DeleteItem"))
+                .willReturn(jsonResponse("{}")));
+        wireMockServer.stubFor(post(anyUrl())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Query"))
+                .willReturn(jsonResponse("{\"Items\":[]}")));
+        wireMockServer.stubFor(put(urlPathMatching("/.*")).willReturn(aResponse().withStatus(200)));
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void migratesLocalPhase1DataIntoTheConfiguredCloudBackend() throws Exception {
+        Path sourceDir = tempDir.resolve("source-workdir");
+        Files.createDirectories(sourceDir);
+        Path sourceDb = sourceDir.resolve("sessions.sqlite3");
+        seedSource(sourceDir, sourceDb);
+
+        Path configFile = writeCloudConfig();
+        StringWriter out = new StringWriter();
+        CommandLine cmd = Main.commandLine();
+        cmd.setOut(new PrintWriter(out));
+        cmd.setErr(new PrintWriter(new StringWriter()));
+
+        int exitCode = cmd.execute(
+                "--config",
+                configFile.toString(),
+                "migrate-to-cloud",
+                "--source-dir",
+                sourceDir.toString(),
+                "--source-db",
+                sourceDb.toString());
+
+        assertEquals(0, exitCode);
+        assertTrue(out.toString().contains("Migrated 1 backup session(s) and 1 account record(s)"));
+        wireMockServer.verify(anyRequestedFor(anyUrl())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.PutItem")));
+        wireMockServer.verify(anyRequestedFor(urlPathMatching(".*alice%40example\\.com\\.tgz")));
+    }
+
+    private void seedSource(Path sourceDir, Path sourceDb) throws IOException {
+        try (SqliteMetadataStore metadataStore = new SqliteMetadataStore(sourceDb)) {
+            LocalStorageProvider storageProvider = new LocalStorageProvider(sourceDir);
+            metadataStore.save(new BackupSession(
+                    "mbox-20260101120000",
+                    BackupType.MAILBOX,
+                    SessionStatus.FINISHED,
+                    Instant.parse("2026-01-01T12:00:00Z"),
+                    Instant.parse("2026-01-01T12:05:00Z"),
+                    "1K"));
+            try (var destination = storageProvider.openWrite("mbox-20260101120000", "alice@example.com", "tgz")) {
+                destination.write("tgz-content".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            }
+            metadataStore.recordAccountBackup(new BackupAccountRecord(
+                    null,
+                    "mbox-20260101120000",
+                    "alice@example.com",
+                    "1K",
+                    Instant.parse("2026-01-01T12:00:00Z"),
+                    Instant.parse("2026-01-01T12:05:00Z")));
+        }
+    }
+
+    private Path writeCloudConfig() throws IOException {
+        Path configFile = tempDir.resolve("zmbackup.yaml");
+        Files.writeString(
+                configFile,
+                """
+                zimbraLdap:
+                  url: ldap://127.0.0.1:389
+                  bindDn: uid=zimbra,cn=admins,cn=zimbra
+                  bindPassword: secret
+                zimbraMailbox:
+                  backupUser: %s
+                  restBaseUrl: https://127.0.0.1:7071
+                  adminUser: zimbra
+                  adminPassword: secret
+                backup:
+                  workDir: %s
+                  logFile: %s
+                  blockedListFile: %s
+                  emailNotify:
+                    recipient: admin@example.com
+                    sender: root@example.com
+                storage:
+                  backend: s3
+                  s3:
+                    bucket: test-bucket
+                    region: us-east-1
+                    prefix: sessions/
+                    endpointOverride: %s
+                metadata:
+                  backend: dynamodb
+                  dynamodb:
+                    region: us-east-1
+                    endpointOverride: %s
+                allowInsecure: true
+                """
+                        .formatted(
+                                System.getProperty("user.name"),
+                                tempDir,
+                                tempDir.resolve("zmbackup.log"),
+                                tempDir.resolve("blockedlist.conf"),
+                                wireMockServer.baseUrl(),
+                                wireMockServer.baseUrl()));
+        return configFile;
+    }
+
+    private static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder jsonResponse(String body) {
+        return aResponse().withStatus(200).withHeader("Content-Type", "application/x-amz-json-1.0").withBody(body);
+    }
+}

--- a/app/src/test/java/io/zmbackup/app/config/AppConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/AppConfigTest.java
@@ -24,24 +24,49 @@ class AppConfigTest {
             true,
             new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com"));
 
+    private static final StorageConfig STORAGE_CONFIG = new StorageConfig(StorageBackend.LOCAL, null);
+
+    private static final MetadataConfig METADATA_CONFIG = new MetadataConfig(MetadataBackend.SQLITE, null);
+
     @Test
     void rejectsNullZimbraLdap() {
-        assertThrows(NullPointerException.class, () -> new AppConfig(null, MAILBOX_CONFIG, BACKUP_CONFIG, false));
+        assertThrows(
+                NullPointerException.class,
+                () -> new AppConfig(null, MAILBOX_CONFIG, BACKUP_CONFIG, STORAGE_CONFIG, METADATA_CONFIG, false));
     }
 
     @Test
     void rejectsNullZimbraMailbox() {
-        assertThrows(NullPointerException.class, () -> new AppConfig(LDAP_CONFIG, null, BACKUP_CONFIG, false));
+        assertThrows(
+                NullPointerException.class,
+                () -> new AppConfig(LDAP_CONFIG, null, BACKUP_CONFIG, STORAGE_CONFIG, METADATA_CONFIG, false));
     }
 
     @Test
     void rejectsNullBackup() {
-        assertThrows(NullPointerException.class, () -> new AppConfig(LDAP_CONFIG, MAILBOX_CONFIG, null, false));
+        assertThrows(
+                NullPointerException.class,
+                () -> new AppConfig(LDAP_CONFIG, MAILBOX_CONFIG, null, STORAGE_CONFIG, METADATA_CONFIG, false));
+    }
+
+    @Test
+    void rejectsNullStorage() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new AppConfig(LDAP_CONFIG, MAILBOX_CONFIG, BACKUP_CONFIG, null, METADATA_CONFIG, false));
+    }
+
+    @Test
+    void rejectsNullMetadata() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new AppConfig(LDAP_CONFIG, MAILBOX_CONFIG, BACKUP_CONFIG, STORAGE_CONFIG, null, false));
     }
 
     @Test
     void toStringDoesNotLeakNestedSecrets() {
-        AppConfig config = new AppConfig(LDAP_CONFIG, MAILBOX_CONFIG, BACKUP_CONFIG, false);
+        AppConfig config = new AppConfig(
+                LDAP_CONFIG, MAILBOX_CONFIG, BACKUP_CONFIG, STORAGE_CONFIG, METADATA_CONFIG, false);
 
         String result = config.toString();
 

--- a/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,21 @@ class YamlConfigLoaderTest {
                 level: ERROR
                 recipient: admin@example.com
                 sender: root@example.com
+            storage:
+              backend: s3
+              s3:
+                bucket: my-zmbackup-bucket
+                region: us-east-1
+                prefix: custom-prefix/
+                endpointOverride: https://s3.example.com
+            metadata:
+              backend: dynamodb
+              dynamodb:
+                region: us-west-2
+                sessionTable: custom_session
+                accountTable: custom_account
+                lockTable: custom_lock
+                endpointOverride: https://dynamodb.example.com
             allowInsecure: true
             """;
 
@@ -99,6 +115,19 @@ class YamlConfigLoaderTest {
         assertEquals("admin@example.com", config.backup().emailNotify().recipient());
         assertEquals("root@example.com", config.backup().emailNotify().sender());
         assertEquals(true, config.allowInsecure());
+
+        assertEquals(StorageBackend.S3, config.storage().backend());
+        assertEquals("my-zmbackup-bucket", config.storage().s3().bucket());
+        assertEquals("us-east-1", config.storage().s3().region());
+        assertEquals("custom-prefix/", config.storage().s3().prefix());
+        assertEquals(URI.create("https://s3.example.com"), config.storage().s3().endpointOverride());
+
+        assertEquals(MetadataBackend.DYNAMODB, config.metadata().backend());
+        assertEquals("us-west-2", config.metadata().dynamodb().region());
+        assertEquals("custom_session", config.metadata().dynamodb().sessionTable());
+        assertEquals("custom_account", config.metadata().dynamodb().accountTable());
+        assertEquals("custom_lock", config.metadata().dynamodb().lockTable());
+        assertEquals(URI.create("https://dynamodb.example.com"), config.metadata().dynamodb().endpointOverride());
     }
 
     private static void assertFalseSsl(AppConfig config) {
@@ -122,6 +151,10 @@ class YamlConfigLoaderTest {
         assertTrue(config.backup().lockBackup());
         assertEquals(EmailNotifyLevel.ALL, config.backup().emailNotify().level());
         assertEquals(false, config.allowInsecure());
+        assertEquals(StorageBackend.LOCAL, config.storage().backend());
+        assertEquals(null, config.storage().s3());
+        assertEquals(MetadataBackend.SQLITE, config.metadata().backend());
+        assertEquals(null, config.metadata().dynamodb());
     }
 
     @Test
@@ -344,5 +377,70 @@ class YamlConfigLoaderTest {
         String yaml = "zimbraLdap: !!java.net.URL [\"http://example.com\"]";
 
         assertThrows(YAMLException.class, () -> YamlConfigLoader.load(new StringReader(yaml)));
+    }
+
+    @Test
+    void s3BackendWithoutBucketThrowsConfigException() {
+        String yaml = MINIMAL_YAML
+                + """
+                storage:
+                  backend: s3
+                  s3:
+                    region: us-east-1
+                """;
+
+        ConfigException exception =
+                assertThrows(ConfigException.class, () -> YamlConfigLoader.load(new StringReader(yaml)));
+        assertTrue(exception.getMessage().contains("storage.s3.bucket"));
+    }
+
+    @Test
+    void dynamodbBackendWithoutRegionThrowsConfigException() {
+        String yaml = MINIMAL_YAML
+                + """
+                metadata:
+                  backend: dynamodb
+                """;
+
+        ConfigException exception =
+                assertThrows(ConfigException.class, () -> YamlConfigLoader.load(new StringReader(yaml)));
+        assertTrue(exception.getMessage().contains("metadata.dynamodb.region"));
+    }
+
+    @Test
+    void invalidStorageBackendThrowsConfigException() {
+        String yaml = MINIMAL_YAML
+                + """
+                storage:
+                  backend: nfs
+                """;
+
+        ConfigException exception =
+                assertThrows(ConfigException.class, () -> YamlConfigLoader.load(new StringReader(yaml)));
+        assertTrue(exception.getMessage().contains("storage.backend"));
+    }
+
+    @Test
+    void s3BackendAppliesDefaultPrefixAndDynamoDbAppliesDefaultTableNames() {
+        String yaml = MINIMAL_YAML
+                + """
+                storage:
+                  backend: s3
+                  s3:
+                    bucket: my-zmbackup-bucket
+                    region: us-east-1
+                metadata:
+                  backend: dynamodb
+                  dynamodb:
+                    region: us-east-1
+                """;
+
+        AppConfig config = YamlConfigLoader.load(new StringReader(yaml));
+
+        assertEquals(S3Config.DEFAULT_PREFIX, config.storage().s3().prefix());
+        assertEquals(null, config.storage().s3().endpointOverride());
+        assertEquals(DynamoDbConfig.DEFAULT_SESSION_TABLE, config.metadata().dynamodb().sessionTable());
+        assertEquals(DynamoDbConfig.DEFAULT_ACCOUNT_TABLE, config.metadata().dynamodb().accountTable());
+        assertEquals(DynamoDbConfig.DEFAULT_LOCK_TABLE, config.metadata().dynamodb().lockTable());
     }
 }

--- a/aws/build.gradle.kts
+++ b/aws/build.gradle.kts
@@ -1,0 +1,6 @@
+dependencies {
+    implementation(project(":core"))
+    implementation(libs.aws.sdk.s3)
+    implementation(libs.aws.sdk.dynamodb)
+    testImplementation(libs.wiremock)
+}

--- a/aws/src/main/java/io/zmbackup/aws/DynamoDBLock.java
+++ b/aws/src/main/java/io/zmbackup/aws/DynamoDBLock.java
@@ -1,0 +1,110 @@
+package io.zmbackup.aws;
+
+import io.zmbackup.core.port.LockContentionException;
+import io.zmbackup.core.port.RunLock;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+
+public final class DynamoDBLock implements RunLock {
+
+    private static final String LOCK_ID = "zmbackup";
+    private static final Logger LOG = Logger.getLogger(DynamoDBLock.class.getName());
+
+    private final DynamoDbClient client;
+    private final String lockTable;
+
+    private DynamoDBLock(DynamoDbClient client, String lockTable) {
+        this.client = client;
+        this.lockTable = lockTable;
+    }
+
+    public static DynamoDBLock acquire(String region, String lockTable, URI endpointOverride, Duration leaseDuration)
+            throws IOException {
+        DynamoDbClientBuilder builder = DynamoDbClient.builder().region(Region.of(region));
+        if (endpointOverride != null) {
+            builder.endpointOverride(endpointOverride);
+        }
+        DynamoDbClient client = builder.build();
+        Instant now = Instant.now();
+        Instant expiresAt = now.plus(leaseDuration);
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("lockId", AttributeValue.fromS(LOCK_ID));
+        item.put("holder", AttributeValue.fromS(holderDescription()));
+        item.put("expiresAt", AttributeValue.fromS(expiresAt.toString()));
+        item.put("expiresAtEpochSeconds", AttributeValue.fromN(Long.toString(expiresAt.getEpochSecond())));
+        try {
+            client.putItem(PutItemRequest.builder()
+                    .tableName(lockTable)
+                    .item(item)
+                    .conditionExpression("attribute_not_exists(lockId) OR expiresAt < :now")
+                    .expressionAttributeValues(Map.of(":now", AttributeValue.fromS(now.toString())))
+                    .build());
+            return new DynamoDBLock(client, lockTable);
+        } catch (ConditionalCheckFailedException e) {
+            String holder = currentHolder(client, lockTable);
+            client.close();
+            throw new LockContentionException(
+                    "Another zmbackup process (" + holder + ") is already running against " + lockTable);
+        } catch (SdkException e) {
+            client.close();
+            throw new IOException(e);
+        }
+    }
+
+    private static String currentHolder(DynamoDbClient client, String lockTable) {
+        try {
+            GetItemResponse response = client.getItem(GetItemRequest.builder()
+                    .tableName(lockTable)
+                    .key(Map.of("lockId", AttributeValue.fromS(LOCK_ID)))
+                    .build());
+            if (response.hasItem() && response.item().containsKey("holder")) {
+                return response.item().get("holder").s();
+            }
+        } catch (SdkException e) {
+            LOG.log(Level.WARNING, "Failed to read current lock holder from " + lockTable, e);
+        }
+        return "unknown";
+    }
+
+    private static String holderDescription() {
+        String hostname;
+        try {
+            hostname = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            hostname = "unknown-host";
+        }
+        return hostname + ":" + ProcessHandle.current().pid();
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            client.deleteItem(DeleteItemRequest.builder()
+                    .tableName(lockTable)
+                    .key(Map.of("lockId", AttributeValue.fromS(LOCK_ID)))
+                    .build());
+        } catch (SdkException e) {
+            throw new IOException(e);
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/aws/src/main/java/io/zmbackup/aws/DynamoDBMetadataStore.java
+++ b/aws/src/main/java/io/zmbackup/aws/DynamoDBMetadataStore.java
@@ -1,0 +1,353 @@
+package io.zmbackup.aws;
+
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import io.zmbackup.core.port.MetadataStore;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+
+public final class DynamoDBMetadataStore implements MetadataStore {
+
+    static final String SESSION_ID_INDEX = "sessionId-index";
+
+    private static final int BATCH_GET_SIZE = 100;
+
+    private final DynamoDbClient client;
+    private final String sessionTable;
+    private final String accountTable;
+
+    public DynamoDBMetadataStore(String region, String sessionTable, String accountTable, URI endpointOverride) {
+        this.sessionTable = Objects.requireNonNull(sessionTable, "sessionTable must not be null");
+        this.accountTable = Objects.requireNonNull(accountTable, "accountTable must not be null");
+        DynamoDbClientBuilder builder =
+                DynamoDbClient.builder().region(Region.of(Objects.requireNonNull(region, "region must not be null")));
+        if (endpointOverride != null) {
+            builder.endpointOverride(endpointOverride);
+        }
+        this.client = builder.build();
+    }
+
+    @Override
+    public void save(BackupSession session) throws IOException {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("sessionId", AttributeValue.fromS(session.sessionId()));
+        item.put("type", AttributeValue.fromS(session.type().sessionPrefix()));
+        item.put("status", AttributeValue.fromS(session.status().dbValue()));
+        item.put("initialDate", AttributeValue.fromS(toDb(session.startedAt())));
+        if (session.completedAt() != null) {
+            item.put("conclusionDate", AttributeValue.fromS(toDb(session.completedAt())));
+        }
+        if (session.size() != null) {
+            item.put("size", AttributeValue.fromS(session.size()));
+        }
+        try {
+            client.putItem(PutItemRequest.builder().tableName(sessionTable).item(item).build());
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public Optional<BackupSession> findSession(String sessionId) throws IOException {
+        try {
+            GetItemResponse response = client.getItem(GetItemRequest.builder()
+                    .tableName(sessionTable)
+                    .key(Map.of("sessionId", AttributeValue.fromS(sessionId)))
+                    .build());
+            return response.hasItem() ? Optional.of(mapSession(response.item())) : Optional.empty();
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public List<BackupSession> listSessions() throws IOException {
+        try {
+            List<BackupSession> sessions = new ArrayList<>();
+            Map<String, AttributeValue> lastKey = null;
+            do {
+                ScanRequest.Builder requestBuilder = ScanRequest.builder().tableName(sessionTable);
+                if (lastKey != null) {
+                    requestBuilder.exclusiveStartKey(lastKey);
+                }
+                ScanResponse response = client.scan(requestBuilder.build());
+                for (Map<String, AttributeValue> item : response.items()) {
+                    sessions.add(mapSession(item));
+                }
+                lastKey = response.lastEvaluatedKey();
+            } while (lastKey != null && !lastKey.isEmpty());
+            return sessions;
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public List<BackupSession> findSessionsCompletedBefore(Instant cutoff) throws IOException {
+        try {
+            List<BackupSession> sessions = new ArrayList<>();
+            Map<String, AttributeValue> lastKey = null;
+            do {
+                ScanRequest.Builder requestBuilder = ScanRequest.builder()
+                        .tableName(sessionTable)
+                        .filterExpression("attribute_exists(conclusionDate) AND conclusionDate < :cutoff")
+                        .expressionAttributeValues(Map.of(":cutoff", AttributeValue.fromS(toDb(cutoff))));
+                if (lastKey != null) {
+                    requestBuilder.exclusiveStartKey(lastKey);
+                }
+                ScanResponse response = client.scan(requestBuilder.build());
+                for (Map<String, AttributeValue> item : response.items()) {
+                    sessions.add(mapSession(item));
+                }
+                lastKey = response.lastEvaluatedKey();
+            } while (lastKey != null && !lastKey.isEmpty());
+            return sessions;
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void deleteSession(String sessionId) throws IOException {
+        for (BackupAccountRecord record : findAccountsForSession(sessionId)) {
+            deleteAccountItem(record.email(), sessionId);
+        }
+        deleteSessionItem(sessionId);
+    }
+
+    @Override
+    public int truncate() throws IOException {
+        List<BackupSession> sessions = listSessions();
+        for (BackupSession session : sessions) {
+            deleteSession(session.sessionId());
+        }
+        return sessions.size();
+    }
+
+    @Override
+    public void recordAccountBackup(BackupAccountRecord record) throws IOException {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("email", AttributeValue.fromS(record.email()));
+        item.put("sessionId", AttributeValue.fromS(record.sessionId()));
+        item.put("accountSize", AttributeValue.fromS(record.size()));
+        item.put("initialDate", AttributeValue.fromS(toDb(record.startedAt())));
+        if (record.completedAt() != null) {
+            item.put("conclusionDate", AttributeValue.fromS(toDb(record.completedAt())));
+        }
+        try {
+            client.putItem(PutItemRequest.builder().tableName(accountTable).item(item).build());
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public List<BackupAccountRecord> findAccountsForSession(String sessionId) throws IOException {
+        try {
+            List<BackupAccountRecord> records = new ArrayList<>();
+            Map<String, AttributeValue> lastKey = null;
+            do {
+                QueryRequest.Builder requestBuilder = QueryRequest.builder()
+                        .tableName(accountTable)
+                        .indexName(SESSION_ID_INDEX)
+                        .keyConditionExpression("sessionId = :sessionId")
+                        .expressionAttributeValues(Map.of(":sessionId", AttributeValue.fromS(sessionId)));
+                if (lastKey != null) {
+                    requestBuilder.exclusiveStartKey(lastKey);
+                }
+                QueryResponse response = client.query(requestBuilder.build());
+                for (Map<String, AttributeValue> item : response.items()) {
+                    records.add(mapAccount(item));
+                }
+                lastKey = response.lastEvaluatedKey();
+            } while (lastKey != null && !lastKey.isEmpty());
+            return records;
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public Optional<Instant> lastSuccessfulBackupTime(String email) throws IOException {
+        List<BackupAccountRecord> candidates = queryAccountsByEmail(email);
+        Set<String> mailboxPrefixes = new HashSet<>(BackupType.mailboxSessionPrefixes());
+        List<BackupAccountRecord> mailboxCandidates = new ArrayList<>();
+        for (BackupAccountRecord candidate : candidates) {
+            if (mailboxPrefixes.contains(sessionPrefixOf(candidate.sessionId()))) {
+                mailboxCandidates.add(candidate);
+            }
+        }
+        if (mailboxCandidates.isEmpty()) {
+            return Optional.empty();
+        }
+        Set<String> sessionIds = new HashSet<>();
+        for (BackupAccountRecord candidate : mailboxCandidates) {
+            sessionIds.add(candidate.sessionId());
+        }
+        Set<String> nonInProgress = nonInProgressSessionIds(sessionIds);
+        Instant latest = null;
+        for (BackupAccountRecord candidate : mailboxCandidates) {
+            if (!nonInProgress.contains(candidate.sessionId()) || candidate.completedAt() == null) {
+                continue;
+            }
+            if (latest == null || candidate.completedAt().isAfter(latest)) {
+                latest = candidate.completedAt();
+            }
+        }
+        return Optional.ofNullable(latest);
+    }
+
+    @Override
+    public boolean backedUpSince(String identifier, Instant since) throws IOException {
+        for (BackupAccountRecord record : queryAccountsByEmail(identifier)) {
+            if (record.completedAt() != null && record.completedAt().isAfter(since)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String sessionPrefixOf(String sessionId) {
+        int dash = sessionId.indexOf('-');
+        return dash < 0 ? sessionId : sessionId.substring(0, dash);
+    }
+
+    private List<BackupAccountRecord> queryAccountsByEmail(String email) throws IOException {
+        try {
+            List<BackupAccountRecord> records = new ArrayList<>();
+            Map<String, AttributeValue> lastKey = null;
+            do {
+                QueryRequest.Builder requestBuilder = QueryRequest.builder()
+                        .tableName(accountTable)
+                        .keyConditionExpression("email = :email")
+                        .expressionAttributeValues(Map.of(":email", AttributeValue.fromS(email)));
+                if (lastKey != null) {
+                    requestBuilder.exclusiveStartKey(lastKey);
+                }
+                QueryResponse response = client.query(requestBuilder.build());
+                for (Map<String, AttributeValue> item : response.items()) {
+                    records.add(mapAccount(item));
+                }
+                lastKey = response.lastEvaluatedKey();
+            } while (lastKey != null && !lastKey.isEmpty());
+            return records;
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private Set<String> nonInProgressSessionIds(Set<String> sessionIds) throws IOException {
+        if (sessionIds.isEmpty()) {
+            return Set.of();
+        }
+        Set<String> result = new HashSet<>();
+        List<String> ids = new ArrayList<>(sessionIds);
+        for (int start = 0; start < ids.size(); start += BATCH_GET_SIZE) {
+            result.addAll(batchGetNonInProgress(ids.subList(start, Math.min(start + BATCH_GET_SIZE, ids.size()))));
+        }
+        return result;
+    }
+
+    private Set<String> batchGetNonInProgress(List<String> sessionIds) throws IOException {
+        try {
+            List<Map<String, AttributeValue>> keys = new ArrayList<>();
+            for (String sessionId : sessionIds) {
+                keys.add(Map.of("sessionId", AttributeValue.fromS(sessionId)));
+            }
+            Set<String> result = new HashSet<>();
+            Map<String, KeysAndAttributes> requestItems =
+                    new HashMap<>(Map.of(sessionTable, KeysAndAttributes.builder().keys(keys).build()));
+            while (!requestItems.isEmpty()) {
+                BatchGetItemResponse response =
+                        client.batchGetItem(BatchGetItemRequest.builder().requestItems(requestItems).build());
+                for (Map<String, AttributeValue> item :
+                        response.responses().getOrDefault(sessionTable, List.of())) {
+                    if (!SessionStatus.IN_PROGRESS.dbValue().equals(item.get("status").s())) {
+                        result.add(item.get("sessionId").s());
+                    }
+                }
+                requestItems = response.unprocessedKeys();
+            }
+            return result;
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private void deleteAccountItem(String email, String sessionId) throws IOException {
+        try {
+            client.deleteItem(DeleteItemRequest.builder()
+                    .tableName(accountTable)
+                    .key(Map.of("email", AttributeValue.fromS(email), "sessionId", AttributeValue.fromS(sessionId)))
+                    .build());
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private void deleteSessionItem(String sessionId) throws IOException {
+        try {
+            client.deleteItem(DeleteItemRequest.builder()
+                    .tableName(sessionTable)
+                    .key(Map.of("sessionId", AttributeValue.fromS(sessionId)))
+                    .build());
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private static BackupSession mapSession(Map<String, AttributeValue> item) {
+        return new BackupSession(
+                item.get("sessionId").s(),
+                BackupType.fromSessionPrefix(item.get("type").s()),
+                SessionStatus.fromDbValue(item.get("status").s()),
+                fromDb(item.get("initialDate").s()),
+                item.containsKey("conclusionDate") ? fromDb(item.get("conclusionDate").s()) : null,
+                item.containsKey("size") ? item.get("size").s() : null);
+    }
+
+    private static BackupAccountRecord mapAccount(Map<String, AttributeValue> item) {
+        return new BackupAccountRecord(
+                null,
+                item.get("sessionId").s(),
+                item.get("email").s(),
+                item.get("accountSize").s(),
+                fromDb(item.get("initialDate").s()),
+                item.containsKey("conclusionDate") ? fromDb(item.get("conclusionDate").s()) : null);
+    }
+
+    private static String toDb(Instant instant) {
+        return instant.toString();
+    }
+
+    private static Instant fromDb(String value) {
+        return Instant.parse(value);
+    }
+}

--- a/aws/src/main/java/io/zmbackup/aws/HumanReadableSize.java
+++ b/aws/src/main/java/io/zmbackup/aws/HumanReadableSize.java
@@ -1,0 +1,26 @@
+package io.zmbackup.aws;
+
+final class HumanReadableSize {
+
+    private static final String[] UNITS = {"K", "M", "G", "T", "P"};
+
+    private HumanReadableSize() {
+    }
+
+    static String format(long bytes) {
+        if (bytes < 1024) {
+            return bytes + "B";
+        }
+        double value = bytes;
+        int unitIndex = -1;
+        while (value >= 1024 && unitIndex < UNITS.length - 1) {
+            value /= 1024;
+            unitIndex++;
+        }
+        long tenths = Math.round(value * 10);
+        if (tenths % 10 == 0) {
+            return (tenths / 10) + UNITS[unitIndex];
+        }
+        return (tenths / 10.0) + UNITS[unitIndex];
+    }
+}

--- a/aws/src/main/java/io/zmbackup/aws/S3MultipartOutputStream.java
+++ b/aws/src/main/java/io/zmbackup/aws/S3MultipartOutputStream.java
@@ -1,0 +1,144 @@
+package io.zmbackup.aws;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+
+final class S3MultipartOutputStream extends OutputStream {
+
+    static final int PART_SIZE_BYTES = 8 * 1024 * 1024;
+
+    private static final Logger LOG = Logger.getLogger(S3MultipartOutputStream.class.getName());
+
+    private final S3Client s3Client;
+    private final String bucket;
+    private final String key;
+    private final byte[] buffer = new byte[PART_SIZE_BYTES];
+    private final List<CompletedPart> completedParts = new ArrayList<>();
+
+    private int bufferLength;
+    private String uploadId;
+    private int nextPartNumber = 1;
+    private boolean closed;
+
+    S3MultipartOutputStream(S3Client s3Client, String bucket, String key) {
+        this.s3Client = s3Client;
+        this.bucket = bucket;
+        this.key = key;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        write(new byte[] {(byte) b}, 0, 1);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        int remaining = len;
+        int offset = off;
+        while (remaining > 0) {
+            int spaceInBuffer = buffer.length - bufferLength;
+            int toCopy = Math.min(spaceInBuffer, remaining);
+            System.arraycopy(b, offset, buffer, bufferLength, toCopy);
+            bufferLength += toCopy;
+            offset += toCopy;
+            remaining -= toCopy;
+            if (bufferLength == buffer.length) {
+                uploadPart();
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (uploadId == null) {
+            putWholeObject();
+            return;
+        }
+        if (bufferLength > 0) {
+            uploadPart();
+        }
+        try {
+            s3Client.completeMultipartUpload(CompleteMultipartUploadRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .uploadId(uploadId)
+                    .multipartUpload(CompletedMultipartUpload.builder().parts(completedParts).build())
+                    .build());
+        } catch (SdkException e) {
+            abort();
+            throw new IOException(e);
+        }
+    }
+
+    private void putWholeObject() throws IOException {
+        try {
+            s3Client.putObject(
+                    PutObjectRequest.builder().bucket(bucket).key(key).build(),
+                    RequestBody.fromBytes(Arrays.copyOf(buffer, bufferLength)));
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private void uploadPart() throws IOException {
+        try {
+            if (uploadId == null) {
+                uploadId = s3Client.createMultipartUpload(
+                                CreateMultipartUploadRequest.builder().bucket(bucket).key(key).build())
+                        .uploadId();
+            }
+            int partNumber = nextPartNumber++;
+            UploadPartResponse response = s3Client.uploadPart(
+                    UploadPartRequest.builder()
+                            .bucket(bucket)
+                            .key(key)
+                            .uploadId(uploadId)
+                            .partNumber(partNumber)
+                            .build(),
+                    RequestBody.fromBytes(Arrays.copyOf(buffer, bufferLength)));
+            completedParts.add(CompletedPart.builder()
+                    .partNumber(partNumber)
+                    .eTag(response.eTag())
+                    .build());
+            bufferLength = 0;
+        } catch (SdkException e) {
+            abort();
+            throw new IOException(e);
+        }
+    }
+
+    private void abort() {
+        if (uploadId == null) {
+            return;
+        }
+        try {
+            s3Client.abortMultipartUpload(AbortMultipartUploadRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .uploadId(uploadId)
+                    .build());
+        } catch (SdkException e) {
+            LOG.log(Level.WARNING, "Failed to abort multipart upload " + uploadId + " for " + key, e);
+        }
+    }
+}

--- a/aws/src/main/java/io/zmbackup/aws/S3StorageProvider.java
+++ b/aws/src/main/java/io/zmbackup/aws/S3StorageProvider.java
@@ -1,0 +1,172 @@
+package io.zmbackup.aws;
+
+import io.zmbackup.core.port.StorageProvider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+public final class S3StorageProvider implements StorageProvider {
+
+    private static final int DELETE_BATCH_SIZE = 1000;
+
+    private final S3Client s3Client;
+    private final String bucket;
+    private final String keyPrefix;
+
+    public S3StorageProvider(String bucket, String region, String keyPrefix, URI endpointOverride) {
+        this.bucket = Objects.requireNonNull(bucket, "bucket must not be null");
+        this.keyPrefix = normalizePrefix(Objects.requireNonNull(keyPrefix, "keyPrefix must not be null"));
+        S3ClientBuilder builder = S3Client.builder()
+                .region(Region.of(Objects.requireNonNull(region, "region must not be null")))
+                .serviceConfiguration(
+                        S3Configuration.builder().checksumValidationEnabled(false).build());
+        if (endpointOverride != null) {
+            builder.endpointOverride(endpointOverride).forcePathStyle(true);
+        }
+        this.s3Client = builder.build();
+    }
+
+    private static String normalizePrefix(String prefix) {
+        if (prefix.isEmpty() || prefix.endsWith("/")) {
+            return prefix;
+        }
+        return prefix + "/";
+    }
+
+    @Override
+    public OutputStream openWrite(String sessionId, String account, String suffix) throws IOException {
+        return new S3MultipartOutputStream(s3Client, bucket, objectKey(sessionId, account, suffix));
+    }
+
+    @Override
+    public InputStream openRead(String sessionId, String account, String suffix) throws IOException {
+        try {
+            return s3Client.getObject(GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(objectKey(sessionId, account, suffix))
+                    .build());
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public boolean exists(String sessionId, String account, String suffix) {
+        try {
+            s3Client.headObject(HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(objectKey(sessionId, account, suffix))
+                    .build());
+            return true;
+        } catch (SdkException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String sizeOfAccount(String sessionId, String account) throws IOException {
+        String prefix = sessionPrefix(sessionId);
+        String accountFilePrefix = account + ".";
+        long total = 0;
+        for (S3Object object : listObjects(prefix + accountFilePrefix)) {
+            String fileName = object.key().substring(prefix.length());
+            if (fileName.startsWith(accountFilePrefix) && fileName.indexOf('.', accountFilePrefix.length()) < 0) {
+                total += object.size();
+            }
+        }
+        return HumanReadableSize.format(total);
+    }
+
+    @Override
+    public String sizeOfSession(String sessionId) throws IOException {
+        long total = 0;
+        for (S3Object object : listObjects(sessionPrefix(sessionId))) {
+            total += object.size();
+        }
+        return HumanReadableSize.format(total);
+    }
+
+    @Override
+    public void deleteSession(String sessionId) throws IOException {
+        deleteObjects(listObjects(sessionPrefix(sessionId)));
+    }
+
+    @Override
+    public int deleteEmptyFiles() throws IOException {
+        List<S3Object> empty = new ArrayList<>();
+        for (S3Object object : listObjects(keyPrefix)) {
+            if (object.size() == 0) {
+                empty.add(object);
+            }
+        }
+        deleteObjects(empty);
+        return empty.size();
+    }
+
+    private String sessionPrefix(String sessionId) {
+        return keyPrefix + sessionId + "/";
+    }
+
+    private String objectKey(String sessionId, String account, String suffix) {
+        return sessionPrefix(sessionId) + account + "." + suffix;
+    }
+
+    private List<S3Object> listObjects(String prefix) throws IOException {
+        try {
+            List<S3Object> objects = new ArrayList<>();
+            String continuationToken = null;
+            boolean truncated;
+            do {
+                ListObjectsV2Request.Builder requestBuilder =
+                        ListObjectsV2Request.builder().bucket(bucket).prefix(prefix);
+                if (continuationToken != null) {
+                    requestBuilder.continuationToken(continuationToken);
+                }
+                ListObjectsV2Response response = s3Client.listObjectsV2(requestBuilder.build());
+                objects.addAll(response.contents());
+                truncated = Boolean.TRUE.equals(response.isTruncated());
+                continuationToken = response.nextContinuationToken();
+            } while (truncated);
+            return objects;
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private void deleteObjects(List<S3Object> objects) throws IOException {
+        if (objects.isEmpty()) {
+            return;
+        }
+        try {
+            for (int start = 0; start < objects.size(); start += DELETE_BATCH_SIZE) {
+                List<ObjectIdentifier> batch = new ArrayList<>();
+                for (S3Object object : objects.subList(start, Math.min(start + DELETE_BATCH_SIZE, objects.size()))) {
+                    batch.add(ObjectIdentifier.builder().key(object.key()).build());
+                }
+                s3Client.deleteObjects(DeleteObjectsRequest.builder()
+                        .bucket(bucket)
+                        .delete(Delete.builder().objects(batch).build())
+                        .build());
+            }
+        } catch (SdkException e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/aws/src/test/java/io/zmbackup/aws/DynamoDBLockTest.java
+++ b/aws/src/test/java/io/zmbackup/aws/DynamoDBLockTest.java
@@ -1,0 +1,93 @@
+package io.zmbackup.aws;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.zmbackup.core.port.LockContentionException;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DynamoDBLockTest {
+
+    private static final String LOCK_TABLE = "zmbackup_lock";
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void acquireSucceedsWhenNoLockItemExists() throws IOException {
+        stubTarget("PutItem", 200, "{}");
+        stubTarget("DeleteItem", 200, "{}");
+
+        DynamoDBLock lock = DynamoDBLock.acquire("us-east-1", LOCK_TABLE, endpoint(), Duration.ofHours(24));
+
+        lock.close();
+    }
+
+    @Test
+    void acquireThrowsLockContentionExceptionOnConditionalCheckFailure() {
+        wireMockServer.stubFor(post(com.github.tomakehurst.wiremock.client.WireMock.anyUrl())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.PutItem"))
+                .willReturn(aResponse()
+                        .withStatus(400)
+                        .withHeader("Content-Type", "application/x-amz-json-1.0")
+                        .withHeader("x-amzn-errortype", "ConditionalCheckFailedException")
+                        .withBody("{\"__type\":\"com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException\","
+                                + "\"message\":\"The conditional request failed\"}")));
+        stubTarget(
+                "GetItem",
+                200,
+                "{\"Item\":{\"lockId\":{\"S\":\"zmbackup\"},\"holder\":{\"S\":\"other-host:123\"}}}");
+
+        LockContentionException exception = assertThrows(
+                LockContentionException.class,
+                () -> DynamoDBLock.acquire("us-east-1", LOCK_TABLE, endpoint(), Duration.ofHours(24)));
+
+        assertTrue(exception.getMessage().contains("other-host:123"));
+    }
+
+    @Test
+    void closeDeletesTheLockItem() throws IOException {
+        stubTarget("PutItem", 200, "{}");
+        stubTarget("DeleteItem", 200, "{}");
+        DynamoDBLock lock = DynamoDBLock.acquire("us-east-1", LOCK_TABLE, endpoint(), Duration.ofHours(24));
+
+        lock.close();
+
+        wireMockServer.verify(postRequestedFor(com.github.tomakehurst.wiremock.client.WireMock.anyUrl())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.DeleteItem")));
+    }
+
+    private URI endpoint() {
+        return URI.create(wireMockServer.baseUrl());
+    }
+
+    private void stubTarget(String operation, int status, String body) {
+        wireMockServer.stubFor(post(com.github.tomakehurst.wiremock.client.WireMock.anyUrl())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810." + operation))
+                .willReturn(aResponse()
+                        .withStatus(status)
+                        .withHeader("Content-Type", "application/x-amz-json-1.0")
+                        .withBody(body)));
+    }
+}

--- a/aws/src/test/java/io/zmbackup/aws/DynamoDBLockTest.java
+++ b/aws/src/test/java/io/zmbackup/aws/DynamoDBLockTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -22,6 +23,12 @@ class DynamoDBLockTest {
     private static final String LOCK_TABLE = "zmbackup_lock";
 
     private WireMockServer wireMockServer;
+
+    @BeforeAll
+    static void setUpCredentials() {
+        System.setProperty("aws.accessKeyId", "test");
+        System.setProperty("aws.secretAccessKey", "test");
+    }
 
     @BeforeEach
     void setUp() {

--- a/aws/src/test/java/io/zmbackup/aws/DynamoDBMetadataStoreTest.java
+++ b/aws/src/test/java/io/zmbackup/aws/DynamoDBMetadataStoreTest.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +31,12 @@ class DynamoDBMetadataStoreTest {
     private static final String ACCOUNT_TABLE = "zmbackup_account";
 
     private WireMockServer wireMockServer;
+
+    @BeforeAll
+    static void setUpCredentials() {
+        System.setProperty("aws.accessKeyId", "test");
+        System.setProperty("aws.secretAccessKey", "test");
+    }
 
     @BeforeEach
     void setUp() {

--- a/aws/src/test/java/io/zmbackup/aws/DynamoDBMetadataStoreTest.java
+++ b/aws/src/test/java/io/zmbackup/aws/DynamoDBMetadataStoreTest.java
@@ -1,0 +1,268 @@
+package io.zmbackup.aws;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.SessionStatus;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DynamoDBMetadataStoreTest {
+
+    private static final String SESSION_TABLE = "zmbackup_session";
+    private static final String ACCOUNT_TABLE = "zmbackup_account";
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void saveSendsPutItemOmittingAbsentAttributes() throws IOException {
+        stubTarget("PutItem", "{}");
+        BackupSession session = new BackupSession(
+                "full-20260101120000", BackupType.FULL, SessionStatus.IN_PROGRESS, Instant.parse(
+                        "2026-01-01T12:00:00Z"), null, null);
+
+        store().save(session);
+
+        wireMockServer.verify(postRequestedFor(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.PutItem"))
+                .withRequestBody(containing("\"full\""))
+                .withRequestBody(containing("\"IN PROGRESS\""))
+                .withRequestBody(new com.github.tomakehurst.wiremock.matching.NegativeRegexPattern(
+                        ".*conclusionDate.*")));
+    }
+
+    @Test
+    void findSessionReturnsEmptyWhenNoItem() throws IOException {
+        stubTarget("GetItem", "{}");
+
+        Optional<BackupSession> result = store().findSession("full-20260101120000");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void findSessionMapsItemBackToDomain() throws IOException {
+        stubTarget(
+                "GetItem",
+                "{\"Item\":{"
+                        + "\"sessionId\":{\"S\":\"full-20260101120000\"},"
+                        + "\"type\":{\"S\":\"full\"},"
+                        + "\"status\":{\"S\":\"FINISHED\"},"
+                        + "\"initialDate\":{\"S\":\"2026-01-01T12:00:00Z\"},"
+                        + "\"conclusionDate\":{\"S\":\"2026-01-01T13:00:00Z\"},"
+                        + "\"size\":{\"S\":\"1.0M\"}"
+                        + "}}");
+
+        Optional<BackupSession> result = store().findSession("full-20260101120000");
+
+        assertTrue(result.isPresent());
+        assertEquals(BackupType.FULL, result.get().type());
+        assertEquals(SessionStatus.FINISHED, result.get().status());
+        assertEquals("1.0M", result.get().size());
+    }
+
+    @Test
+    void listSessionsFollowsPagination() throws IOException {
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Scan"))
+                .withRequestBody(new com.github.tomakehurst.wiremock.matching.NegativeRegexPattern(
+                        ".*ExclusiveStartKey.*"))
+                .willReturn(jsonResponse(
+                        "{\"Items\":[" + sessionItem("full-20260101120000") + "],"
+                                + "\"LastEvaluatedKey\":{\"sessionId\":{\"S\":\"full-20260101120000\"}}}")));
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Scan"))
+                .withRequestBody(containing("ExclusiveStartKey"))
+                .willReturn(jsonResponse("{\"Items\":[" + sessionItem("inc-20260102120000") + "]}")));
+
+        List<BackupSession> sessions = store().listSessions();
+
+        assertEquals(2, sessions.size());
+    }
+
+    @Test
+    void findSessionsCompletedBeforeSendsFilterExpression() throws IOException {
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Scan"))
+                .willReturn(jsonResponse("{\"Items\":[" + sessionItem("full-20260101120000") + "]}")));
+
+        List<BackupSession> sessions = store().findSessionsCompletedBefore(Instant.parse("2026-06-01T00:00:00Z"));
+
+        assertEquals(1, sessions.size());
+        wireMockServer.verify(postRequestedFor(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Scan"))
+                .withRequestBody(containing("attribute_exists(conclusionDate)")));
+    }
+
+    @Test
+    void deleteSessionDeletesEachAccountThenTheSessionItself() throws IOException {
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Query"))
+                .willReturn(jsonResponse("{\"Items\":[" + accountItem("full-20260101120000", "alice@example.com")
+                        + "]}")));
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.DeleteItem"))
+                .willReturn(jsonResponse("{}")));
+
+        store().deleteSession("full-20260101120000");
+
+        wireMockServer.verify(2, postRequestedFor(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.DeleteItem")));
+    }
+
+    @Test
+    void truncateDeletesEverySessionAndReturnsPreDeleteCount() throws IOException {
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Scan"))
+                .willReturn(jsonResponse("{\"Items\":[" + sessionItem("full-20260101120000") + ","
+                        + sessionItem("inc-20260102120000") + "]}")));
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Query"))
+                .willReturn(jsonResponse("{\"Items\":[]}")));
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.DeleteItem"))
+                .willReturn(jsonResponse("{}")));
+
+        int removed = store().truncate();
+
+        assertEquals(2, removed);
+    }
+
+    @Test
+    void recordAccountBackupSendsPutItemOnAccountTable() throws IOException {
+        stubTarget("PutItem", "{}");
+        BackupAccountRecord record = new BackupAccountRecord(
+                null,
+                "full-20260101120000",
+                "alice@example.com",
+                "1K",
+                Instant.parse("2026-01-01T12:00:00Z"),
+                Instant.parse("2026-01-01T12:05:00Z"));
+
+        store().recordAccountBackup(record);
+
+        wireMockServer.verify(postRequestedFor(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.PutItem"))
+                .withRequestBody(containing("\"" + ACCOUNT_TABLE + "\""))
+                .withRequestBody(containing("alice@example.com")));
+    }
+
+    @Test
+    void findAccountsForSessionQueriesTheSessionIdIndex() throws IOException {
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Query"))
+                .willReturn(jsonResponse(
+                        "{\"Items\":[" + accountItem("full-20260101120000", "alice@example.com") + "]}")));
+
+        List<BackupAccountRecord> records = store().findAccountsForSession("full-20260101120000");
+
+        assertEquals(1, records.size());
+        assertEquals("alice@example.com", records.get(0).email());
+        wireMockServer.verify(postRequestedFor(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Query"))
+                .withRequestBody(containing(DynamoDBMetadataStore.SESSION_ID_INDEX)));
+    }
+
+    @Test
+    void lastSuccessfulBackupTimeIgnoresInProgressAndNonMailboxSessions() throws IOException {
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Query"))
+                .willReturn(jsonResponse("{\"Items\":["
+                        + accountItem("full-20260101120000", "alice@example.com", "2026-01-01T12:00:00Z")
+                        + ","
+                        + accountItem("mbox-20260201120000", "alice@example.com", "2026-02-01T12:00:00Z")
+                        + ","
+                        + accountItem("ldap-20260301120000", "alice@example.com", "2026-03-01T12:00:00Z")
+                        + "]}")));
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.BatchGetItem"))
+                .willReturn(jsonResponse("{\"Responses\":{\"" + SESSION_TABLE + "\":["
+                        + "{\"sessionId\":{\"S\":\"full-20260101120000\"},\"status\":{\"S\":\"FINISHED\"}},"
+                        + "{\"sessionId\":{\"S\":\"mbox-20260201120000\"},\"status\":{\"S\":\"IN PROGRESS\"}}"
+                        + "]}}")));
+
+        Optional<Instant> result = store().lastSuccessfulBackupTime("alice@example.com");
+
+        assertTrue(result.isPresent());
+        assertEquals(Instant.parse("2026-01-01T12:00:00Z"), result.get());
+    }
+
+    @Test
+    void backedUpSinceReturnsTrueOnlyWhenARecordCompletedAfterTheCutoff() throws IOException {
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Query"))
+                .willReturn(jsonResponse("{\"Items\":["
+                        + accountItem("full-20260101120000", "alice@example.com", "2026-01-01T12:00:00Z")
+                        + "]}")));
+
+        assertTrue(store().backedUpSince("alice@example.com", Instant.parse("2025-12-01T00:00:00Z")));
+        assertFalse(store().backedUpSince("alice@example.com", Instant.parse("2026-06-01T00:00:00Z")));
+    }
+
+    private DynamoDBMetadataStore store() {
+        return new DynamoDBMetadataStore(
+                "us-east-1", SESSION_TABLE, ACCOUNT_TABLE, URI.create(wireMockServer.baseUrl()));
+    }
+
+    private void stubTarget(String operation, String responseBody) {
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810." + operation))
+                .willReturn(jsonResponse(responseBody)));
+    }
+
+    private static com.github.tomakehurst.wiremock.matching.UrlPattern anyPath() {
+        return com.github.tomakehurst.wiremock.client.WireMock.anyUrl();
+    }
+
+    private static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder jsonResponse(String body) {
+        return aResponse().withStatus(200).withHeader("Content-Type", "application/x-amz-json-1.0").withBody(body);
+    }
+
+    private static String sessionItem(String sessionId) {
+        return "{\"sessionId\":{\"S\":\"" + sessionId + "\"},"
+                + "\"type\":{\"S\":\"" + sessionId.substring(0, sessionId.indexOf('-')) + "\"},"
+                + "\"status\":{\"S\":\"FINISHED\"},"
+                + "\"initialDate\":{\"S\":\"2026-01-01T12:00:00Z\"},"
+                + "\"conclusionDate\":{\"S\":\"2026-01-01T13:00:00Z\"}}";
+    }
+
+    private static String accountItem(String sessionId, String email) {
+        return accountItem(sessionId, email, "2026-01-01T12:00:00Z");
+    }
+
+    private static String accountItem(String sessionId, String email, String completedAt) {
+        return "{\"email\":{\"S\":\"" + email + "\"},"
+                + "\"sessionId\":{\"S\":\"" + sessionId + "\"},"
+                + "\"accountSize\":{\"S\":\"1K\"},"
+                + "\"initialDate\":{\"S\":\"2026-01-01T11:00:00Z\"},"
+                + "\"conclusionDate\":{\"S\":\"" + completedAt + "\"}}";
+    }
+}

--- a/aws/src/test/java/io/zmbackup/aws/S3StorageProviderTest.java
+++ b/aws/src/test/java/io/zmbackup/aws/S3StorageProviderTest.java
@@ -1,0 +1,257 @@
+package io.zmbackup.aws;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.head;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class S3StorageProviderTest {
+
+    private static final String BUCKET = "test-bucket";
+    private static final String SESSION_ID = "full-20260101120000";
+    private static final String ACCOUNT = "alice.smith";
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void openWriteOfSmallContentUsesPlainPutObject() throws IOException {
+        wireMockServer.stubFor(put(urlEqualTo("/" + BUCKET + "/sessions/" + SESSION_ID + "/" + ACCOUNT + ".tgz"))
+                .willReturn(aResponse().withStatus(200).withHeader("ETag", "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"")));
+        S3StorageProvider provider = provider();
+
+        try (OutputStream out = provider.openWrite(SESSION_ID, ACCOUNT, "tgz")) {
+            out.write("small content".getBytes(StandardCharsets.UTF_8));
+        }
+
+        wireMockServer.verify(putRequestedFor(
+                urlEqualTo("/" + BUCKET + "/sessions/" + SESSION_ID + "/" + ACCOUNT + ".tgz")));
+    }
+
+    @Test
+    void openWriteOfLargeContentUsesMultipartUpload() throws IOException {
+        String key = "sessions/" + SESSION_ID + "/" + ACCOUNT + ".tgz";
+        wireMockServer.stubFor(post(urlEqualTo("/" + BUCKET + "/" + key + "?uploads"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<InitiateMultipartUploadResult><Bucket>" + BUCKET + "</Bucket><Key>" + key
+                                + "</Key><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>")));
+        wireMockServer.stubFor(put(urlPathEqualTo("/" + BUCKET + "/" + key))
+                .withQueryParam("uploadId", com.github.tomakehurst.wiremock.client.WireMock.equalTo("upload-1"))
+                .willReturn(aResponse().withStatus(200).withHeader("ETag", "\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"")));
+        wireMockServer.stubFor(post(urlPathEqualTo("/" + BUCKET + "/" + key))
+                .withQueryParam("uploadId", com.github.tomakehurst.wiremock.client.WireMock.equalTo("upload-1"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<CompleteMultipartUploadResult><Bucket>" + BUCKET + "</Bucket><Key>" + key
+                                + "</Key><ETag>\"cccccccccccccccccccccccccccccccc\"</ETag></CompleteMultipartUploadResult>")));
+        S3StorageProvider provider = provider();
+        byte[] content = randomBytes(S3MultipartOutputStream.PART_SIZE_BYTES + 1024);
+
+        try (OutputStream out = provider.openWrite(SESSION_ID, ACCOUNT, "tgz")) {
+            out.write(content);
+        }
+
+        wireMockServer.verify(postRequestedFor(urlEqualTo("/" + BUCKET + "/" + key + "?uploads")));
+        wireMockServer.verify(2, putRequestedFor(urlPathEqualTo("/" + BUCKET + "/" + key)));
+        wireMockServer.verify(postRequestedFor(urlPathEqualTo("/" + BUCKET + "/" + key)));
+    }
+
+    @Test
+    void multipartUploadIsAbortedWhenAPartUploadFails() {
+        String key = "sessions/" + SESSION_ID + "/" + ACCOUNT + ".tgz";
+        wireMockServer.stubFor(post(urlEqualTo("/" + BUCKET + "/" + key + "?uploads"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<InitiateMultipartUploadResult><Bucket>" + BUCKET + "</Bucket><Key>" + key
+                                + "</Key><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>")));
+        wireMockServer.stubFor(put(urlPathEqualTo("/" + BUCKET + "/" + key))
+                .willReturn(aResponse().withStatus(500)));
+        wireMockServer.stubFor(delete(urlPathEqualTo("/" + BUCKET + "/" + key))
+                .willReturn(aResponse().withStatus(204)));
+        S3StorageProvider provider = provider();
+        byte[] content = randomBytes(S3MultipartOutputStream.PART_SIZE_BYTES + 1024);
+
+        assertThrows(IOException.class, () -> {
+            try (OutputStream out = provider.openWrite(SESSION_ID, ACCOUNT, "tgz")) {
+                out.write(content);
+            }
+        });
+
+        wireMockServer.verify(deleteRequestedFor(urlPathEqualTo("/" + BUCKET + "/" + key)));
+    }
+
+    @Test
+    void openReadReturnsObjectContent() throws IOException {
+        String key = "sessions/" + SESSION_ID + "/" + ACCOUNT + ".ldiff";
+        wireMockServer.stubFor(get(urlPathEqualTo("/" + BUCKET + "/" + key))
+                .willReturn(aResponse().withStatus(200).withBody("ldiff-content")));
+        S3StorageProvider provider = provider();
+
+        try (InputStream in = provider.openRead(SESSION_ID, ACCOUNT, "ldiff")) {
+            assertArrayEquals("ldiff-content".getBytes(StandardCharsets.UTF_8), in.readAllBytes());
+        }
+    }
+
+    @Test
+    void existsReturnsTrueOn200AndFalseOn404() {
+        String key = "sessions/" + SESSION_ID + "/" + ACCOUNT + ".tgz";
+        wireMockServer.stubFor(head(urlPathEqualTo("/" + BUCKET + "/" + key))
+                .willReturn(aResponse().withStatus(200)));
+        S3StorageProvider provider = provider();
+
+        assertTrue(provider.exists(SESSION_ID, ACCOUNT, "tgz"));
+
+        wireMockServer.resetAll();
+        wireMockServer.stubFor(head(urlPathEqualTo("/" + BUCKET + "/" + key))
+                .willReturn(aResponse().withStatus(404)));
+
+        assertFalse(provider.exists(SESSION_ID, ACCOUNT, "tgz"));
+    }
+
+    @Test
+    void sizeOfAccountSumsOnlyMatchingObjectsAndIgnoresExtendedAccountNames() throws IOException {
+        String prefix = "sessions/" + SESSION_ID + "/";
+        wireMockServer.stubFor(get(urlPathEqualTo("/" + BUCKET))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody(listBucketResult(
+                                false,
+                                null,
+                                entry(prefix + ACCOUNT + ".ldiff", 500),
+                                entry(prefix + ACCOUNT + ".tgz", 1524),
+                                entry(prefix + ACCOUNT + ".au.tgz", 999999)))));
+        S3StorageProvider provider = provider();
+
+        String size = provider.sizeOfAccount(SESSION_ID, ACCOUNT);
+
+        assertEquals("2K", size);
+    }
+
+    @Test
+    void sizeOfSessionSumsEveryObjectAcrossPages() throws IOException {
+        String prefix = "sessions/" + SESSION_ID + "/";
+        wireMockServer.stubFor(get(urlPathEqualTo("/" + BUCKET))
+                .withQueryParam("continuation-token", com.github.tomakehurst.wiremock.client.WireMock.absent())
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody(listBucketResult(true, "next-token", entry(prefix + "a@example.com.tgz", 200)))));
+        wireMockServer.stubFor(get(urlPathEqualTo("/" + BUCKET))
+                .withQueryParam("continuation-token", com.github.tomakehurst.wiremock.client.WireMock.equalTo("next-token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody(listBucketResult(false, null, entry(prefix + "b@example.com.tgz", 312)))));
+        S3StorageProvider provider = provider();
+
+        String size = provider.sizeOfSession(SESSION_ID);
+
+        assertEquals("512B", size);
+    }
+
+    @Test
+    void deleteSessionBatchDeletesEveryListedObject() throws IOException {
+        String prefix = "sessions/" + SESSION_ID + "/";
+        wireMockServer.stubFor(get(urlPathEqualTo("/" + BUCKET))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody(listBucketResult(false, null, entry(prefix + ACCOUNT + ".tgz", 10)))));
+        wireMockServer.stubFor(post(urlPathEqualTo("/" + BUCKET))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<DeleteResult></DeleteResult>")));
+        S3StorageProvider provider = provider();
+
+        provider.deleteSession(SESSION_ID);
+
+        wireMockServer.verify(postRequestedFor(urlPathEqualTo("/" + BUCKET)));
+    }
+
+    @Test
+    void deleteEmptyFilesRemovesOnlyZeroByteObjects() throws IOException {
+        wireMockServer.stubFor(get(urlPathEqualTo("/" + BUCKET))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody(listBucketResult(
+                                false, null, entry("sessions/x/a.tgz", 0), entry("sessions/x/b.tgz", 10)))));
+        wireMockServer.stubFor(post(urlPathEqualTo("/" + BUCKET))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<DeleteResult></DeleteResult>")));
+        S3StorageProvider provider = provider();
+
+        int removed = provider.deleteEmptyFiles();
+
+        assertEquals(1, removed);
+    }
+
+    private S3StorageProvider provider() {
+        return new S3StorageProvider(BUCKET, "us-east-1", "sessions/", URI.create(wireMockServer.baseUrl()));
+    }
+
+    private static byte[] randomBytes(int size) {
+        byte[] bytes = new byte[size];
+        new Random(42).nextBytes(bytes);
+        return bytes;
+    }
+
+    private static String entry(String key, long size) {
+        return "<Contents><Key>" + key + "</Key><Size>" + size + "</Size></Contents>";
+    }
+
+    private static String listBucketResult(boolean truncated, String nextToken, String... entries) {
+        StringBuilder body = new StringBuilder("<ListBucketResult><Name>bucket</Name>");
+        for (String entry : entries) {
+            body.append(entry);
+        }
+        body.append("<IsTruncated>").append(truncated).append("</IsTruncated>");
+        if (nextToken != null) {
+            body.append("<NextContinuationToken>").append(nextToken).append("</NextContinuationToken>");
+        }
+        body.append("</ListBucketResult>");
+        return body.toString();
+    }
+}

--- a/aws/src/test/java/io/zmbackup/aws/S3StorageProviderTest.java
+++ b/aws/src/test/java/io/zmbackup/aws/S3StorageProviderTest.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +37,12 @@ class S3StorageProviderTest {
     private static final String ACCOUNT = "alice.smith";
 
     private WireMockServer wireMockServer;
+
+    @BeforeAll
+    static void setUpCredentials() {
+        System.setProperty("aws.accessKeyId", "test");
+        System.setProperty("aws.secretAccessKey", "test");
+    }
 
     @BeforeEach
     void setUp() {

--- a/core/src/main/java/io/zmbackup/core/domain/CloudMigrationResult.java
+++ b/core/src/main/java/io/zmbackup/core/domain/CloudMigrationResult.java
@@ -1,0 +1,3 @@
+package io.zmbackup.core.domain;
+
+public record CloudMigrationResult(int sessionsMigrated, int accountsMigrated) {}

--- a/core/src/main/java/io/zmbackup/core/port/LockContentionException.java
+++ b/core/src/main/java/io/zmbackup/core/port/LockContentionException.java
@@ -1,0 +1,10 @@
+package io.zmbackup.core.port;
+
+import java.io.IOException;
+
+public class LockContentionException extends IOException {
+
+    public LockContentionException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/io/zmbackup/core/port/RunLock.java
+++ b/core/src/main/java/io/zmbackup/core/port/RunLock.java
@@ -1,0 +1,9 @@
+package io.zmbackup.core.port;
+
+import java.io.IOException;
+
+public interface RunLock extends AutoCloseable {
+
+    @Override
+    void close() throws IOException;
+}

--- a/core/src/main/java/io/zmbackup/core/service/CloudMigrationService.java
+++ b/core/src/main/java/io/zmbackup/core/service/CloudMigrationService.java
@@ -1,0 +1,75 @@
+package io.zmbackup.core.service;
+
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.CloudMigrationResult;
+import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.StorageProvider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class CloudMigrationService {
+
+    private static final List<String> SUFFIXES = List.of("ldiff", "tgz");
+
+    private final StorageProvider sourceStorage;
+    private final MetadataStore sourceMetadata;
+    private final StorageProvider destinationStorage;
+    private final MetadataStore destinationMetadata;
+
+    public CloudMigrationService(
+            StorageProvider sourceStorage,
+            MetadataStore sourceMetadata,
+            StorageProvider destinationStorage,
+            MetadataStore destinationMetadata) {
+        this.sourceStorage = Objects.requireNonNull(sourceStorage, "sourceStorage must not be null");
+        this.sourceMetadata = Objects.requireNonNull(sourceMetadata, "sourceMetadata must not be null");
+        this.destinationStorage = Objects.requireNonNull(destinationStorage, "destinationStorage must not be null");
+        this.destinationMetadata =
+                Objects.requireNonNull(destinationMetadata, "destinationMetadata must not be null");
+    }
+
+    public CloudMigrationResult migrate() throws IOException {
+        int sessionsMigrated = 0;
+        int accountsMigrated = 0;
+        for (BackupSession session : sourceMetadata.listSessions()) {
+            destinationMetadata.save(session);
+            sessionsMigrated++;
+            accountsMigrated += migrateAccounts(session.sessionId());
+        }
+        return new CloudMigrationResult(sessionsMigrated, accountsMigrated);
+    }
+
+    private int migrateAccounts(String sessionId) throws IOException {
+        Set<String> alreadyPresent = destinationMetadata.findAccountsForSession(sessionId).stream()
+                .map(BackupAccountRecord::email)
+                .collect(Collectors.toSet());
+        int migrated = 0;
+        for (BackupAccountRecord record : sourceMetadata.findAccountsForSession(sessionId)) {
+            if (alreadyPresent.contains(record.email())) {
+                continue;
+            }
+            migrateFiles(sessionId, record.email());
+            destinationMetadata.recordAccountBackup(record);
+            migrated++;
+        }
+        return migrated;
+    }
+
+    private void migrateFiles(String sessionId, String email) throws IOException {
+        for (String suffix : SUFFIXES) {
+            if (!sourceStorage.exists(sessionId, email, suffix)) {
+                continue;
+            }
+            try (InputStream in = sourceStorage.openRead(sessionId, email, suffix);
+                    OutputStream out = destinationStorage.openWrite(sessionId, email, suffix)) {
+                in.transferTo(out);
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/zmbackup/core/service/CloudMigrationServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/CloudMigrationServiceTest.java
@@ -1,0 +1,222 @@
+package io.zmbackup.core.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.zmbackup.core.domain.BackupAccountRecord;
+import io.zmbackup.core.domain.BackupSession;
+import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.CloudMigrationResult;
+import io.zmbackup.core.domain.SessionStatus;
+import io.zmbackup.core.port.MetadataStore;
+import io.zmbackup.core.port.StorageProvider;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class CloudMigrationServiceTest {
+
+    private final InMemoryStorage sourceStorage = new InMemoryStorage();
+    private final InMemoryMetadata sourceMetadata = new InMemoryMetadata();
+    private final InMemoryStorage destinationStorage = new InMemoryStorage();
+    private final InMemoryMetadata destinationMetadata = new InMemoryMetadata();
+    private final CloudMigrationService migrationService =
+            new CloudMigrationService(sourceStorage, sourceMetadata, destinationStorage, destinationMetadata);
+
+    @Test
+    void migratesSessionsAccountsAndFiles() throws IOException {
+        seedSession("full-20260101120000", "alice@example.com", "ldiff-content", "tgz-content");
+
+        CloudMigrationResult result = migrationService.migrate();
+
+        assertEquals(1, result.sessionsMigrated());
+        assertEquals(1, result.accountsMigrated());
+        assertEquals(
+                "full-20260101120000",
+                destinationMetadata.sessions.get("full-20260101120000").sessionId());
+        assertEquals(
+                "ldiff-content",
+                new String(
+                        destinationStorage.readAll("full-20260101120000", "alice@example.com", "ldiff"),
+                        StandardCharsets.UTF_8));
+        assertEquals(
+                "tgz-content",
+                new String(
+                        destinationStorage.readAll("full-20260101120000", "alice@example.com", "tgz"),
+                        StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void migratesOnlyTheSuffixesThatExist() throws IOException {
+        seedSession("mbox-20260101120000", "bob@example.com", null, "tgz-only");
+
+        migrationService.migrate();
+
+        assertTrue(destinationStorage.exists("mbox-20260101120000", "bob@example.com", "tgz"));
+        assertTrue(!destinationStorage.exists("mbox-20260101120000", "bob@example.com", "ldiff"));
+    }
+
+    @Test
+    void retryingAfterAPartialFailureDoesNotDuplicateAlreadyMigratedAccounts() throws IOException {
+        seedSession("full-20260101120000", "alice@example.com", "ldiff", "tgz");
+        sourceMetadata.recordAccountBackup(new BackupAccountRecord(
+                null,
+                "full-20260101120000",
+                "bob@example.com",
+                "1K",
+                Instant.parse("2026-01-01T12:00:00Z"),
+                Instant.parse("2026-01-01T12:05:00Z")));
+        sourceStorage.write("full-20260101120000", "bob@example.com", "ldiff", "bob-ldiff");
+
+        CloudMigrationResult first = migrationService.migrate();
+        CloudMigrationResult second = migrationService.migrate();
+
+        assertEquals(2, first.accountsMigrated());
+        assertEquals(0, second.accountsMigrated());
+        assertEquals(
+                2,
+                destinationMetadata.findAccountsForSession("full-20260101120000").size());
+    }
+
+    private void seedSession(String sessionId, String email, String ldiffContent, String tgzContent)
+            throws IOException {
+        sourceMetadata.save(new BackupSession(
+                sessionId,
+                BackupType.FULL,
+                SessionStatus.FINISHED,
+                Instant.parse("2026-01-01T12:00:00Z"),
+                Instant.parse("2026-01-01T12:05:00Z"),
+                "10M"));
+        sourceMetadata.recordAccountBackup(new BackupAccountRecord(
+                null, sessionId, email, "1K", Instant.parse("2026-01-01T12:00:00Z"), Instant.parse(
+                        "2026-01-01T12:05:00Z")));
+        if (ldiffContent != null) {
+            sourceStorage.write(sessionId, email, "ldiff", ldiffContent);
+        }
+        if (tgzContent != null) {
+            sourceStorage.write(sessionId, email, "tgz", tgzContent);
+        }
+    }
+
+    private static final class InMemoryStorage implements StorageProvider {
+        private final Map<String, byte[]> files = new HashMap<>();
+
+        void write(String sessionId, String account, String suffix, String content) {
+            files.put(key(sessionId, account, suffix), content.getBytes(StandardCharsets.UTF_8));
+        }
+
+        byte[] readAll(String sessionId, String account, String suffix) {
+            return files.get(key(sessionId, account, suffix));
+        }
+
+        private static String key(String sessionId, String account, String suffix) {
+            return sessionId + "/" + account + "." + suffix;
+        }
+
+        @Override
+        public OutputStream openWrite(String sessionId, String account, String suffix) {
+            return new ByteArrayOutputStream() {
+                @Override
+                public void close() {
+                    files.put(key(sessionId, account, suffix), toByteArray());
+                }
+            };
+        }
+
+        @Override
+        public InputStream openRead(String sessionId, String account, String suffix) {
+            return new ByteArrayInputStream(files.get(key(sessionId, account, suffix)));
+        }
+
+        @Override
+        public boolean exists(String sessionId, String account, String suffix) {
+            return files.containsKey(key(sessionId, account, suffix));
+        }
+
+        @Override
+        public String sizeOfAccount(String sessionId, String account) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String sizeOfSession(String sessionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void deleteSession(String sessionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int deleteEmptyFiles() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class InMemoryMetadata implements MetadataStore {
+        final Map<String, BackupSession> sessions = new LinkedHashMap<>();
+        final Map<String, List<BackupAccountRecord>> accounts = new LinkedHashMap<>();
+
+        @Override
+        public void save(BackupSession session) {
+            sessions.put(session.sessionId(), session);
+        }
+
+        @Override
+        public Optional<BackupSession> findSession(String sessionId) {
+            return Optional.ofNullable(sessions.get(sessionId));
+        }
+
+        @Override
+        public List<BackupSession> listSessions() {
+            return List.copyOf(sessions.values());
+        }
+
+        @Override
+        public List<BackupSession> findSessionsCompletedBefore(Instant cutoff) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void deleteSession(String sessionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int truncate() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void recordAccountBackup(BackupAccountRecord record) {
+            accounts.computeIfAbsent(record.sessionId(), key -> new ArrayList<>()).add(record);
+        }
+
+        @Override
+        public List<BackupAccountRecord> findAccountsForSession(String sessionId) {
+            return accounts.getOrDefault(sessionId, List.of());
+        }
+
+        @Override
+        public Optional<Instant> lastSuccessfulBackupTime(String email) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean backedUpSince(String identifier, Instant since) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ picocli = "4.7.7"
 logback = "1.6.3"
 slf4j = "2.0.18"
 sqlite-jdbc = "3.53.4.0"
+aws-sdk = "2.29.52"
 cucumber = "7.34.7"
 shadow = "9.6.1"
 foojay-resolver = "1.0.0"
@@ -26,6 +27,8 @@ picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 slf4j-jul-to-slf4j = { module = "org.slf4j:jul-to-slf4j", version.ref = "slf4j" }
 sqlite-jdbc = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite-jdbc" }
+aws-sdk-s3 = { module = "software.amazon.awssdk:s3", version.ref = "aws-sdk" }
+aws-sdk-dynamodb = { module = "software.amazon.awssdk:dynamodb", version.ref = "aws-sdk" }
 cucumber-java = { module = "io.cucumber:cucumber-java", version.ref = "cucumber" }
 cucumber-junit-platform-engine = { module = "io.cucumber:cucumber-junit-platform-engine", version.ref = "cucumber" }
 spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugs-annotations" }

--- a/project/config/zmbackup.yaml
+++ b/project/config/zmbackup.yaml
@@ -72,8 +72,31 @@ backup:
     # Address the report is sent from.
     sender: {ZMBKP_MAIL_SENDER}
 
+# Where backup content (LDIF/TGZ files) is stored. Optional; both sections below default to the
+# local filesystem, matching zmbackup 1.0/2.0 Phase 1 behavior. Set backend: s3 to store backup
+# content in Amazon S3 instead - see zmbackupdocs specs/13-cloud-backends.md.
+storage:
+  backend: local
+  # s3:
+  #   bucket: my-zmbackup-bucket
+  #   region: us-east-1
+  #   prefix: sessions/
+
+# Where session/account metadata is stored. Optional; defaults to the local SQLite database
+# alongside workDir above. Set backend: dynamodb to store metadata in DynamoDB instead, and to
+# switch the run lock from a local PID file to a DynamoDB-based distributed lock - see
+# zmbackupdocs specs/13-cloud-backends.md.
+metadata:
+  backend: sqlite
+  # dynamodb:
+  #   region: us-east-1
+  #   sessionTable: zmbackup_session
+  #   accountTable: zmbackup_account
+  #   lockTable: zmbackup_lock
+
 # Explicit opt-in required to start with a setting that sends credentials in cleartext or skips
 # certificate verification (sslEnabled: false, trustAllCertificates: true with no
-# caCertificatePath, or a non-https:// restBaseUrl). zmbackup refuses to start with such a
-# setting unless this is true. Optional, defaults to false.
+# caCertificatePath, a non-https:// restBaseUrl, or a non-https:// storage/metadata
+# endpointOverride). zmbackup refuses to start with such a setting unless this is true. Optional,
+# defaults to false.
 allowInsecure: false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,4 +4,4 @@ plugins {
 
 rootProject.name = "zmbackup"
 
-include("core", "zimbra", "local", "app")
+include("core", "zimbra", "local", "aws", "app")


### PR DESCRIPTION
## Summary

Closes #412 (Phase 2: Cloud Backends — S3 + DynamoDB).

- New `aws` Gradle module (`software.amazon.awssdk:s3`/`dynamodb`):
  - `S3StorageProvider` — streams `openWrite` content directly into S3 via a hand-rolled streaming
    multipart upload (no local temp files, no buffering the whole object), falling back to a plain
    `PutObject` for small content; `openRead`/`exists`/`sizeOfAccount`/`sizeOfSession`/
    `deleteSession`/`deleteEmptyFiles` round out the port.
  - `DynamoDBMetadataStore` — `zmbackup_session` (PK `sessionId`) + `zmbackup_account` (PK `email`,
    SK `sessionId`, plus a `sessionId-index` GSI so `findAccountsForSession` stays a `Query`, not a
    table `Scan`); hot paths (`lastSuccessfulBackupTime`, `backedUpSince`, `findAccountsForSession`)
    use `Query`, the same infrequent whole-table operations `SqliteMetadataStore` already scans
    (`listSessions`, `findSessionsCompletedBefore`) use `Scan` here too.
  - `DynamoDBLock` — a distributed run lock (conditional `PutItem` + lease expiry) for when
    `metadata.backend: dynamodb` means there's no shared local filesystem for a PID-file lock.
- `core.port.RunLock`/`LockContentionException` — `PidLock` now implements `RunLock` too, so
  `LockedExecution` acquires whichever lock `AppContext.acquireRunLock()` returns and handles either
  backend's contention the same way.
- `core.service.CloudMigrationService` — built only against `StorageProvider`/`MetadataStore`, so
  it has no AWS-specific code; copies sessions/accounts/files from a source pair to a destination
  pair, skipping accounts already present at the destination (same retry-safety pattern
  `MigrationService` already uses).
- New `storage`/`metadata` config sections (`AppConfig`/`YamlConfigLoader`) select `local`/`s3` and
  `sqlite`/`dynamodb` independently; both default to the Phase 1 behavior, so an existing
  `zmbackup.yaml` is unaffected.
- New `migrate-to-cloud --source-dir --source-db` CLI command — deliberately not an overload of the
  existing `migrate` command (which imports a bash-tool `sessions.txt`, an unrelated operation).

Full design, and the reasoning behind every place this diverges from the issue's original sketch,
is in lucascbeyeler/zmbackupdocs `specs/13-cloud-backends.md` (companion PR on that repo, branch
`claude/task-412-qlq833`), per that repo's own documented convention of analyzing/updating the spec
set alongside a design-level `zmbackup` change.

## Test plan

- [x] `./gradlew check` — full test suite, SpotBugs (`effort=MAX`, `MEDIUM`+ confidence), and JaCoCo
      line-coverage verification (≥80% per module) all pass across every module, `aws` included.
- [x] New tests added for every new/changed production class:
  - `aws`: `S3StorageProviderTest`, `DynamoDBMetadataStoreTest`, `DynamoDBLockTest` — all against a
    real WireMock server (S3/DynamoDB request-shape stubs), matching this project's existing
    no-Mockito, real-but-local-infrastructure testing convention (same approach
    `ZimbraRestMailboxExporterTest` already uses for Zimbra's REST API) rather than a
    LocalStack/Docker integration suite this project's CI has no support for yet.
  - `core`: `CloudMigrationServiceTest` (in-memory fakes — full migration, partial-retry dedup,
    ldiff-only/tgz-only/both-suffix sessions).
  - `app`: `AppContextTest` additions (backend selection wiring, insecure-endpoint refusal),
    `YamlConfigLoaderTest`/`AppConfigTest` additions (parsing, defaults, conditional-required
    validation), `MigrateToCloudCommandTest` (CLI wiring end-to-end against a real local source and
    a WireMock-backed S3/DynamoDB destination).
- [x] Verified `./gradlew :aws:test`/`:core:test`/`:app:test` individually while iterating, not just
      the aggregate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqQhg8H4eb6CkET8uW119w

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqQhg8H4eb6CkET8uW119w)_