### PR TITLE
Acquire the run lock before opening the SQLite metadata store

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -157,7 +157,7 @@ public final class AppContext {
         return new SqliteMetadataStore(config.backup().workDir().resolve(METADATA_STORE_FILENAME));
     }
 
-    public RunLock acquireRunLock() throws IOException {
+    public static RunLock acquireRunLock(AppConfig config) throws IOException {
         if (config.metadata().backend() == MetadataBackend.DYNAMODB) {
             DynamoDbConfig dynamodb = config.metadata().dynamodb();
             return DynamoDBLock.acquire(

--- a/app/src/main/java/io/zmbackup/app/PidLock.java
+++ b/app/src/main/java/io/zmbackup/app/PidLock.java
@@ -2,6 +2,7 @@ package io.zmbackup.app;
 
 import io.zmbackup.core.port.LockContentionException;
 import io.zmbackup.core.port.RunLock;
+import io.zmbackup.local.PosixFileHardening;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -24,6 +25,7 @@ public final class PidLock implements RunLock {
     }
 
     public static PidLock acquire(Path workDir) throws IOException {
+        PosixFileHardening.createDirectories(workDir);
         Path lockFile = workDir.resolve(LOCK_FILENAME);
         FileChannel channel = FileChannel.open(
                 lockFile, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);

--- a/app/src/main/java/io/zmbackup/app/cli/AbstractBackupCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/AbstractBackupCommand.java
@@ -1,6 +1,5 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.BackupType;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -31,11 +30,10 @@ abstract class AbstractBackupCommand implements Callable<Integer> {
 
     @Override
     public final Integer call() throws Exception {
-        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
         return LockedExecution.run(
-                context,
+                parent.parent().configFile(),
                 spec.commandLine().getErr(),
-                () -> BackupRunner.run(
+                context -> BackupRunner.run(
                         context,
                         spec.commandLine().getOut(),
                         spec.commandLine().getErr(),

--- a/app/src/main/java/io/zmbackup/app/cli/DeleteCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/DeleteCommand.java
@@ -1,6 +1,5 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import java.io.PrintWriter;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
@@ -29,10 +28,9 @@ public final class DeleteCommand implements Callable<Integer> {
             return CommandLine.ExitCode.USAGE;
         }
 
-        AppContext context = AppContext.fromConfigFile(parent.configFile());
         PrintWriter out = spec.commandLine().getOut();
 
-        return LockedExecution.run(context, err, () -> {
+        return LockedExecution.run(parent.configFile(), err, context -> {
             out.println("Removing session " + sessionId + " - please wait.");
             if (context.sessionService().deleteSession(sessionId)) {
                 out.println("Backup session " + sessionId + " removed.");

--- a/app/src/main/java/io/zmbackup/app/cli/HousekeepCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/HousekeepCommand.java
@@ -1,6 +1,5 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.BackupSession;
 import io.zmbackup.core.service.HousekeepService;
 import java.io.PrintWriter;
@@ -22,11 +21,10 @@ public final class HousekeepCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        AppContext context = AppContext.fromConfigFile(parent.configFile());
         PrintWriter out = spec.commandLine().getOut();
-        HousekeepService housekeepService = context.housekeepService();
 
-        return LockedExecution.run(context, spec.commandLine().getErr(), () -> {
+        return LockedExecution.run(parent.configFile(), spec.commandLine().getErr(), context -> {
+            HousekeepService housekeepService = context.housekeepService();
             out.println("Removing old backup sessions - please wait.");
             List<BackupSession> rotated =
                     housekeepService.rotateOldSessions(context.config().backup().rotateDays());

--- a/app/src/main/java/io/zmbackup/app/cli/LockedExecution.java
+++ b/app/src/main/java/io/zmbackup/app/cli/LockedExecution.java
@@ -1,22 +1,29 @@
 package io.zmbackup.app.cli;
 
 import io.zmbackup.app.AppContext;
+import io.zmbackup.app.config.AppConfig;
+import io.zmbackup.app.config.YamlConfigLoader;
 import io.zmbackup.core.port.LockContentionException;
 import io.zmbackup.core.port.RunLock;
 import java.io.PrintWriter;
-import java.util.concurrent.Callable;
+import java.nio.file.Path;
 import picocli.CommandLine;
 
 final class LockedExecution {
 
     private LockedExecution() {}
 
-    static Integer run(AppContext context, PrintWriter err, Callable<Integer> body) throws Exception {
-        try (RunLock lock = context.acquireRunLock()) {
-            return body.call();
+    static Integer run(Path configFile, PrintWriter err, ContextBody body) throws Exception {
+        AppConfig config = YamlConfigLoader.load(configFile);
+        try (RunLock lock = AppContext.acquireRunLock(config)) {
+            return body.call(new AppContext(config));
         } catch (LockContentionException e) {
             err.println(e.getMessage());
             return CommandLine.ExitCode.SOFTWARE;
         }
+    }
+
+    interface ContextBody {
+        Integer call(AppContext context) throws Exception;
     }
 }

--- a/app/src/main/java/io/zmbackup/app/cli/MigrateCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/MigrateCommand.java
@@ -1,6 +1,5 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,13 +25,12 @@ public final class MigrateCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        AppContext context = AppContext.fromConfigFile(parent.configFile());
         PrintWriter out = spec.commandLine().getOut();
         PrintWriter err = spec.commandLine().getErr();
-        Path workDir = context.config().backup().workDir();
-        Path sessionsTxt = workDir.resolve(SESSIONS_TXT);
 
-        return LockedExecution.run(context, err, () -> {
+        return LockedExecution.run(parent.configFile(), err, context -> {
+            Path workDir = context.config().backup().workDir();
+            Path sessionsTxt = workDir.resolve(SESSIONS_TXT);
             if (!Files.exists(sessionsTxt)) {
                 out.println("No " + SESSIONS_TXT + " found in " + workDir + " - nothing to migrate.");
                 return 0;

--- a/app/src/main/java/io/zmbackup/app/cli/MigrateToCloudCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/MigrateToCloudCommand.java
@@ -1,6 +1,5 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.CloudMigrationResult;
 import io.zmbackup.core.service.CloudMigrationService;
 import io.zmbackup.local.LocalStorageProvider;
@@ -36,10 +35,9 @@ public final class MigrateToCloudCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        AppContext context = AppContext.fromConfigFile(parent.configFile());
         PrintWriter out = spec.commandLine().getOut();
 
-        return LockedExecution.run(context, spec.commandLine().getErr(), () -> {
+        return LockedExecution.run(parent.configFile(), spec.commandLine().getErr(), context -> {
             try (SqliteMetadataStore sourceMetadata = new SqliteMetadataStore(sourceDb)) {
                 LocalStorageProvider sourceStorage = new LocalStorageProvider(sourceDir);
                 CloudMigrationService migrationService = new CloudMigrationService(

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreCommand.java
@@ -1,6 +1,5 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.RestoreResult;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -65,9 +64,8 @@ public final class RestoreCommand implements Callable<Integer> {
             return CommandLine.ExitCode.USAGE;
         }
 
-        AppContext context = AppContext.fromConfigFile(parent.configFile());
         PrintWriter out = spec.commandLine().getOut();
-        return LockedExecution.run(context, err, () -> {
+        return LockedExecution.run(parent.configFile(), err, context -> {
             RestoreResult result = destination != null
                     ? context.restoreService().restoreMailbox(sessionId, accounts, destination)
                     : context.restoreService().restoreFull(sessionId, accounts);

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreDomainCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreDomainCommand.java
@@ -1,6 +1,5 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.RestoreResult;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -34,8 +33,7 @@ public final class RestoreDomainCommand implements Callable<Integer> {
         if (!CliValidation.validateSessionId(sessionId, err) || !CliValidation.validateDomains(domains, err)) {
             return CommandLine.ExitCode.USAGE;
         }
-        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(context, err, () -> {
+        return LockedExecution.run(parent.parent().configFile(), err, context -> {
             RestoreResult result = context.restoreService().restoreDomain(sessionId, domains);
             return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
         });

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreLdapCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreLdapCommand.java
@@ -1,6 +1,5 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.RestoreResult;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -34,8 +33,7 @@ public final class RestoreLdapCommand implements Callable<Integer> {
         if (!CliValidation.validateSessionId(sessionId, err) || !CliValidation.validateEmails(accounts, err)) {
             return CommandLine.ExitCode.USAGE;
         }
-        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(context, err, () -> {
+        return LockedExecution.run(parent.parent().configFile(), err, context -> {
             RestoreResult result = context.restoreService().restoreLdap(sessionId, accounts);
             return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
         });

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreMailboxCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreMailboxCommand.java
@@ -1,6 +1,5 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.RestoreResult;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -45,8 +44,7 @@ public final class RestoreMailboxCommand implements Callable<Integer> {
             return CommandLine.ExitCode.USAGE;
         }
 
-        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(context, err, () -> {
+        return LockedExecution.run(parent.parent().configFile(), err, context -> {
             RestoreResult result = context.restoreService().restoreMailbox(sessionId, accounts, destination);
             return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
         });

--- a/app/src/main/java/io/zmbackup/app/cli/RestoreServerConfigCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/RestoreServerConfigCommand.java
@@ -1,6 +1,5 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import io.zmbackup.core.domain.RestoreResult;
 import java.io.PrintWriter;
 import java.util.concurrent.Callable;
@@ -32,8 +31,7 @@ public final class RestoreServerConfigCommand implements Callable<Integer> {
         if (!CliValidation.validateSessionId(sessionId, err)) {
             return CommandLine.ExitCode.USAGE;
         }
-        AppContext context = AppContext.fromConfigFile(parent.parent().configFile());
-        return LockedExecution.run(context, err, () -> {
+        return LockedExecution.run(parent.parent().configFile(), err, context -> {
             RestoreResult result = context.restoreService().restoreServerConfig(sessionId);
             return RestoreRunner.printResult(spec.commandLine().getOut(), sessionId, result);
         });

--- a/app/src/main/java/io/zmbackup/app/cli/TruncateCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/TruncateCommand.java
@@ -1,6 +1,5 @@
 package io.zmbackup.app.cli;
 
-import io.zmbackup.app.AppContext;
 import java.io.PrintWriter;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
@@ -39,8 +38,7 @@ public final class TruncateCommand implements Callable<Integer> {
             return CommandLine.ExitCode.USAGE;
         }
 
-        AppContext context = AppContext.fromConfigFile(parent.configFile());
-        return LockedExecution.run(context, err, () -> {
+        return LockedExecution.run(parent.configFile(), err, context -> {
             out.println("TEST/DEV USE ONLY - truncating the backup metadata database. "
                     + "The backup files on disk are not affected.");
             int removed = context.sessionService().truncateDatabase();

--- a/app/src/test/java/io/zmbackup/app/AppContextTest.java
+++ b/app/src/test/java/io/zmbackup/app/AppContextTest.java
@@ -208,7 +208,7 @@ class AppContextTest {
 
             assertInstanceOf(S3StorageProvider.class, context.storageProvider());
             assertInstanceOf(DynamoDBMetadataStore.class, context.metadataStore());
-            try (RunLock lock = context.acquireRunLock()) {
+            try (RunLock lock = AppContext.acquireRunLock(config)) {
                 assertInstanceOf(DynamoDBLock.class, lock);
             }
         } finally {

--- a/app/src/test/java/io/zmbackup/app/cli/TruncateCommandTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/TruncateCommandTest.java
@@ -1,6 +1,7 @@
 package io.zmbackup.app.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.zmbackup.app.AppContext;
@@ -66,6 +67,9 @@ class TruncateCommandTest {
 
             assertEquals(CommandLine.ExitCode.SOFTWARE, exitCode);
             assertTrue(err.toString().contains("already running"));
+            assertFalse(
+                    Files.exists(tempDir.resolve("sessions.sqlite3")),
+                    "lock contention must be detected before the SQLite metadata store is ever opened");
         }
     }
 

--- a/local/src/main/java/io/zmbackup/local/PosixFileHardening.java
+++ b/local/src/main/java/io/zmbackup/local/PosixFileHardening.java
@@ -12,7 +12,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
 
-final class PosixFileHardening {
+public final class PosixFileHardening {
 
     private static final Set<PosixFilePermission> DIRECTORY_PERMISSIONS = PosixFilePermissions.fromString("rwx------");
     private static final Set<PosixFilePermission> FILE_PERMISSIONS = PosixFilePermissions.fromString("rw-------");
@@ -22,7 +22,7 @@ final class PosixFileHardening {
 
     private PosixFileHardening() {}
 
-    static void createDirectories(Path dir) throws IOException {
+    public static void createDirectories(Path dir) throws IOException {
         if (POSIX_SUPPORTED) {
             Files.createDirectories(dir, PosixFilePermissions.asFileAttribute(DIRECTORY_PERMISSIONS));
         } else {


### PR DESCRIPTION
## Summary

- `AppContext.fromConfigFile(...)` built `SqliteMetadataStore` (opening a JDBC connection and running its schema DDL) before `LockedExecution.run(...)` ever checked `PidLock`/`DynamoDBLock`. An overlapping `zmbackup` invocation against the same `workDir` (a still-running `backup full`, a concurrent `housekeep`, etc.) could therefore touch the SQLite file, unguarded by the run lock, before contention was ever detected — surfacing a raw `SQLITE_BUSY` `IOException` instead of `PidLock`'s intended "Another zmbackup process (pid N) is already running against `<workDir>`" message.
- `LockedExecution` now loads the config and acquires the run lock (`AppContext.acquireRunLock(config)`, now `static`) *before* constructing `AppContext`, so lock contention is always caught first. Every mutating command (`backup *`, `restore*`, `delete`, `housekeep`, `migrate`, `migrate-to-cloud`, `truncate`) is updated to the new `LockedExecution.run(configFile, err, context -> ...)` signature; `list`/`accounts list` are untouched since they never acquired the lock.
- `PidLock.acquire()` now hardens `workDir` itself (via `PosixFileHardening.createDirectories`, now `public`) before creating its lock file there, since it can no longer rely on `SqliteMetadataStore` having already created/hardened that directory first.

Fixes lucascbeyeler/zmbackup#423.

## Test plan

- [x] `./gradlew :local:test :app:test` (temporarily run against a local JDK 21 toolchain override, since JDK 17 wasn't available in this sandbox — reverted before committing; CI runs the real JDK 17 toolchain)
- [x] Added `TruncateCommandTest.failsWithoutRunningWhenAnotherProcessHoldsTheLock` assertion that `sessions.sqlite3` is never created when the run lock is already held, directly covering the regression
- [x] Confirmed the new assertion fails against the pre-fix code path (reverted the ordering locally, re-ran, saw the failure, restored the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTivehSUrzAjaRT7GM8176


---
_Generated by [Claude Code](https://claude.ai/code/session_01WTivehSUrzAjaRT7GM8176)_