### PR TITLE
Run a full backup on an account's first incremental backup

### DIFF
--- a/app/src/main/java/io/zmbackup/app/cli/BackupIncrementalCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupIncrementalCommand.java
@@ -6,7 +6,10 @@ import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
-@Command(name = "incremental", description = "Back up mail received since each account's last successful backup.")
+@Command(
+        name = "incremental",
+        description = "Back up mail received since each account's last successful backup. "
+                + "An account with no prior successful backup gets a full backup (LDAP entry and mailbox) instead.")
 public final class BackupIncrementalCommand extends AbstractAccountScopedBackupCommand {
 
     @Option(names = "--account", description = "Back up only this account (repeatable); default: every account.")

--- a/core/src/main/java/io/zmbackup/core/service/BackupService.java
+++ b/core/src/main/java/io/zmbackup/core/service/BackupService.java
@@ -281,17 +281,21 @@ public class BackupService {
                     logIfNothingExported(identifier, mailboxExporter.export(identifier, destination));
                 }
             } else if (type == BackupType.INCREMENTAL) {
-                try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, TGZ_SUFFIX)) {
-                    logIfNothingExported(
-                            identifier, mailboxExporter.export(identifier, destination, incrementalCutoff(identifier)));
+                Optional<Instant> lastBackup = metadataStore.lastSuccessfulBackupTime(identifier);
+                if (lastBackup.isEmpty()) {
+                    LOG.info(() -> "No prior successful backup found for " + identifier
+                            + " - running a full backup instead of an incremental one.");
+                    fullExport(sessionId, identifier);
+                } else {
+                    try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, TGZ_SUFFIX)) {
+                        logIfNothingExported(
+                                identifier,
+                                mailboxExporter.export(
+                                        identifier, destination, lastBackup.get().minus(INCREMENTAL_LOOKBACK)));
+                    }
                 }
             } else if (type == BackupType.FULL) {
-                try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, LDIFF_SUFFIX)) {
-                    ldapExporter.export(identifier, LdapObjectType.ACCOUNT, destination);
-                }
-                try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, TGZ_SUFFIX)) {
-                    logIfNothingExported(identifier, mailboxExporter.export(identifier, destination));
-                }
+                fullExport(sessionId, identifier);
             } else if (type == BackupType.SERVER_CONFIG) {
                 try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, ZIP_SUFFIX)) {
                     serverConfigArchiver.export(destination);
@@ -316,11 +320,13 @@ public class BackupService {
         return true;
     }
 
-    private Instant incrementalCutoff(String email) throws IOException {
-        return metadataStore
-                .lastSuccessfulBackupTime(email)
-                .map(lastBackup -> lastBackup.minus(INCREMENTAL_LOOKBACK))
-                .orElse(null);
+    private void fullExport(String sessionId, String identifier) throws IOException {
+        try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, LDIFF_SUFFIX)) {
+            ldapExporter.export(identifier, LdapObjectType.ACCOUNT, destination);
+        }
+        try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, TGZ_SUFFIX)) {
+            logIfNothingExported(identifier, mailboxExporter.export(identifier, destination));
+        }
     }
 
     private List<String> resolveIdentifiers(BackupType type, List<String> identifiers, String domain, boolean force)

--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -619,9 +619,23 @@ class BackupServiceTest {
         Optional<BackupSession> result = backupService.backup(BackupType.INCREMENTAL, List.of("alice@example.com"));
 
         assertTrue(result.isPresent());
+        assertTrue(result.get().sessionId().startsWith("inc-"));
         assertEquals(SessionStatus.FINISHED, result.get().status());
+        assertEquals(Set.of(LdapObjectType.ACCOUNT), ldapExporter.exportedTypesFor("alice@example.com"));
         assertTrue(mailboxExporter.exported.containsKey("alice@example.com"));
         assertEquals(null, mailboxExporter.exported.get("alice@example.com"));
+    }
+
+    @Test
+    void incrementalTypeSkipsMailboxAndRecordWhenLdapExportFailsOnFirstRun() throws IOException {
+        ldapExporter.failing.add("bad@example.com");
+
+        Optional<BackupSession> result = backupService.backup(BackupType.INCREMENTAL, List.of("bad@example.com"));
+
+        assertTrue(result.isPresent());
+        assertEquals(SessionStatus.FAILED, result.get().status());
+        assertTrue(metadataStore.findAccountsForSession(result.get().sessionId()).isEmpty());
+        assertFalse(mailboxExporter.exported.containsKey("bad@example.com"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `backup incremental` previously fell back to a full **mailbox** export for an account with no prior successful backup (`since == null`), but never exported the account's LDAP entry — that stayed uncaptured until a `backup full` was run.
- `BackupService.backupOne` now checks `metadataStore.lastSuccessfulBackupTime(identifier)` for `INCREMENTAL`: when absent, it delegates to the same LDAP + mailbox export helper `FULL` uses (`fullExport`), and logs an `INFO` line (`"No prior successful backup found for <identifier> - running a full backup instead of an incremental one."`) so the fallback is visible in logs.
- `BackupIncrementalCommand`'s `--help` description now states this behavior up front, so it's clear before running `backup incremental` against an account with no prior backup.
- Design docs updated in `zmbackupdocs` (same branch) per repo convention.

## Test plan
- [x] `./gradlew :core:test --tests "io.zmbackup.core.service.BackupServiceTest"` — all 41 tests pass, including updated `incrementalTypeFallsBackToFullExportWhenNoPriorBackup` (now asserts the LDAP export happens too) and new `incrementalTypeSkipsMailboxAndRecordWhenLdapExportFailsOnFirstRun`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqxrPVH3NDZvPQqRb44pq5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqxrPVH3NDZvPQqRb44pq5)_