### PR TITLE
Add server config backup/restore (BackupType.SERVER_CONFIG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,13 @@ The table below documents what zmbackup covers.
 - **Restoring `serverconfig` writes files directly back to their original host paths**, not through
   any Zimbra API — unlike every other restore in this table. It does not stop or reload Zimbra
   services for you; restart the affected services (or run `zmcertmgr`/`zmcontrol restart` as
-  appropriate) after restoring certificates, keystores, or `localconfig.xml`. A restore is
-  all-or-nothing: if the archive contains anything that doesn't resolve back under the currently
-  configured `serverConfig.paths`, nothing in it is written.
+  appropriate) after restoring certificates, keystores, or `localconfig.xml`. If the archive contains
+  anything that doesn't resolve back under the currently configured `serverConfig.paths`, the whole
+  restore is refused and nothing is written - that check is a security boundary. A file that *is* in
+  the allowed paths but that `zimbraMailbox.backupUser` simply doesn't have permission to overwrite
+  (e.g. a root-owned file under `/opt/zimbra/conf/crontabs` on a stock install) is skipped
+  individually instead - the restore still reports success, and `zmbackup.log`/syslog names exactly
+  which files were skipped and why.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
Closes the last gap in the Backup & Restore Scope table — Zimbra component passwords, TLS certificates, Java keystores, and server config were previously never touched by zmbackup at all.

- New `backup serverconfig`/`restore serverconfig` pair archives whatever paths are configured in `serverConfig.paths` (default `/opt/zimbra/conf`, `/opt/zimbra/ssl`) as a single permission-preserving zip.
- Restore validates every archive entry against the same allow-list before writing anything — an entry that doesn't resolve back under `serverConfig.paths` aborts the whole restore (security boundary, unchanged).
- **Restore is best-effort per file, not all-or-nothing**, for permission (not security) failures: found by testing against a real Zimbra host where `/opt/zimbra/conf/crontabs` is root-owned and unwritable by the `zimbra` user. A file the backup user genuinely can't write is now skipped individually and logged, rather than aborting the restore of every cert and `localconfig.xml` the account *can* write.
- Fixes `BackupType.conflictingSessionPrefixes()`, which previously returned an empty conflict list for any type with neither `includesLdap()` nor `includesMailbox()` set — `SERVER_CONFIG` is the first such type, and the empty list would have produced invalid SQL in `SqliteMetadataStore.backedUpSince` under the default `lockBackup: true`.
- Suppresses a SpotBugs `DMI_HARDCODED_ABSOLUTE_FILENAME` false positive on `ServerConfigFileArchiver`'s intentional `Path.of("/")` filesystem-root constant.
- README updated: scope table, and documents the best-effort-per-file restore behavior.

## Test plan
- [x] `./gradlew test` — all modules pass
- [x] Live-verified against a real Zimbra test host: backed up its actual `/opt/zimbra/conf` and `/opt/zimbra/ssl`, restored the archive in place, confirmed content/permissions match exactly for every file `zimbra` can write, and the root-owned `crontabs` files are correctly reported as skipped rather than failing the whole restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XEb2hq3wW49AAuVmAebjA