### PR TITLE
Add indexes on backup_account.email and backup_account.sessionID

### DIFF
--- a/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
+++ b/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
@@ -49,6 +49,12 @@ public class SqliteMetadataStore implements MetadataStore, Closeable {
             )
             """;
 
+    private static final String CREATE_INDEX_BACKUP_ACCOUNT_EMAIL =
+            "create index if not exists idx_backup_account_email on backup_account(email)";
+
+    private static final String CREATE_INDEX_BACKUP_ACCOUNT_SESSION_ID =
+            "create index if not exists idx_backup_account_sessionID on backup_account(sessionID)";
+
     private static final String SQLITE_URI_PREFIX = "file:";
 
     private final ReentrantLock lock = new ReentrantLock();
@@ -63,6 +69,8 @@ public class SqliteMetadataStore implements MetadataStore, Closeable {
             try (Statement statement = connection.createStatement()) {
                 statement.execute(CREATE_BACKUP_SESSION);
                 statement.execute(CREATE_BACKUP_ACCOUNT);
+                statement.execute(CREATE_INDEX_BACKUP_ACCOUNT_EMAIL);
+                statement.execute(CREATE_INDEX_BACKUP_ACCOUNT_SESSION_ID);
             }
         } catch (SQLException e) {
             throw new IOException(e);

--- a/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
+++ b/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
@@ -2,6 +2,7 @@ package io.zmbackup.local;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.zmbackup.core.domain.BackupAccountRecord;
 import io.zmbackup.core.domain.BackupSession;
@@ -12,8 +13,14 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
@@ -283,6 +290,26 @@ class SqliteMetadataStoreTest {
 
         assertEquals(
                 true, store.backedUpSince("user@example.com", BackupType.MAILBOX, now.minus(24, ChronoUnit.HOURS)));
+    }
+
+    @Test
+    void constructingStoreCreatesIndexesOnFrequentlyQueriedBackupAccountColumns(@TempDir Path workDir)
+            throws IOException, SQLException {
+        Path databaseFile = workDir.resolve("sessions.sqlite3");
+
+        new SqliteMetadataStore(databaseFile).close();
+
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + databaseFile);
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery(
+                        "select name from sqlite_master where type = 'index' and tbl_name = 'backup_account'")) {
+            List<String> indexNames = new ArrayList<>();
+            while (rs.next()) {
+                indexNames.add(rs.getString("name"));
+            }
+            assertTrue(indexNames.contains("idx_backup_account_email"));
+            assertTrue(indexNames.contains("idx_backup_account_sessionID"));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `SqliteMetadataStore` now creates `idx_backup_account_email` and `idx_backup_account_sessionID` alongside its existing `create table if not exists` DDL, so `backup_account` lookups by `email`/`sessionID` are no longer full table scans as the number of backup sessions/accounts grows.
- These are the columns actually filtered/joined on in `lastSuccessfulBackupTime`, `backedUpSince`, `deleteSession`, and `findAccountsForSession`. `backup_session` doesn't get a separate index on `sessionID` since it's already that table's primary key (and thus already indexed by SQLite).
- Because the DDL runs with `create index if not exists` in the constructor (same pattern as the table DDL), existing `sessions.sqlite3` databases pick up the new indexes automatically the next time any zmbackup command opens them — no separate migration step needed.
- Companion doc update in `zmbackupdocs` (`specs/04-data-model.md §3`) describing the new indexes: https://github.com/lucascbeyeler/zmbackupdocs/pull/new/claude/issue-231-v6q2th

Fixes #231

## Test plan
- [x] `./gradlew :local:test --tests "io.zmbackup.local.SqliteMetadataStoreTest"` — 29 tests pass, including a new test asserting both indexes exist in `sqlite_master` after construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiAHnKXscHZh8k7K34ipqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiAHnKXscHZh8k7K34ipqn)_