### PR TITLE
Consolidate identifier patterns, bound DynamoDB history queries, parallelize dedup check, configurable SMTP relay

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -53,10 +53,6 @@ public final class AppContext {
 
     private static final Duration DYNAMODB_LOCK_LEASE = Duration.ofHours(24);
 
-    private static final String NOTIFY_SMTP_HOST = "localhost";
-
-    private static final int NOTIFY_SMTP_PORT = 25;
-
     private static final Notifier NO_NOTIFIER = new Notifier() {
         @Override
         public void notifyBegin(String sessionId, BackupType type) {}
@@ -273,8 +269,8 @@ public final class AppContext {
         boolean notifyOnFinishSuccess = level == EmailNotifyLevel.ALL || level == EmailNotifyLevel.FINISH;
         boolean notifyOnFinishError = level == EmailNotifyLevel.ALL || level == EmailNotifyLevel.ERROR;
         return new EmailNotifier(
-                NOTIFY_SMTP_HOST,
-                NOTIFY_SMTP_PORT,
+                config.backup().emailNotify().smtpHost(),
+                config.backup().emailNotify().smtpPort(),
                 config.backup().emailNotify().sender(),
                 config.backup().emailNotify().recipient(),
                 notifyOnBegin,

--- a/app/src/main/java/io/zmbackup/app/cli/CliValidation.java
+++ b/app/src/main/java/io/zmbackup/app/cli/CliValidation.java
@@ -1,13 +1,14 @@
 package io.zmbackup.app.cli;
 
+import io.zmbackup.core.domain.Identifiers;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.regex.Pattern;
 
 final class CliValidation {
 
-    private static final Pattern EMAIL = Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
-    private static final Pattern DOMAIN = Pattern.compile("^[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+    private static final Pattern EMAIL = Identifiers.EMAIL;
+    private static final Pattern DOMAIN = Identifiers.DOMAIN;
     private static final Pattern SESSION_ID =
             Pattern.compile("^(full|inc|ldap|domain|distlist|alias|mbox|signature)-[0-9]{14}$");
 

--- a/app/src/main/java/io/zmbackup/app/config/EmailNotifyConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/EmailNotifyConfig.java
@@ -2,13 +2,21 @@ package io.zmbackup.app.config;
 
 import java.util.Objects;
 
-public record EmailNotifyConfig(EmailNotifyLevel level, String recipient, String sender) {
+public record EmailNotifyConfig(
+        EmailNotifyLevel level, String recipient, String sender, String smtpHost, int smtpPort) {
+
+    public static final String DEFAULT_SMTP_HOST = "localhost";
+    public static final int DEFAULT_SMTP_PORT = 25;
 
     public EmailNotifyConfig {
         Objects.requireNonNull(level, "level must not be null");
         if (level != EmailNotifyLevel.NONE) {
             Objects.requireNonNull(recipient, "recipient must not be null unless level is NONE");
             Objects.requireNonNull(sender, "sender must not be null unless level is NONE");
+        }
+        Objects.requireNonNull(smtpHost, "smtpHost must not be null");
+        if (smtpPort < 1 || smtpPort > 65535) {
+            throw new IllegalArgumentException("smtpPort must be between 1 and 65535");
         }
     }
 }

--- a/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
+++ b/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
@@ -129,7 +129,9 @@ public final class YamlConfigLoader {
                         : requireString(root, "backup.emailNotify.recipient"),
                 notifyDisabled
                         ? optionalString(root, "backup.emailNotify.sender")
-                        : requireString(root, "backup.emailNotify.sender"));
+                        : requireString(root, "backup.emailNotify.sender"),
+                optionalStringDefault(root, "backup.emailNotify.smtpHost", EmailNotifyConfig.DEFAULT_SMTP_HOST),
+                optionalInt(root, "backup.emailNotify.smtpPort", EmailNotifyConfig.DEFAULT_SMTP_PORT));
     }
 
     private static Object get(Map<String, Object> root, String dottedPath) {

--- a/app/src/test/java/io/zmbackup/app/AppContextTest.java
+++ b/app/src/test/java/io/zmbackup/app/AppContextTest.java
@@ -120,7 +120,12 @@ class AppContextTest {
                         3,
                         30,
                         true,
-                        new EmailNotifyConfig(EmailNotifyLevel.NONE, null, null)),
+                        new EmailNotifyConfig(
+                                EmailNotifyLevel.NONE,
+                                null,
+                                null,
+                                EmailNotifyConfig.DEFAULT_SMTP_HOST,
+                                EmailNotifyConfig.DEFAULT_SMTP_PORT)),
                 LOCAL_STORAGE,
                 SQLITE_METADATA,
                 false);
@@ -234,7 +239,12 @@ class AppContextTest {
                         3,
                         30,
                         true,
-                        new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com")),
+                        new EmailNotifyConfig(
+                                EmailNotifyLevel.ALL,
+                                "admin@example.com",
+                                "root@example.com",
+                                EmailNotifyConfig.DEFAULT_SMTP_HOST,
+                                EmailNotifyConfig.DEFAULT_SMTP_PORT)),
                 new StorageConfig(
                         StorageBackend.S3,
                         new S3Config("test-bucket", "us-east-1", S3Config.DEFAULT_PREFIX, endpointOverride)),
@@ -265,7 +275,12 @@ class AppContextTest {
                         3,
                         30,
                         true,
-                        new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com")),
+                        new EmailNotifyConfig(
+                                EmailNotifyLevel.ALL,
+                                "admin@example.com",
+                                "root@example.com",
+                                EmailNotifyConfig.DEFAULT_SMTP_HOST,
+                                EmailNotifyConfig.DEFAULT_SMTP_PORT)),
                 LOCAL_STORAGE,
                 SQLITE_METADATA,
                 false);
@@ -296,7 +311,12 @@ class AppContextTest {
                         3,
                         30,
                         true,
-                        new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com")),
+                        new EmailNotifyConfig(
+                                EmailNotifyLevel.ALL,
+                                "admin@example.com",
+                                "root@example.com",
+                                EmailNotifyConfig.DEFAULT_SMTP_HOST,
+                                EmailNotifyConfig.DEFAULT_SMTP_PORT)),
                 LOCAL_STORAGE,
                 SQLITE_METADATA,
                 allowInsecure);
@@ -321,7 +341,12 @@ class AppContextTest {
                         3,
                         30,
                         true,
-                        new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com")),
+                        new EmailNotifyConfig(
+                                EmailNotifyLevel.ALL,
+                                "admin@example.com",
+                                "root@example.com",
+                                EmailNotifyConfig.DEFAULT_SMTP_HOST,
+                                EmailNotifyConfig.DEFAULT_SMTP_PORT)),
                 LOCAL_STORAGE,
                 SQLITE_METADATA,
                 allowInsecure);

--- a/app/src/test/java/io/zmbackup/app/config/AppConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/AppConfigTest.java
@@ -22,7 +22,12 @@ class AppConfigTest {
             3,
             30,
             true,
-            new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com"));
+            new EmailNotifyConfig(
+                    EmailNotifyLevel.ALL,
+                    "admin@example.com",
+                    "root@example.com",
+                    EmailNotifyConfig.DEFAULT_SMTP_HOST,
+                    EmailNotifyConfig.DEFAULT_SMTP_PORT));
 
     private static final StorageConfig STORAGE_CONFIG = new StorageConfig(StorageBackend.LOCAL, null);
 

--- a/app/src/test/java/io/zmbackup/app/config/BackupConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/BackupConfigTest.java
@@ -9,7 +9,12 @@ import org.junit.jupiter.api.Test;
 class BackupConfigTest {
 
     private static final EmailNotifyConfig EMAIL_NOTIFY =
-            new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", "root@example.com");
+            new EmailNotifyConfig(
+                    EmailNotifyLevel.ALL,
+                    "admin@example.com",
+                    "root@example.com",
+                    EmailNotifyConfig.DEFAULT_SMTP_HOST,
+                    EmailNotifyConfig.DEFAULT_SMTP_PORT);
 
     @Test
     void rejectsMaxParallelProcessesBelowOne() {

--- a/app/src/test/java/io/zmbackup/app/config/EmailNotifyConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/EmailNotifyConfigTest.java
@@ -11,25 +11,53 @@ class EmailNotifyConfigTest {
     void rejectsNullLevel() {
         assertThrows(
                 NullPointerException.class,
-                () -> new EmailNotifyConfig(null, "admin@example.com", "root@example.com"));
+                () -> new EmailNotifyConfig(
+                        null, "admin@example.com", "root@example.com", "localhost", 25));
     }
 
     @Test
     void rejectsNullRecipient() {
         assertThrows(
-                NullPointerException.class, () -> new EmailNotifyConfig(EmailNotifyLevel.ALL, null, "root@example.com"));
+                NullPointerException.class,
+                () -> new EmailNotifyConfig(
+                        EmailNotifyLevel.ALL, null, "root@example.com", "localhost", 25));
     }
 
     @Test
     void rejectsNullSender() {
         assertThrows(
                 NullPointerException.class,
-                () -> new EmailNotifyConfig(EmailNotifyLevel.ALL, "admin@example.com", null));
+                () -> new EmailNotifyConfig(
+                        EmailNotifyLevel.ALL, "admin@example.com", null, "localhost", 25));
+    }
+
+    @Test
+    void rejectsNullSmtpHost() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new EmailNotifyConfig(
+                        EmailNotifyLevel.ALL, "admin@example.com", "root@example.com", null, 25));
+    }
+
+    @Test
+    void rejectsSmtpPortBelowOne() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new EmailNotifyConfig(
+                        EmailNotifyLevel.ALL, "admin@example.com", "root@example.com", "localhost", 0));
+    }
+
+    @Test
+    void rejectsSmtpPortAboveSixtyFiveThirtyFive() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new EmailNotifyConfig(
+                        EmailNotifyLevel.ALL, "admin@example.com", "root@example.com", "localhost", 65536));
     }
 
     @Test
     void allowsNullRecipientAndSenderWhenLevelIsNone() {
-        EmailNotifyConfig config = new EmailNotifyConfig(EmailNotifyLevel.NONE, null, null);
+        EmailNotifyConfig config = new EmailNotifyConfig(EmailNotifyLevel.NONE, null, null, "localhost", 25);
 
         assertEquals(EmailNotifyLevel.NONE, config.level());
         assertEquals(null, config.recipient());
@@ -38,10 +66,13 @@ class EmailNotifyConfigTest {
 
     @Test
     void storesConfiguredFields() {
-        EmailNotifyConfig config = new EmailNotifyConfig(EmailNotifyLevel.ERROR, "admin@example.com", "root@example.com");
+        EmailNotifyConfig config = new EmailNotifyConfig(
+                EmailNotifyLevel.ERROR, "admin@example.com", "root@example.com", "mail.example.com", 587);
 
         assertEquals(EmailNotifyLevel.ERROR, config.level());
         assertEquals("admin@example.com", config.recipient());
         assertEquals("root@example.com", config.sender());
+        assertEquals("mail.example.com", config.smtpHost());
+        assertEquals(587, config.smtpPort());
     }
 }

--- a/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
@@ -47,6 +47,8 @@ class YamlConfigLoaderTest {
                 level: ERROR
                 recipient: admin@example.com
                 sender: root@example.com
+                smtpHost: mail.example.com
+                smtpPort: 587
             storage:
               backend: s3
               s3:
@@ -114,6 +116,8 @@ class YamlConfigLoaderTest {
         assertEquals(EmailNotifyLevel.ERROR, config.backup().emailNotify().level());
         assertEquals("admin@example.com", config.backup().emailNotify().recipient());
         assertEquals("root@example.com", config.backup().emailNotify().sender());
+        assertEquals("mail.example.com", config.backup().emailNotify().smtpHost());
+        assertEquals(587, config.backup().emailNotify().smtpPort());
         assertEquals(true, config.allowInsecure());
 
         assertEquals(StorageBackend.S3, config.storage().backend());
@@ -150,6 +154,8 @@ class YamlConfigLoaderTest {
         assertEquals(30, config.backup().rotateDays());
         assertTrue(config.backup().lockBackup());
         assertEquals(EmailNotifyLevel.ALL, config.backup().emailNotify().level());
+        assertEquals(EmailNotifyConfig.DEFAULT_SMTP_HOST, config.backup().emailNotify().smtpHost());
+        assertEquals(EmailNotifyConfig.DEFAULT_SMTP_PORT, config.backup().emailNotify().smtpPort());
         assertEquals(false, config.allowInsecure());
         assertEquals(StorageBackend.LOCAL, config.storage().backend());
         assertEquals(null, config.storage().s3());

--- a/aws/src/main/java/io/zmbackup/aws/DynamoDBMetadataStore.java
+++ b/aws/src/main/java/io/zmbackup/aws/DynamoDBMetadataStore.java
@@ -45,6 +45,7 @@ public final class DynamoDBMetadataStore implements MetadataStore {
     private static final int BATCH_WRITE_SIZE = 25;
     private static final int MAX_UNPROCESSED_KEYS_RETRIES = 8;
     private static final long UNPROCESSED_KEYS_BASE_BACKOFF_MILLIS = 50;
+    private static final int RECENT_CANDIDATE_LIMIT = 5;
 
     private final DynamoDbClient client;
     private final String sessionTable;
@@ -201,24 +202,20 @@ public final class DynamoDBMetadataStore implements MetadataStore {
 
     @Override
     public Optional<Instant> lastSuccessfulBackupTime(String email) throws IOException {
-        List<BackupAccountRecord> candidates = queryAccountsByEmail(email);
-        Set<String> mailboxPrefixes = new HashSet<>(BackupType.mailboxSessionPrefixes());
-        List<BackupAccountRecord> mailboxCandidates = new ArrayList<>();
-        for (BackupAccountRecord candidate : candidates) {
-            if (mailboxPrefixes.contains(sessionPrefixOf(candidate.sessionId()))) {
-                mailboxCandidates.add(candidate);
-            }
+        List<BackupAccountRecord> candidates = new ArrayList<>();
+        for (String prefix : BackupType.mailboxSessionPrefixes()) {
+            candidates.addAll(queryMostRecentByPrefix(email, prefix, RECENT_CANDIDATE_LIMIT));
         }
-        if (mailboxCandidates.isEmpty()) {
+        if (candidates.isEmpty()) {
             return Optional.empty();
         }
         Set<String> sessionIds = new HashSet<>();
-        for (BackupAccountRecord candidate : mailboxCandidates) {
+        for (BackupAccountRecord candidate : candidates) {
             sessionIds.add(candidate.sessionId());
         }
         Set<String> nonInProgress = nonInProgressSessionIds(sessionIds);
         Instant latest = null;
-        for (BackupAccountRecord candidate : mailboxCandidates) {
+        for (BackupAccountRecord candidate : candidates) {
             if (!nonInProgress.contains(candidate.sessionId()) || candidate.completedAt() == null) {
                 continue;
             }
@@ -231,40 +228,32 @@ public final class DynamoDBMetadataStore implements MetadataStore {
 
     @Override
     public boolean backedUpSince(String identifier, BackupType type, Instant since) throws IOException {
-        Set<String> conflictingPrefixes = new HashSet<>(type.conflictingSessionPrefixes());
-        for (BackupAccountRecord record : queryAccountsByEmail(identifier)) {
-            if (record.completedAt() != null
-                    && record.completedAt().isAfter(since)
-                    && conflictingPrefixes.contains(sessionPrefixOf(record.sessionId()))) {
-                return true;
+        for (String prefix : type.conflictingSessionPrefixes()) {
+            for (BackupAccountRecord record : queryMostRecentByPrefix(identifier, prefix, RECENT_CANDIDATE_LIMIT)) {
+                if (record.completedAt() != null && record.completedAt().isAfter(since)) {
+                    return true;
+                }
             }
         }
         return false;
     }
 
-    private static String sessionPrefixOf(String sessionId) {
-        int dash = sessionId.indexOf('-');
-        return dash < 0 ? sessionId : sessionId.substring(0, dash);
-    }
-
-    private List<BackupAccountRecord> queryAccountsByEmail(String email) throws IOException {
+    private List<BackupAccountRecord> queryMostRecentByPrefix(String email, String prefix, int limit)
+            throws IOException {
         try {
-            List<BackupAccountRecord> records = new ArrayList<>();
-            Map<String, AttributeValue> lastKey = null;
-            do {
-                QueryRequest.Builder requestBuilder = QueryRequest.builder()
-                        .tableName(accountTable)
-                        .keyConditionExpression("email = :email")
-                        .expressionAttributeValues(Map.of(":email", AttributeValue.fromS(email)));
-                if (lastKey != null) {
-                    requestBuilder.exclusiveStartKey(lastKey);
-                }
-                QueryResponse response = client.query(requestBuilder.build());
-                for (Map<String, AttributeValue> item : response.items()) {
-                    records.add(mapAccount(item));
-                }
-                lastKey = response.lastEvaluatedKey();
-            } while (lastKey != null && !lastKey.isEmpty());
+            QueryResponse response = client.query(QueryRequest.builder()
+                    .tableName(accountTable)
+                    .keyConditionExpression("email = :email and begins_with(sessionId, :prefix)")
+                    .expressionAttributeValues(Map.of(
+                            ":email", AttributeValue.fromS(email),
+                            ":prefix", AttributeValue.fromS(prefix)))
+                    .scanIndexForward(false)
+                    .limit(limit)
+                    .build());
+            List<BackupAccountRecord> records = new ArrayList<>(response.items().size());
+            for (Map<String, AttributeValue> item : response.items()) {
+                records.add(mapAccount(item));
+            }
             return records;
         } catch (SdkException e) {
             throw new IOException(e);

--- a/aws/src/test/java/io/zmbackup/aws/DynamoDBMetadataStoreTest.java
+++ b/aws/src/test/java/io/zmbackup/aws/DynamoDBMetadataStoreTest.java
@@ -258,15 +258,9 @@ class DynamoDBMetadataStoreTest {
 
     @Test
     void lastSuccessfulBackupTimeIgnoresInProgressAndNonMailboxSessions() throws IOException {
-        wireMockServer.stubFor(post(anyPath())
-                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Query"))
-                .willReturn(jsonResponse("{\"Items\":["
-                        + accountItem("full-20260101120000", "alice@example.com", "2026-01-01T12:00:00Z")
-                        + ","
-                        + accountItem("mbox-20260201120000", "alice@example.com", "2026-02-01T12:00:00Z")
-                        + ","
-                        + accountItem("ldap-20260301120000", "alice@example.com", "2026-03-01T12:00:00Z")
-                        + "]}")));
+        stubQueryForPrefix("full", accountItem("full-20260101120000", "alice@example.com", "2026-01-01T12:00:00Z"));
+        stubQueryForPrefix("mbox", accountItem("mbox-20260201120000", "alice@example.com", "2026-02-01T12:00:00Z"));
+        stubQueryForPrefix("inc");
         wireMockServer.stubFor(post(anyPath())
                 .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.BatchGetItem"))
                 .willReturn(jsonResponse("{\"Responses\":{\"" + SESSION_TABLE + "\":["
@@ -278,6 +272,20 @@ class DynamoDBMetadataStoreTest {
 
         assertTrue(result.isPresent());
         assertEquals(Instant.parse("2026-01-01T12:00:00Z"), result.get());
+    }
+
+    @Test
+    void lastSuccessfulBackupTimeQueriesEachMailboxPrefixWithABoundedDescendingLimit() throws IOException {
+        stubTarget("Query", "{\"Items\":[]}");
+
+        Optional<Instant> result = store().lastSuccessfulBackupTime("alice@example.com");
+
+        assertTrue(result.isEmpty());
+        wireMockServer.verify(postRequestedFor(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Query"))
+                .withRequestBody(containing("begins_with(sessionId, :prefix)"))
+                .withRequestBody(containing("\"ScanIndexForward\":false"))
+                .withRequestBody(containing("\"Limit\":5")));
     }
 
     @Test
@@ -326,11 +334,10 @@ class DynamoDBMetadataStoreTest {
 
     @Test
     void backedUpSinceIsFalseForANonOverlappingBackupType() throws IOException {
-        wireMockServer.stubFor(post(anyPath())
-                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Query"))
-                .willReturn(jsonResponse("{\"Items\":["
-                        + accountItem("ldap-20260101120000", "alice@example.com", "2026-01-01T12:00:00Z")
-                        + "]}")));
+        stubQueryForPrefix("ldap", accountItem("ldap-20260101120000", "alice@example.com", "2026-01-01T12:00:00Z"));
+        stubQueryForPrefix("full");
+        stubQueryForPrefix("inc");
+        stubQueryForPrefix("mbox");
 
         assertFalse(store().backedUpSince(
                 "alice@example.com", BackupType.MAILBOX, Instant.parse("2025-12-01T00:00:00Z")));
@@ -338,11 +345,7 @@ class DynamoDBMetadataStoreTest {
 
     @Test
     void backedUpSinceIsTrueForMailboxWhenAFullBackupAlreadyCoveredItToday() throws IOException {
-        wireMockServer.stubFor(post(anyPath())
-                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Query"))
-                .willReturn(jsonResponse("{\"Items\":["
-                        + accountItem("full-20260101120000", "alice@example.com", "2026-01-01T12:00:00Z")
-                        + "]}")));
+        stubQueryForPrefix("full", accountItem("full-20260101120000", "alice@example.com", "2026-01-01T12:00:00Z"));
 
         assertTrue(store().backedUpSince(
                 "alice@example.com", BackupType.MAILBOX, Instant.parse("2025-12-01T00:00:00Z")));
@@ -357,6 +360,13 @@ class DynamoDBMetadataStoreTest {
         wireMockServer.stubFor(post(anyPath())
                 .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810." + operation))
                 .willReturn(jsonResponse(responseBody)));
+    }
+
+    private void stubQueryForPrefix(String prefix, String... items) {
+        wireMockServer.stubFor(post(anyPath())
+                .withHeader("X-Amz-Target", equalTo("DynamoDB_20120810.Query"))
+                .withRequestBody(containing("\"S\":\"" + prefix + "\""))
+                .willReturn(jsonResponse("{\"Items\":[" + String.join(",", items) + "]}")));
     }
 
     private static com.github.tomakehurst.wiremock.matching.UrlPattern anyPath() {

--- a/core/src/main/java/io/zmbackup/core/domain/Identifiers.java
+++ b/core/src/main/java/io/zmbackup/core/domain/Identifiers.java
@@ -1,0 +1,11 @@
+package io.zmbackup.core.domain;
+
+import java.util.regex.Pattern;
+
+public final class Identifiers {
+
+    public static final Pattern EMAIL = Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+    public static final Pattern DOMAIN = Pattern.compile("^[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+
+    private Identifiers() {}
+}

--- a/core/src/main/java/io/zmbackup/core/service/BackupService.java
+++ b/core/src/main/java/io/zmbackup/core/service/BackupService.java
@@ -3,6 +3,7 @@ package io.zmbackup.core.service;
 import io.zmbackup.core.domain.BackupAccountRecord;
 import io.zmbackup.core.domain.BackupSession;
 import io.zmbackup.core.domain.BackupType;
+import io.zmbackup.core.domain.Identifiers;
 import io.zmbackup.core.domain.LdapObjectType;
 import io.zmbackup.core.domain.SessionStatus;
 import io.zmbackup.core.port.AccountDiscovery;
@@ -44,10 +45,6 @@ public class BackupService {
             DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneId.systemDefault());
     private static final String LDIFF_SUFFIX = "ldiff";
     private static final String TGZ_SUFFIX = "tgz";
-
-    private static final Pattern DISCOVERED_EMAIL = Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
-
-    private static final Pattern DISCOVERED_DOMAIN = Pattern.compile("^[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
 
     private static final Duration INCREMENTAL_LOOKBACK = Duration.ofHours(48);
 
@@ -320,7 +317,7 @@ public class BackupService {
         if (objectType == LdapObjectType.SIGNATURE) {
             return identifiers;
         }
-        Pattern pattern = objectType == LdapObjectType.DOMAIN ? DISCOVERED_DOMAIN : DISCOVERED_EMAIL;
+        Pattern pattern = objectType == LdapObjectType.DOMAIN ? Identifiers.DOMAIN : Identifiers.EMAIL;
         List<String> allowed = new ArrayList<>(identifiers.size());
         for (String identifier : identifiers) {
             if (pattern.matcher(identifier).matches()) {
@@ -346,13 +343,19 @@ public class BackupService {
 
     private List<String> filterAlreadyBackedUpToday(BackupType type, List<String> identifiers, boolean force)
             throws IOException {
-        if (!lockBackup || force) {
+        if (!lockBackup || force || identifiers.isEmpty()) {
             return identifiers;
         }
         Instant since = Instant.now().minus(LOCK_BACKUP_WINDOW);
-        List<String> allowed = new ArrayList<>(identifiers.size());
+        List<Callable<Boolean>> tasks = new ArrayList<>(identifiers.size());
         for (String identifier : identifiers) {
-            if (metadataStore.backedUpSince(identifier, type, since)) {
+            tasks.add(() -> metadataStore.backedUpSince(identifier, type, since));
+        }
+        List<Boolean> alreadyBackedUp = Parallel.run(maxParallelProcesses, tasks);
+        List<String> allowed = new ArrayList<>(identifiers.size());
+        for (int i = 0; i < identifiers.size(); i++) {
+            String identifier = identifiers.get(i);
+            if (alreadyBackedUp.get(i)) {
                 LOG.info(() -> identifier + " already has backup today - skipping.");
             } else {
                 allowed.add(identifier);

--- a/core/src/test/java/io/zmbackup/core/domain/IdentifiersTest.java
+++ b/core/src/test/java/io/zmbackup/core/domain/IdentifiersTest.java
@@ -1,0 +1,29 @@
+package io.zmbackup.core.domain;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class IdentifiersTest {
+
+    @Test
+    void emailMatchesAWellFormedAddress() {
+        assertTrue(Identifiers.EMAIL.matcher("alice@example.com").matches());
+    }
+
+    @Test
+    void emailRejectsAValueWithNoAtSign() {
+        assertFalse(Identifiers.EMAIL.matcher("alice.example.com").matches());
+    }
+
+    @Test
+    void domainMatchesAWellFormedDomain() {
+        assertTrue(Identifiers.DOMAIN.matcher("example.com").matches());
+    }
+
+    @Test
+    void domainRejectsAValueContainingAnAtSign() {
+        assertFalse(Identifiers.DOMAIN.matcher("alice@example.com").matches());
+    }
+}

--- a/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/UnboundIdLdapAdapter.java
@@ -27,6 +27,7 @@ import com.unboundid.ldif.LDIFWriter;
 import com.unboundid.util.ssl.PEMFileTrustManager;
 import com.unboundid.util.ssl.SSLUtil;
 import com.unboundid.util.ssl.TrustAllTrustManager;
+import io.zmbackup.core.domain.Identifiers;
 import io.zmbackup.core.domain.LdapObjectType;
 import io.zmbackup.core.port.AccountDiscovery;
 import io.zmbackup.core.port.ZimbraLdapExporter;
@@ -225,7 +226,7 @@ public class UnboundIdLdapAdapter implements AccountDiscovery, ZimbraLdapExporte
         return type.objectFilter();
     }
 
-    private static final Pattern DOMAIN_PATTERN = Pattern.compile("^[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+    private static final Pattern DOMAIN_PATTERN = Identifiers.DOMAIN;
 
     private static String domainBaseDn(String domain) throws IOException {
         if (!DOMAIN_PATTERN.matcher(domain).matches()) {

--- a/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
@@ -3,6 +3,7 @@ package io.zmbackup.zimbra;
 import com.unboundid.util.ssl.PEMFileTrustManager;
 import com.unboundid.util.ssl.SSLUtil;
 import com.unboundid.util.ssl.TrustAllTrustManager;
+import io.zmbackup.core.domain.Identifiers;
 import io.zmbackup.core.port.ZimbraMailboxExporter;
 import java.io.File;
 import java.io.IOException;
@@ -37,8 +38,7 @@ public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
     private static final DateTimeFormatter AFTER_DATE_FORMAT =
             DateTimeFormatter.ofPattern("MM/dd/yyyy").withZone(ZoneId.systemDefault());
 
-    private static final Pattern ACCOUNT_PATTERN =
-            Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+    private static final Pattern ACCOUNT_PATTERN = Identifiers.EMAIL;
 
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(30);
 


### PR DESCRIPTION
## Summary

Four independent code-review improvements, each covered by tests:

- **Shared identifier patterns**: the email/domain regexes were independently duplicated in `BackupService`, `CliValidation`, `ZimbraRestMailboxExporter`, and `UnboundIdLdapAdapter`. Consolidated into a new `core.domain.Identifiers` (all four modules already depend on `core`), removing the drift risk of four copies staying in sync by hand.
- **Bounded DynamoDB history queries**: `DynamoDBMetadataStore.lastSuccessfulBackupTime`/`backedUpSince` previously read an account's *entire* backup history on every incremental-cutoff and lockBackup-dedup check. They now issue one `Query` per relevant `BackupType` prefix with `begins_with(sessionId, :prefix)` + `ScanIndexForward(false)` + a small `Limit`, so the cost stays bounded regardless of how long an account's backup history grows.
- **Parallelized dedup check**: `BackupService.filterAlreadyBackedUpToday` issued one sequential `MetadataStore.backedUpSince` call per discovered identifier. It now fans those out through the existing `Parallel.run` (same pool used for the exports themselves), matching how the rest of discovery/export work is already parallelized.
- **Configurable SMTP relay**: `EmailNotifier`'s SMTP host/port were hardcoded to `localhost:25` in `AppContext`. Added `backup.emailNotify.smtpHost`/`smtpPort` to `zmbackup.yaml` (defaulting to `localhost`/`25`, so existing configs are unaffected).

## Test plan

- [x] `./gradlew check` (all modules: tests, SpotBugs, JaCoCo coverage gates) passes
- [x] New/updated unit tests: `IdentifiersTest`, `DynamoDBMetadataStoreTest` (new bounded-query assertions + rewritten per-prefix stubs for the affected `lastSuccessfulBackupTime`/`backedUpSince` cases), `EmailNotifyConfigTest`, `YamlConfigLoaderTest`, existing `BackupServiceTest`/`AppContextTest`/`CliValidationTest`/`ZimbraRestMailboxExporterTest`/`UnboundIdLdapAdapterTest` suites re-verified against the refactor

zmbackupdocs is being updated alongside this PR per its own CLAUDE.md convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwhyvnhT3cgrXqnrYFxjEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwhyvnhT3cgrXqnrYFxjEe)_