### PR TITLE
Lower the Java toolchain from 21 to 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
 
   test-java:
     docker:
-      - image: cimg/openjdk:21.0
+      - image: cimg/openjdk:17.0
     steps:
       - checkout
       - run:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The table below documents what zmbackup covers.
 
 ## Requirements
 
-- **Java 21 (JDK)** - required to build and run zmbackup; the Gradle toolchain will download it automatically if it isn't already installed.
+- **Java 17 (JDK)** - required to build and run zmbackup; the Gradle toolchain will download it automatically if it isn't already installed.
 
 ## Installation
 
@@ -79,7 +79,7 @@ git clone -b master https://github.com/lucascbeyeler/zmbackup.git
 ```
 
 Inside the project folder, execute the script **install-java.sh** and follow all the instructions
-to install the project. It checks for (and, if missing, installs) a Java 21 JDK, builds
+to install the project. It checks for (and, if missing, installs) a Java 17 JDK, builds
 `zmbackup.jar` with the bundled Gradle wrapper, then installs the jar, a thin `zmbackup` launcher,
 `zmbackup.yaml`, the blocked list and a cron file.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ subprojects {
 
     configure<JavaPluginExtension> {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(21))
+            languageVersion.set(JavaLanguageVersion.of(17))
         }
     }
 

--- a/installScriptJava/vars.sh
+++ b/installScriptJava/vars.sh
@@ -14,7 +14,7 @@ ZMBKP_LIB="/usr/local/lib/zmbackup"
 ZMBKP_JAR_NAME="zmbackup.jar"
 ZMBKP_CRON_FILE="/etc/cron.d/zmbackup"
 
-JAVA_MIN_VERSION="21"
+JAVA_MIN_VERSION="17"
 
 OSE_USER="zimbra"
 OSE_INSTALL_DIR="/opt/zimbra"

--- a/tests/unit/test_installer_java_check.bats
+++ b/tests/unit/test_installer_java_check.bats
@@ -19,33 +19,33 @@ setup() {
   [[ "$output" == *"NOT FOUND"* ]]
 }
 
-@test "check_java_runtime: sets NEED_JAVA=N when an OpenJDK 21 runtime is present" {
-  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "21.0.5" 2024-10-15
-OpenJDK Runtime Environment (build 21.0.5+11)'
+@test "check_java_runtime: sets NEED_JAVA=N when an OpenJDK 17 runtime is present" {
+  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "17.0.9" 2023-10-17
+OpenJDK Runtime Environment (build 17.0.9+9)'
   check_java_runtime
   [ "$NEED_JAVA" = "N" ]
 }
 
-@test "check_java_runtime: reports OK when an OpenJDK 21 runtime is present" {
-  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "21.0.5" 2024-10-15'
+@test "check_java_runtime: reports OK when an OpenJDK 17 runtime is present" {
+  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "17.0.9" 2023-10-17'
   run check_java_runtime
   [[ "$output" == *"OK"* ]]
 }
 
-@test "check_java_runtime: sets NEED_JAVA=Y when the runtime is older than 21" {
-  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "17.0.9" 2023-10-17'
+@test "check_java_runtime: sets NEED_JAVA=Y when the runtime is older than 17" {
+  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "11.0.20" 2023-07-18'
   check_java_runtime
   [ "$NEED_JAVA" = "Y" ]
 }
 
-@test "check_java_runtime: reports TOO OLD when the runtime is older than 21" {
-  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "17.0.9" 2023-10-17'
+@test "check_java_runtime: reports TOO OLD when the runtime is older than 17" {
+  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "11.0.20" 2023-07-18'
   run check_java_runtime
   [[ "$output" == *"TOO OLD"* ]]
 }
 
 @test "check_java_runtime: accepts a newer major version than the minimum" {
-  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "23.0.1" 2024-10-15'
+  export MOCK_JAVA_VERSION_OUTPUT='openjdk version "21.0.5" 2024-10-15'
   check_java_runtime
   [ "$NEED_JAVA" = "N" ]
 }

--- a/tests/unit/test_installer_java_depDownload.bats
+++ b/tests/unit/test_installer_java_depDownload.bats
@@ -27,7 +27,7 @@ setup() {
 @test "install_java_ubuntu: prints manual command hint naming the JDK package" {
   export MOCK_APT_FAIL=1
   run install_java_ubuntu
-  [[ "$output" == *"openjdk-21-jdk"* ]]
+  [[ "$output" == *"openjdk-17-jdk"* ]]
 }
 
 @test "install_java_redhat: succeeds when yum succeeds" {
@@ -47,5 +47,5 @@ setup() {
 @test "install_java_redhat: prints manual command hint naming the JDK package" {
   export MOCK_YUM_FAIL=1
   run install_java_redhat
-  [[ "$output" == *"java-21-openjdk-devel"* ]]
+  [[ "$output" == *"java-17-openjdk-devel"* ]]
 }

--- a/tests/unit/test_installer_java_vars.bats
+++ b/tests/unit/test_installer_java_vars.bats
@@ -45,8 +45,8 @@ setup() {
   [ "$ZMBKP_JAR_NAME" = "zmbackup.jar" ]
 }
 
-@test "vars: JAVA_MIN_VERSION is 21" {
-  [ "$JAVA_MIN_VERSION" = "21" ]
+@test "vars: JAVA_MIN_VERSION is 17" {
+  [ "$JAVA_MIN_VERSION" = "17" ]
 }
 
 @test "vars: OSE_USER is zimbra" {


### PR DESCRIPTION
## Summary
- Nothing in the codebase actually needs a Java-21-only language feature or API, and pinning the Gradle toolchain (`build.gradle.kts`) to 21 meant the built jar's class files (version 65) couldn't run on any JVM older than 21
- That's what broke the 2.0 BETA on the Zimbra host in #214: `install-java.sh` reported a successful install, but `zmbackup` itself then failed with `UnsupportedClassVersionError` because the host's runtime only supports up to Java 17 (class file version 61)
- Lowers `JavaLanguageVersion` to 17 in `build.gradle.kts`, `JAVA_MIN_VERSION` to `"17"` in `installScriptJava/vars.sh` (so the installer's own version check/auto-install target Java 17), the CircleCI `test-java` image to `cimg/openjdk:17.0`, README, and the bats tests that assert these values
- Companion docs update in [lucascbeyeler/zmbackupdocs#33](https://github.com/lucascbeyeler/zmbackupdocs/pull/33)

## Test plan
- [x] `./gradlew check` — full build, unit tests, JaCoCo coverage verification, and SpotBugs all pass against the Java 17 toolchain
- [x] Verified the built `app/build/libs/zmbackup.jar`'s class files are now version 61 (Java 17), down from 65 (Java 21)
- [x] `npx bats --verbose-run tests/unit/` — all installer bats tests pass, including the updated `JAVA_MIN_VERSION`/`check_java_runtime`/package-name assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkYcJTvyPEQWw1wnajAVjL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkYcJTvyPEQWw1wnajAVjL)_