### PR TITLE
Close three untested branches found in a test-suite coverage audit

### DIFF
--- a/app/src/test/java/io/zmbackup/app/cli/RestoreRunnerTest.java
+++ b/app/src/test/java/io/zmbackup/app/cli/RestoreRunnerTest.java
@@ -1,0 +1,41 @@
+package io.zmbackup.app.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.zmbackup.core.domain.RestoreResult;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RestoreRunnerTest {
+
+    @Test
+    void printResultReturnsZeroAndSummarizesACompleteSuccess() {
+        StringWriter buffer = new StringWriter();
+        RestoreResult result = new RestoreResult(3, List.of());
+
+        int exitCode = RestoreRunner.printResult(new PrintWriter(buffer), "session-1", result);
+
+        assertEquals(0, exitCode);
+        String output = buffer.toString();
+        assertTrue(output.contains("Restore session session-1 completed (3/3 accounts restored)"), output);
+        assertTrue(output.startsWith("Restore session session-1 completed ("), output);
+    }
+
+    @Test
+    void printResultReturnsOneAndReportsFailedCountWhenSomeAccountsFail() {
+        StringWriter buffer = new StringWriter();
+        RestoreResult result = new RestoreResult(3, List.of("alice@example.com", "bob@example.com"));
+
+        int exitCode = RestoreRunner.printResult(new PrintWriter(buffer), "session-2", result);
+
+        assertEquals(1, exitCode);
+        String output = buffer.toString();
+        assertTrue(
+                output.contains(
+                        "Restore session session-2 completed with errors (1/3 accounts restored, 2 failed)"),
+                output);
+    }
+}

--- a/local/src/main/java/io/zmbackup/local/PosixFileHardening.java
+++ b/local/src/main/java/io/zmbackup/local/PosixFileHardening.java
@@ -17,13 +17,25 @@ public final class PosixFileHardening {
     private static final Set<PosixFilePermission> DIRECTORY_PERMISSIONS = PosixFilePermissions.fromString("rwx------");
     private static final Set<PosixFilePermission> FILE_PERMISSIONS = PosixFilePermissions.fromString("rw-------");
 
-    private static final boolean POSIX_SUPPORTED =
-            FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+    private static boolean posixSupported = detectPosixSupport();
 
     private PosixFileHardening() {}
 
+    private static boolean detectPosixSupport() {
+        return FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+    }
+
+    /** Test-only hook to exercise the non-POSIX fallback branches on a POSIX filesystem. */
+    static void setPosixSupportedForTesting(boolean value) {
+        posixSupported = value;
+    }
+
+    static void restorePosixSupportedForTesting() {
+        posixSupported = detectPosixSupport();
+    }
+
     public static void createDirectories(Path dir) throws IOException {
-        if (POSIX_SUPPORTED) {
+        if (posixSupported) {
             Files.createDirectories(dir, PosixFilePermissions.asFileAttribute(DIRECTORY_PERMISSIONS));
         } else {
             Files.createDirectories(dir);
@@ -31,7 +43,7 @@ public final class PosixFileHardening {
     }
 
     static void createFile(Path file) throws IOException {
-        if (POSIX_SUPPORTED) {
+        if (posixSupported) {
             Files.createFile(file, PosixFilePermissions.asFileAttribute(FILE_PERMISSIONS));
         } else {
             Files.createFile(file);
@@ -39,20 +51,20 @@ public final class PosixFileHardening {
     }
 
     static Path createTempFile(String prefix, String suffix) throws IOException {
-        if (POSIX_SUPPORTED) {
+        if (posixSupported) {
             return Files.createTempFile(prefix, suffix, PosixFilePermissions.asFileAttribute(FILE_PERMISSIONS));
         }
         return Files.createTempFile(prefix, suffix);
     }
 
     static void restrictExistingFile(Path file) throws IOException {
-        if (POSIX_SUPPORTED) {
+        if (posixSupported) {
             Files.setPosixFilePermissions(file, FILE_PERMISSIONS);
         }
     }
 
     static OutputStream newRestrictedOutputStream(Path file, StandardOpenOption... options) throws IOException {
-        if (!POSIX_SUPPORTED) {
+        if (!posixSupported) {
             return Files.newOutputStream(file, options);
         }
         SeekableByteChannel channel =

--- a/local/src/test/java/io/zmbackup/local/PosixFileHardeningFallbackTest.java
+++ b/local/src/test/java/io/zmbackup/local/PosixFileHardeningFallbackTest.java
@@ -1,0 +1,88 @@
+package io.zmbackup.local;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Exercises the {@code posixSupported == false} fallback branches, which never run on the POSIX
+ * filesystems CI executes on, by forcing the flag via the package-private test hook.
+ */
+class PosixFileHardeningFallbackTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void forcePosixUnsupported() {
+        PosixFileHardening.setPosixSupportedForTesting(false);
+    }
+
+    @AfterEach
+    void restorePosixDetection() {
+        PosixFileHardening.restorePosixSupportedForTesting();
+    }
+
+    @Test
+    void createDirectoriesFallsBackToPlainCreationWhenPosixIsUnsupported() throws IOException {
+        Path nested = tempDir.resolve("a").resolve("b");
+
+        PosixFileHardening.createDirectories(nested);
+
+        assertTrue(Files.isDirectory(nested));
+    }
+
+    @Test
+    void createFileFallsBackToPlainCreationWhenPosixIsUnsupported() throws IOException {
+        Path file = tempDir.resolve("session.sqlite3");
+
+        PosixFileHardening.createFile(file);
+
+        assertTrue(Files.exists(file));
+        assertEquals(0, Files.size(file));
+    }
+
+    @Test
+    void createTempFileFallsBackToPlainCreationWhenPosixIsUnsupported() throws IOException {
+        Path file = PosixFileHardening.createTempFile("zmbackup-test-", ".tmp");
+
+        try {
+            assertTrue(Files.exists(file));
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    @Test
+    void restrictExistingFileDoesNothingWhenPosixIsUnsupported() throws IOException {
+        Path file = Files.createFile(tempDir.resolve("preexisting.db"));
+        Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-r--r--"));
+
+        PosixFileHardening.restrictExistingFile(file);
+
+        assertEquals("rw-r--r--", PosixFilePermissions.toString(Files.getPosixFilePermissions(file)));
+    }
+
+    @Test
+    void newRestrictedOutputStreamFallsBackToPlainOutputStreamWhenPosixIsUnsupported() throws IOException {
+        Path file = tempDir.resolve("alice@example.com.tgz");
+
+        try (OutputStream out = PosixFileHardening.newRestrictedOutputStream(
+                file, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+            out.write("content".getBytes(StandardCharsets.UTF_8));
+        }
+
+        assertEquals("content", Files.readString(file));
+    }
+}

--- a/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
+++ b/zimbra/src/main/java/io/zmbackup/zimbra/ZimbraRestMailboxExporter.java
@@ -88,7 +88,7 @@ public class ZimbraRestMailboxExporter implements ZimbraMailboxExporter {
         }
     }
 
-    private static final class NoHostnameCheckTrustManager extends X509ExtendedTrustManager {
+    static final class NoHostnameCheckTrustManager extends X509ExtendedTrustManager {
         private final X509TrustManager delegate;
 
         NoHostnameCheckTrustManager(X509TrustManager delegate) {

--- a/zimbra/src/test/java/io/zmbackup/zimbra/NoHostnameCheckTrustManagerTest.java
+++ b/zimbra/src/test/java/io/zmbackup/zimbra/NoHostnameCheckTrustManagerTest.java
@@ -1,0 +1,91 @@
+package io.zmbackup.zimbra;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import javax.net.ssl.X509TrustManager;
+import org.junit.jupiter.api.Test;
+
+class NoHostnameCheckTrustManagerTest {
+
+    @Test
+    void checkClientTrustedOverloadsAllDelegateToTheTwoArgumentMethod() throws CertificateException {
+        RecordingTrustManager delegate = new RecordingTrustManager();
+        ZimbraRestMailboxExporter.NoHostnameCheckTrustManager trustManager =
+                new ZimbraRestMailboxExporter.NoHostnameCheckTrustManager(delegate);
+        X509Certificate[] chain = new X509Certificate[0];
+
+        trustManager.checkClientTrusted(chain, "RSA");
+        trustManager.checkClientTrusted(chain, "RSA", (java.net.Socket) null);
+        trustManager.checkClientTrusted(chain, "RSA", (javax.net.ssl.SSLEngine) null);
+
+        assertEquals(3, delegate.clientTrustedCalls.size());
+        for (Object[] call : delegate.clientTrustedCalls) {
+            assertSame(chain, call[0]);
+            assertEquals("RSA", call[1]);
+        }
+    }
+
+    @Test
+    void checkServerTrustedOverloadsAllDelegateToTheTwoArgumentMethod() throws CertificateException {
+        RecordingTrustManager delegate = new RecordingTrustManager();
+        ZimbraRestMailboxExporter.NoHostnameCheckTrustManager trustManager =
+                new ZimbraRestMailboxExporter.NoHostnameCheckTrustManager(delegate);
+        X509Certificate[] chain = new X509Certificate[0];
+
+        trustManager.checkServerTrusted(chain, "RSA");
+        trustManager.checkServerTrusted(chain, "RSA", (java.net.Socket) null);
+        trustManager.checkServerTrusted(chain, "RSA", (javax.net.ssl.SSLEngine) null);
+
+        assertEquals(3, delegate.serverTrustedCalls.size());
+        for (Object[] call : delegate.serverTrustedCalls) {
+            assertSame(chain, call[0]);
+            assertEquals("RSA", call[1]);
+        }
+    }
+
+    @Test
+    void getAcceptedIssuersDelegatesToTheWrappedTrustManager() {
+        X509Certificate[] issuers = new X509Certificate[0];
+        RecordingTrustManager delegate = new RecordingTrustManager(issuers);
+        ZimbraRestMailboxExporter.NoHostnameCheckTrustManager trustManager =
+                new ZimbraRestMailboxExporter.NoHostnameCheckTrustManager(delegate);
+
+        assertArrayEquals(issuers, trustManager.getAcceptedIssuers());
+    }
+
+    /** Hand-rolled stub since this module has no mocking library on the test classpath. */
+    private static final class RecordingTrustManager implements X509TrustManager {
+        private final X509Certificate[] acceptedIssuers;
+        private final List<Object[]> clientTrustedCalls = new ArrayList<>();
+        private final List<Object[]> serverTrustedCalls = new ArrayList<>();
+
+        RecordingTrustManager() {
+            this(new X509Certificate[0]);
+        }
+
+        RecordingTrustManager(X509Certificate[] acceptedIssuers) {
+            this.acceptedIssuers = acceptedIssuers;
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+            clientTrustedCalls.add(new Object[] {chain, authType});
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+            serverTrustedCalls.add(new Object[] {chain, authType});
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return acceptedIssuers;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
An audit of the test suite (line/branch coverage per class, cross-referenced against test files) found three genuine gaps despite overall coverage already being healthy (86-95% per module, enforced by a jacoco 80% gate in CI):

- `RestoreRunner.printResult`'s partial-failure branch (non-zero exit code, "completed with errors" message) was never exercised — all five restore commands that share it (`RestoreCommand`, `RestoreDomainCommand`, `RestoreLdapCommand`, `RestoreMailboxCommand`, `RestoreServerConfigCommand`) only had success-path tests.
- `ZimbraRestMailboxExporter`'s `NoHostnameCheckTrustManager` (used when `trustAllCertificates=true`) only had its actually-invoked SSLEngine overload covered by the existing HTTPS integration test; the other five `X509ExtendedTrustManager` delegate overloads were dead-untested code.
- `PosixFileHardening`'s non-POSIX fallback branches (used on filesystems without POSIX permission support) never ran on Linux CI, since every existing test starts with `Assumptions.assumeTrue(posixSupported)`.

## Changes
- Added `RestoreRunnerTest` — direct unit test of both exit-code/message branches.
- Added `NoHostnameCheckTrustManagerTest` — verifies all six trust-check overloads plus `getAcceptedIssuers()` delegate correctly, using a hand-rolled stub (no mocking library on this module's classpath).
- Added `PosixFileHardeningFallbackTest` — forces the fallback path via a new package-private test hook and exercises all five hardening methods.
- `NoHostnameCheckTrustManager` widened from `private` to package-private, and `PosixFileHardening.POSIX_SUPPORTED` changed from a `static final` field to a mutable one with test-only setter/reset hooks — both are minimal testability seams with no behavior change.

Result: all three target classes now at 100% line/branch coverage. `./gradlew check` (tests + coverage gate + SpotBugs) passes clean across all modules with zero SpotBugs findings.

## Test plan
- [x] `./gradlew check` passes across all modules
- [x] New tests confirmed passing individually (`RestoreRunnerTest`, `NoHostnameCheckTrustManagerTest`, `PosixFileHardeningFallbackTest`)
- [x] Jacoco XML reports confirm 100% line/branch coverage on the three target classes
- [x] SpotBugs reports zero findings on touched modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tLh7gAhqaW8uN8MxnBApC