### PR TITLE
Mark the README branch badge as Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Zmbackup is a reliable tool developed to help you in your daily task to backup and restore mails and accounts from Zimbra Open Source Email Platform. It's based on another project called [Zmbkpose](https://github.com/bggo/Zmbkpose), and completely compatible with the structure if you have plans on migrate from one to another.
 
 ![Linux Distro](https://img.shields.io/badge/platform-Rocky%20Linux%20%7C%20Red%20Hat%20%7C%20Ubuntu-blue.svg)
-![Branch](https://img.shields.io/badge/Branch-Unstable-red.svg)
+![Branch](https://img.shields.io/badge/Branch-Beta-orange.svg)
 ![Release](<https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Flucascbeyeler%2Fzmbackup%2F2.0%2FVERSION&search=%5E(.%2B)&replace=%241&label=Release&color=green>)
 [![Build Status](https://circleci.com/gh/lucascbeyeler/zmbackup.svg?style=shield)](https://circleci.com/gh/lucascbeyeler/zmbackup)
 


### PR DESCRIPTION
## Summary
- The `Branch` badge in README.md still said "Unstable" (red) from the 2.0.0-ALPHA phase; updates it to "Beta" (orange) now that 2.0.0-BETA is out.
- The `Release` badge is unaffected — it's dynamic and already resolves to `2.0.0-BETA` from the `VERSION` file on the `2.0` branch.

## Test plan
- [x] Visually confirmed the badge markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tLh7gAhqaW8uN8MxnBApC