### PR TITLE
Include the running process's PID in the default error output

### DIFF
--- a/app/src/main/java/io/zmbackup/app/cli/Main.java
+++ b/app/src/main/java/io/zmbackup/app/cli/Main.java
@@ -57,7 +57,8 @@ public final class Main implements Callable<Integer> {
                 ex.printStackTrace(commandLine.getErr());
             } else {
                 commandLine.getErr().println(ex.getClass().getName()
-                        + (ex.getMessage() != null ? ": " + ex.getMessage() : ""));
+                        + (ex.getMessage() != null ? ": " + ex.getMessage() : "")
+                        + " (zmbackup pid " + ProcessHandle.current().pid() + ")");
                 commandLine.getErr().println("(Run with --stacktrace to get the full stack trace.)");
             }
             return CommandLine.ExitCode.SOFTWARE;

--- a/app/src/test/java/io/zmbackup/app/cli/MainTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/MainTest.java
@@ -259,6 +259,9 @@ class MainTest {
 
         assertEquals(CommandLine.ExitCode.SOFTWARE, exitCode);
         assertTrue(err.toString().contains("(Run with --stacktrace to get the full stack trace.)"));
+        assertTrue(
+                err.toString().contains("(zmbackup pid " + ProcessHandle.current().pid() + ")"),
+                "default output must include the failing process's own PID");
         assertFalse(err.toString().contains("\tat io.zmbackup"), "default output must not include stack frames");
 
         StringWriter verboseErr = new StringWriter();


### PR DESCRIPTION
## Summary

- `Main`'s generic exception handler (the concise-by-default path introduced in #405) now appends `(zmbackup pid <n>)` to the `<exception class>: <message>` line it prints, where `<n>` is `ProcessHandle.current().pid()` — the PID of the `zmbackup` invocation that actually hit the failure.
- Motivated by lucascbeyeler/zmbackup#423/#424 (the `SQLITE_BUSY` ordering bug): an operator diagnosing that kind of failure from a log needs to know *which* of several near-simultaneous cron-scheduled invocations produced a given error line, and the PID is the key to correlating that against `ps`/syslog history at the time.
- `--stacktrace` output is unchanged — a plain Java stack trace carries no PID of its own, so it doesn't repeat the suffix.

## Test plan

- [x] `./gradlew :app:test` (temporarily run against a local JDK 21 toolchain override, since JDK 17 wasn't available in this sandbox — reverted before committing; CI runs the real JDK 17 toolchain)
- [x] Extended `MainTest.reportsConciseErrorByDefaultAndFullStackTraceWithStacktraceFlag` to assert the default (non-`--stacktrace`) output contains `(zmbackup pid <current pid>)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTivehSUrzAjaRT7GM8176


---
_Generated by [Claude Code](https://claude.ai/code/session_01WTivehSUrzAjaRT7GM8176)_