### PR TITLE
Add backup.metadataDir and a SQLite-only backup self type

### DIFF
--- a/app/src/main/java/io/zmbackup/app/AppContext.java
+++ b/app/src/main/java/io/zmbackup/app/AppContext.java
@@ -154,7 +154,7 @@ public final class AppContext {
             return new DynamoDBMetadataStore(
                     dynamodb.region(), dynamodb.sessionTable(), dynamodb.accountTable(), dynamodb.endpointOverride());
         }
-        return new SqliteMetadataStore(config.backup().workDir().resolve(METADATA_STORE_FILENAME));
+        return new SqliteMetadataStore(config.backup().metadataDir().resolve(METADATA_STORE_FILENAME));
     }
 
     public static RunLock acquireRunLock(AppConfig config) throws IOException {
@@ -163,7 +163,7 @@ public final class AppContext {
             return DynamoDBLock.acquire(
                     dynamodb.region(), dynamodb.lockTable(), dynamodb.endpointOverride(), DYNAMODB_LOCK_LEASE);
         }
-        return PidLock.acquire(config.backup().workDir());
+        return PidLock.acquire(config.backup().metadataDir());
     }
 
     private static void checkBackupUser(AppConfig config) {

--- a/app/src/main/java/io/zmbackup/app/cli/BackupCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupCommand.java
@@ -18,7 +18,8 @@ import picocli.CommandLine.Spec;
             BackupDistlistCommand.class,
             BackupSignatureCommand.class,
             BackupDomainCommand.class,
-            BackupServerConfigCommand.class
+            BackupServerConfigCommand.class,
+            BackupSelfCommand.class
         })
 public final class BackupCommand implements Callable<Integer> {
 

--- a/app/src/main/java/io/zmbackup/app/cli/BackupSelfCommand.java
+++ b/app/src/main/java/io/zmbackup/app/cli/BackupSelfCommand.java
@@ -1,0 +1,27 @@
+package io.zmbackup.app.cli;
+
+import io.zmbackup.core.domain.BackupType;
+import java.util.List;
+import picocli.CommandLine.Command;
+
+@Command(
+        name = "self",
+        description = "Back up zmbackup's own SQLite metadata store (sessions.sqlite3) to the same "
+                + "destination as regular backups. A no-op when metadata.backend is not sqlite.")
+public final class BackupSelfCommand extends AbstractBackupCommand {
+
+    @Override
+    BackupType type() {
+        return BackupType.SELF;
+    }
+
+    @Override
+    List<String> identifiers() {
+        return List.of();
+    }
+
+    @Override
+    String domain() {
+        return null;
+    }
+}

--- a/app/src/main/java/io/zmbackup/app/config/BackupConfig.java
+++ b/app/src/main/java/io/zmbackup/app/config/BackupConfig.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 
 public record BackupConfig(
         Path workDir,
+        Path metadataDir,
         Path logFile,
         Path blockedListFile,
         int maxParallelProcesses,
@@ -16,6 +17,7 @@ public record BackupConfig(
 
     public BackupConfig {
         Objects.requireNonNull(workDir, "workDir must not be null");
+        Objects.requireNonNull(metadataDir, "metadataDir must not be null");
         Objects.requireNonNull(logFile, "logFile must not be null");
         Objects.requireNonNull(blockedListFile, "blockedListFile must not be null");
         Objects.requireNonNull(emailNotify, "emailNotify must not be null");

--- a/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
+++ b/app/src/main/java/io/zmbackup/app/config/YamlConfigLoader.java
@@ -117,8 +117,10 @@ public final class YamlConfigLoader {
     }
 
     private static BackupConfig parseBackup(Map<String, Object> root) {
+        Path workDir = requirePath(root, "backup.workDir");
         return new BackupConfig(
-                requirePath(root, "backup.workDir"),
+                workDir,
+                optionalPath(root, "backup.metadataDir", workDir),
                 requirePath(root, "backup.logFile"),
                 requirePath(root, "backup.blockedListFile"),
                 optionalInt(root, "backup.maxParallelProcesses", 3),
@@ -171,6 +173,11 @@ public final class YamlConfigLoader {
 
     private static Path requirePath(Map<String, Object> root, String dottedPath) {
         return Path.of(requireString(root, dottedPath));
+    }
+
+    private static Path optionalPath(Map<String, Object> root, String dottedPath, Path defaultValue) {
+        String value = optionalString(root, dottedPath);
+        return value == null ? defaultValue : Path.of(value);
     }
 
     private static String optionalString(Map<String, Object> root, String dottedPath) {

--- a/app/src/test/java/io/zmbackup/app/AppContextTest.java
+++ b/app/src/test/java/io/zmbackup/app/AppContextTest.java
@@ -1,6 +1,7 @@
 package io.zmbackup.app;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -70,6 +71,23 @@ class AppContextTest {
     }
 
     @Test
+    void wiresComponentsWithSeparateMetadataDirPlacesDatabaseAndLockThereInsteadOfWorkDir() throws Exception {
+        Path workDir = tempDir.resolve("workdir");
+        Path metadataDir = tempDir.resolve("metadatadir");
+        Files.createDirectories(workDir);
+        AppConfig config = configWithWorkDirAndMetadataDir(workDir, metadataDir);
+
+        try (RunLock lock = AppContext.acquireRunLock(config)) {
+            new AppContext(config);
+
+            assertTrue(Files.exists(metadataDir.resolve("sessions.sqlite3")));
+            assertFalse(Files.exists(workDir.resolve("sessions.sqlite3")));
+            assertTrue(Files.exists(metadataDir.resolve("zmbackup.pid")));
+            assertFalse(Files.exists(workDir.resolve("zmbackup.pid")));
+        }
+    }
+
+    @Test
     void fromConfigFileLoadsAndWiresComponents() throws IOException {
         Path configFile = tempDir.resolve("zmbackup.yaml");
         Files.writeString(
@@ -118,6 +136,7 @@ class AppContextTest {
                         null,
                         false),
                 new BackupConfig(
+                        tempDir,
                         tempDir,
                         tempDir.resolve("zmbackup.log"),
                         tempDir.resolve("blockedlist.conf"),
@@ -239,6 +258,7 @@ class AppContextTest {
                         false),
                 new BackupConfig(
                         workDir,
+                        workDir,
                         workDir.resolve("zmbackup.log"),
                         workDir.resolve("blockedlist.conf"),
                         3,
@@ -269,12 +289,45 @@ class AppContextTest {
         return configWithWorkDir(workDir, System.getProperty("user.name"));
     }
 
+    private static AppConfig configWithWorkDirAndMetadataDir(Path workDir, Path metadataDir) {
+        return new AppConfig(
+                new ZimbraLdapConfig(
+                        "ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true, null, false, 600),
+                new ZimbraMailboxConfig(
+                        System.getProperty("user.name"),
+                        true,
+                        "https://127.0.0.1:7071",
+                        "zimbra",
+                        "secret",
+                        null,
+                        false),
+                new BackupConfig(
+                        workDir,
+                        metadataDir,
+                        workDir.resolve("zmbackup.log"),
+                        workDir.resolve("blockedlist.conf"),
+                        3,
+                        30,
+                        true,
+                        new EmailNotifyConfig(
+                                EmailNotifyLevel.ALL,
+                                "admin@example.com",
+                                "root@example.com",
+                                EmailNotifyConfig.DEFAULT_SMTP_HOST,
+                                EmailNotifyConfig.DEFAULT_SMTP_PORT)),
+                LOCAL_STORAGE,
+                SQLITE_METADATA,
+                DEFAULT_SERVER_CONFIG,
+                false);
+    }
+
     private static AppConfig configWithWorkDir(Path workDir, String backupUser) {
         return new AppConfig(
                 new ZimbraLdapConfig(
                         "ldap://127.0.0.1:389", "uid=zimbra,cn=admins,cn=zimbra", "secret", true, null, false, 600),
                 new ZimbraMailboxConfig(backupUser, true, "https://127.0.0.1:7071", "zimbra", "secret", null, false),
                 new BackupConfig(
+                        workDir,
                         workDir,
                         workDir.resolve("zmbackup.log"),
                         workDir.resolve("blockedlist.conf"),
@@ -313,6 +366,7 @@ class AppContextTest {
                         false),
                 new BackupConfig(
                         workDir,
+                        workDir,
                         workDir.resolve("zmbackup.log"),
                         workDir.resolve("blockedlist.conf"),
                         3,
@@ -343,6 +397,7 @@ class AppContextTest {
                         null,
                         true),
                 new BackupConfig(
+                        workDir,
                         workDir,
                         workDir.resolve("zmbackup.log"),
                         workDir.resolve("blockedlist.conf"),

--- a/app/src/test/java/io/zmbackup/app/config/AppConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/AppConfigTest.java
@@ -17,6 +17,7 @@ class AppConfigTest {
 
     private static final BackupConfig BACKUP_CONFIG = new BackupConfig(
             Path.of("/opt/zimbra/backup"),
+            Path.of("/opt/zimbra/backup"),
             Path.of("/opt/zimbra/log/zmbackup.log"),
             Path.of("/etc/zmbackup/blockedlist.conf"),
             3,

--- a/app/src/test/java/io/zmbackup/app/config/BackupConfigTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/BackupConfigTest.java
@@ -22,6 +22,7 @@ class BackupConfigTest {
                 IllegalArgumentException.class,
                 () -> new BackupConfig(
                         Path.of("/opt/zimbra/backup"),
+                        Path.of("/opt/zimbra/backup"),
                         Path.of("/opt/zimbra/log/zmbackup.log"),
                         Path.of("/etc/zmbackup/blockedlist.conf"),
                         0,
@@ -38,6 +39,7 @@ class BackupConfigTest {
                 IllegalArgumentException.class,
                 () -> new BackupConfig(
                         Path.of("/opt/zimbra/backup"),
+                        Path.of("/opt/zimbra/backup"),
                         Path.of("/opt/zimbra/log/zmbackup.log"),
                         Path.of("/etc/zmbackup/blockedlist.conf"),
                         257,
@@ -51,6 +53,7 @@ class BackupConfigTest {
     @Test
     void acceptsMaxParallelProcessesAtTheCeiling() {
         BackupConfig config = new BackupConfig(
+                Path.of("/opt/zimbra/backup"),
                 Path.of("/opt/zimbra/backup"),
                 Path.of("/opt/zimbra/log/zmbackup.log"),
                 Path.of("/etc/zmbackup/blockedlist.conf"),
@@ -68,6 +71,7 @@ class BackupConfigTest {
                 IllegalArgumentException.class,
                 () -> new BackupConfig(
                         Path.of("/opt/zimbra/backup"),
+                        Path.of("/opt/zimbra/backup"),
                         Path.of("/opt/zimbra/log/zmbackup.log"),
                         Path.of("/etc/zmbackup/blockedlist.conf"),
                         3,
@@ -84,6 +88,22 @@ class BackupConfigTest {
                 NullPointerException.class,
                 () -> new BackupConfig(
                         null,
+                        Path.of("/opt/zimbra/backup"),
+                        Path.of("/opt/zimbra/log/zmbackup.log"),
+                        Path.of("/etc/zmbackup/blockedlist.conf"),
+                        3,
+                        30,
+                        true,
+                        EMAIL_NOTIFY));
+    }
+
+    @Test
+    void rejectsNullMetadataDir() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new BackupConfig(
+                        Path.of("/opt/zimbra/backup"),
+                        null,
                         Path.of("/opt/zimbra/log/zmbackup.log"),
                         Path.of("/etc/zmbackup/blockedlist.conf"),
                         3,
@@ -98,6 +118,7 @@ class BackupConfigTest {
                 NullPointerException.class,
                 () -> new BackupConfig(
                         Path.of("/opt/zimbra/backup"),
+                        Path.of("/opt/zimbra/backup"),
                         null,
                         Path.of("/etc/zmbackup/blockedlist.conf"),
                         3,
@@ -111,7 +132,8 @@ class BackupConfigTest {
         assertThrows(
                 NullPointerException.class,
                 () -> new BackupConfig(
-                        Path.of("/opt/zimbra/backup"), Path.of("/opt/zimbra/log/zmbackup.log"), null, 3, 30, true,
+                        Path.of("/opt/zimbra/backup"), Path.of("/opt/zimbra/backup"),
+                        Path.of("/opt/zimbra/log/zmbackup.log"), null, 3, 30, true,
                         EMAIL_NOTIFY));
     }
 
@@ -120,6 +142,7 @@ class BackupConfigTest {
         assertThrows(
                 NullPointerException.class,
                 () -> new BackupConfig(
+                        Path.of("/opt/zimbra/backup"),
                         Path.of("/opt/zimbra/backup"),
                         Path.of("/opt/zimbra/log/zmbackup.log"),
                         Path.of("/etc/zmbackup/blockedlist.conf"),
@@ -133,6 +156,7 @@ class BackupConfigTest {
     void acceptsZeroRotateDaysAndOneMaxParallelProcess() {
         BackupConfig config = new BackupConfig(
                 Path.of("/opt/zimbra/backup"),
+                Path.of("/opt/zimbra/backup"),
                 Path.of("/opt/zimbra/log/zmbackup.log"),
                 Path.of("/etc/zmbackup/blockedlist.conf"),
                 1,
@@ -142,5 +166,21 @@ class BackupConfigTest {
 
         assertEquals(1, config.maxParallelProcesses());
         assertEquals(0, config.rotateDays());
+    }
+
+    @Test
+    void acceptsMetadataDirDifferentFromWorkDir() {
+        BackupConfig config = new BackupConfig(
+                Path.of("/mnt/nas/zmbackup"),
+                Path.of("/var/zmbackup"),
+                Path.of("/opt/zimbra/log/zmbackup.log"),
+                Path.of("/etc/zmbackup/blockedlist.conf"),
+                3,
+                30,
+                true,
+                EMAIL_NOTIFY);
+
+        assertEquals(Path.of("/mnt/nas/zmbackup"), config.workDir());
+        assertEquals(Path.of("/var/zmbackup"), config.metadataDir());
     }
 }

--- a/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
+++ b/app/src/test/java/io/zmbackup/app/config/YamlConfigLoaderTest.java
@@ -39,6 +39,7 @@ class YamlConfigLoaderTest {
               trustAllCertificates: true
             backup:
               workDir: /opt/zimbra/backup
+              metadataDir: /var/zmbackup
               logFile: /opt/zimbra/log/zmbackup.log
               blockedListFile: /etc/zmbackup/blockedlist.conf
               maxParallelProcesses: 5
@@ -114,6 +115,7 @@ class YamlConfigLoaderTest {
         assertEquals(true, config.zimbraMailbox().trustAllCertificates());
 
         assertEquals(Path.of("/opt/zimbra/backup"), config.backup().workDir());
+        assertEquals(Path.of("/var/zmbackup"), config.backup().metadataDir());
         assertEquals(Path.of("/opt/zimbra/log/zmbackup.log"), config.backup().logFile());
         assertEquals(Path.of("/etc/zmbackup/blockedlist.conf"), config.backup().blockedListFile());
         assertEquals(5, config.backup().maxParallelProcesses());
@@ -176,6 +178,7 @@ class YamlConfigLoaderTest {
         assertTrue(config.zimbraMailbox().backupInactiveAccounts());
         assertEquals(null, config.zimbraMailbox().caCertificatePath());
         assertEquals(false, config.zimbraMailbox().trustAllCertificates());
+        assertEquals(config.backup().workDir(), config.backup().metadataDir());
         assertEquals(3, config.backup().maxParallelProcesses());
         assertEquals(30, config.backup().rotateDays());
         assertTrue(config.backup().lockBackup());

--- a/core/src/main/java/io/zmbackup/core/domain/BackupType.java
+++ b/core/src/main/java/io/zmbackup/core/domain/BackupType.java
@@ -12,7 +12,8 @@ public enum BackupType {
     DISTRIBUTION_LIST("distlist", true, false),
     SIGNATURE("signature", true, false),
     DOMAIN("domain", true, false),
-    SERVER_CONFIG("serverconfig", false, false);
+    SERVER_CONFIG("serverconfig", false, false),
+    SELF("self", false, false);
 
     private final String sessionPrefix;
     private final boolean includesLdap;

--- a/core/src/main/java/io/zmbackup/core/port/MetadataStore.java
+++ b/core/src/main/java/io/zmbackup/core/port/MetadataStore.java
@@ -4,6 +4,7 @@ import io.zmbackup.core.domain.BackupAccountRecord;
 import io.zmbackup.core.domain.BackupSession;
 import io.zmbackup.core.domain.BackupType;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -31,4 +32,12 @@ public interface MetadataStore {
     boolean backedUpSince(String identifier, BackupType type, Instant since) throws IOException;
 
     default void vacuum() throws IOException {}
+
+    default boolean supportsSelfBackup() {
+        return false;
+    }
+
+    default void exportSelfBackup(OutputStream destination) throws IOException {
+        throw new IOException("This metadata backend does not support self-backup");
+    }
 }

--- a/core/src/main/java/io/zmbackup/core/service/BackupService.java
+++ b/core/src/main/java/io/zmbackup/core/service/BackupService.java
@@ -59,7 +59,9 @@ public class BackupService {
     private static final String LDIFF_SUFFIX = "ldiff";
     private static final String TGZ_SUFFIX = "tgz";
     private static final String ZIP_SUFFIX = "zip";
+    private static final String SQLITE_SUFFIX = "sqlite3";
     private static final String SERVER_CONFIG_IDENTIFIER = "serverconfig";
+    private static final String SELF_IDENTIFIER = "self";
 
     private static final Duration INCREMENTAL_LOOKBACK = Duration.ofHours(48);
 
@@ -300,6 +302,10 @@ public class BackupService {
                 try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, ZIP_SUFFIX)) {
                     serverConfigArchiver.export(destination);
                 }
+            } else if (type == BackupType.SELF) {
+                try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, SQLITE_SUFFIX)) {
+                    metadataStore.exportSelfBackup(destination);
+                }
             } else {
                 try (OutputStream destination = storageProvider.openWrite(sessionId, identifier, LDIFF_SUFFIX)) {
                     if (type == BackupType.DOMAIN) {
@@ -334,6 +340,12 @@ public class BackupService {
         if (type == BackupType.SERVER_CONFIG) {
             return filterAlreadyBackedUpToday(
                     type, filterBlocked(List.of(SERVER_CONFIG_IDENTIFIER)), force);
+        }
+        if (type == BackupType.SELF) {
+            if (!metadataStore.supportsSelfBackup()) {
+                return List.of();
+            }
+            return filterAlreadyBackedUpToday(type, filterBlocked(List.of(SELF_IDENTIFIER)), force);
         }
         if (!identifiers.isEmpty()) {
             return identifiers;
@@ -412,6 +424,8 @@ public class BackupService {
             case DOMAIN -> LdapObjectType.DOMAIN;
             case SERVER_CONFIG -> throw new IllegalStateException(
                     "SERVER_CONFIG has no LDAP object type - it is handled directly in backupOne");
+            case SELF -> throw new IllegalStateException(
+                    "SELF has no LDAP object type - it is handled directly in backupOne");
         };
     }
 }

--- a/core/src/test/java/io/zmbackup/core/domain/BackupTypeTest.java
+++ b/core/src/test/java/io/zmbackup/core/domain/BackupTypeTest.java
@@ -91,4 +91,16 @@ class BackupTypeTest {
     void serverConfigConflictsOnlyWithItselfDespiteHavingNoLdapOrMailboxFlag() {
         assertEquals(List.of("serverconfig"), BackupType.SERVER_CONFIG.conflictingSessionPrefixes());
     }
+
+    @Test
+    void selfIncludesNeitherLdapNorMailbox() {
+        assertFalse(BackupType.SELF.includesLdap());
+        assertFalse(BackupType.SELF.includesMailbox());
+        assertEquals("self", BackupType.SELF.sessionPrefix());
+    }
+
+    @Test
+    void selfConflictsOnlyWithItselfDespiteHavingNoLdapOrMailboxFlag() {
+        assertEquals(List.of("self"), BackupType.SELF.conflictingSessionPrefixes());
+    }
 }

--- a/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
+++ b/core/src/test/java/io/zmbackup/core/service/BackupServiceTest.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -168,6 +169,59 @@ class BackupServiceTest {
         Optional<BackupSession> forced = lockingService.backup(BackupType.SERVER_CONFIG, List.of(), null, true);
         assertTrue(forced.isPresent());
         assertEquals(2, serverConfigArchiver.exportCount);
+    }
+
+    @Test
+    void selfTypeArchivesWithoutAnyDiscoveryAndNeedsNoIdentifiers() throws IOException {
+        Optional<BackupSession> result = backupService.backup(BackupType.SELF);
+
+        assertTrue(result.isPresent());
+        BackupSession session = result.get();
+        assertTrue(session.sessionId().startsWith("self-"));
+        assertEquals(BackupType.SELF, session.type());
+        assertEquals(SessionStatus.FINISHED, session.status());
+        assertEquals(1, metadataStore.selfBackupExportCount);
+        assertTrue(accountDiscovery.discoverCalls.isEmpty());
+        List<BackupAccountRecord> records = metadataStore.findAccountsForSession(session.sessionId());
+        assertEquals(List.of("self"), namesOf(records).stream().sorted().toList());
+    }
+
+    @Test
+    void selfBackupFailsSessionWhenMetadataStoreExportFails() throws IOException {
+        metadataStore.failNextSelfBackupExport = true;
+
+        Optional<BackupSession> result = backupService.backup(BackupType.SELF);
+
+        assertTrue(result.isPresent());
+        assertEquals(SessionStatus.FAILED, result.get().status());
+    }
+
+    @Test
+    void selfBackupIsANoOpWhenMetadataStoreDoesNotSupportIt() throws IOException {
+        metadataStore.selfBackupSupported = false;
+
+        Optional<BackupSession> result = backupService.backup(BackupType.SELF);
+
+        assertTrue(result.isEmpty());
+        assertEquals(0, metadataStore.selfBackupExportCount);
+    }
+
+    @Test
+    void selfBackupHonorsLockBackupAndForce() throws IOException {
+        BackupService lockingService = BackupService.builder(
+                        accountDiscovery, ldapExporter, mailboxExporter, storageProvider, metadataStore)
+                .lockBackup(true)
+                .build();
+
+        Optional<BackupSession> first = lockingService.backup(BackupType.SELF);
+        assertTrue(first.isPresent());
+
+        Optional<BackupSession> second = lockingService.backup(BackupType.SELF);
+        assertTrue(second.isEmpty());
+
+        Optional<BackupSession> forced = lockingService.backup(BackupType.SELF, List.of(), null, true);
+        assertTrue(forced.isPresent());
+        assertEquals(2, metadataStore.selfBackupExportCount);
     }
 
     @Test
@@ -978,6 +1032,25 @@ class BackupServiceTest {
                             && record.completedAt() != null
                             && record.completedAt().isAfter(since)
                             && conflicting.contains(sessionPrefixOf(record.sessionId())));
+        }
+
+        boolean selfBackupSupported = true;
+        int selfBackupExportCount = 0;
+        boolean failNextSelfBackupExport = false;
+
+        @Override
+        public boolean supportsSelfBackup() {
+            return selfBackupSupported;
+        }
+
+        @Override
+        public void exportSelfBackup(OutputStream destination) throws IOException {
+            selfBackupExportCount++;
+            if (failNextSelfBackupExport) {
+                failNextSelfBackupExport = false;
+                throw new IOException("simulated self-backup failure");
+            }
+            destination.write("fake-sqlite-snapshot".getBytes(StandardCharsets.UTF_8));
         }
 
         private static String sessionPrefixOf(String sessionId) {

--- a/local/src/main/java/io/zmbackup/local/PosixFileHardening.java
+++ b/local/src/main/java/io/zmbackup/local/PosixFileHardening.java
@@ -57,6 +57,13 @@ public final class PosixFileHardening {
         return Files.createTempFile(prefix, suffix);
     }
 
+    static Path createTempDirectory(String prefix) throws IOException {
+        if (posixSupported) {
+            return Files.createTempDirectory(prefix, PosixFilePermissions.asFileAttribute(DIRECTORY_PERMISSIONS));
+        }
+        return Files.createTempDirectory(prefix);
+    }
+
     static void restrictExistingFile(Path file) throws IOException {
         if (posixSupported) {
             Files.setPosixFilePermissions(file, FILE_PERMISSIONS);

--- a/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
+++ b/local/src/main/java/io/zmbackup/local/SqliteMetadataStore.java
@@ -7,6 +7,7 @@ import io.zmbackup.core.domain.SessionStatus;
 import io.zmbackup.core.port.MetadataStore;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
@@ -330,6 +331,32 @@ public class SqliteMetadataStore implements MetadataStore, Closeable {
             throw new IOException(e);
         } finally {
             lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean supportsSelfBackup() {
+        return true;
+    }
+
+    @Override
+    public void exportSelfBackup(OutputStream destination) throws IOException {
+        Path snapshotDir = PosixFileHardening.createTempDirectory("zmbackup-self-");
+        Path snapshot = snapshotDir.resolve("sessions.sqlite3");
+        try {
+            lock.lock();
+            try (PreparedStatement statement = connection.prepareStatement("VACUUM INTO ?")) {
+                statement.setString(1, snapshot.toString());
+                statement.execute();
+            } catch (SQLException e) {
+                throw new IOException(e);
+            } finally {
+                lock.unlock();
+            }
+            Files.copy(snapshot, destination);
+        } finally {
+            Files.deleteIfExists(snapshot);
+            Files.deleteIfExists(snapshotDir);
         }
     }
 

--- a/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
+++ b/local/src/test/java/io/zmbackup/local/SqliteMetadataStoreTest.java
@@ -148,6 +148,28 @@ class SqliteMetadataStoreTest {
     }
 
     @Test
+    void supportsSelfBackupReturnsTrue() {
+        assertTrue(store.supportsSelfBackup());
+    }
+
+    @Test
+    void exportSelfBackupProducesAReadableSnapshotWithStoredDataIntact(@TempDir Path tempDir) throws IOException {
+        store.save(session("full-1", SessionStatus.FINISHED, "10M"));
+        store.recordAccountBackup(accountRecord("full-1", "user@example.com"));
+
+        Path exported = tempDir.resolve("self-export.sqlite3");
+        try (var destination = Files.newOutputStream(exported)) {
+            store.exportSelfBackup(destination);
+        }
+
+        try (SqliteMetadataStore snapshot = new SqliteMetadataStore(exported)) {
+            assertEquals(1, snapshot.listSessions().size());
+            assertEquals("full-1", snapshot.listSessions().get(0).sessionId());
+            assertEquals(1, snapshot.findAccountsForSession("full-1").size());
+        }
+    }
+
+    @Test
     void recordedAccountBackupCanBeFoundBySession() throws IOException {
         store.save(session("full-1", SessionStatus.FINISHED, "10M"));
         BackupAccountRecord record = accountRecord("full-1", "user@example.com");

--- a/project/config/zmbackup.yaml
+++ b/project/config/zmbackup.yaml
@@ -54,6 +54,12 @@ zimbraMailbox:
 backup:
   # Directory backups and session metadata are stored under.
   workDir: {OSE_DEFAULT_BKP_DIR}
+  # Directory the SQLite metadata store (sessions.sqlite3) and the PID lock file are kept in.
+  # Optional, defaults to workDir above. Point this at local disk when workDir is a network share
+  # (NFS/SMB) - both files rely on OS-level file locking, which is unreliable over network
+  # filesystems - see zmbackupdocs specs/09-concurrency-security.md. Use `backup self` to copy the
+  # SQLite database itself out to the regular backup destination alongside everything else.
+  # metadataDir: /var/zmbackup
   # Path zmbackup writes its logs to.
   logFile: {OSE_INSTALL_DIR}/log/zmbackup.log
   # Path to the file listing accounts that should never be backed up.


### PR DESCRIPTION
## Summary

Scoped from a discussion about running zmbackup with Zimbra on local disk and the backup
destination on a NAS: SQLite's file locking (and `PidLock`'s OS-level `FileLock`) is unreliable
over NFS/SMB, so both need to stay off the network share even when backup content itself lives
there.

- Adds an optional `backup.metadataDir` config field. `sessions.sqlite3` and the PID lock file
  (`zmbackup.pid`) now live under `metadataDir` instead of always under `workDir` — defaults to
  `workDir`, so existing installs are unaffected unless an operator sets it explicitly (e.g. to a
  local-disk path while `workDir` points at a NAS mount).
- Adds `backup self` (`BackupType.SELF`), a new host-level singleton backup type that copies a
  consistent snapshot of `sessions.sqlite3` (via SQLite's `VACUUM INTO`, safe under the store's
  long-lived WAL-mode connection) out to the same destination as regular backups. It's a no-op
  ("Nothing found to back up for self.") when `metadata.backend: dynamodb`, since there's no local
  file to export.
- Deliberately **does not** back up `zmbackup.yaml` (it holds plaintext credentials) and does not
  add a `restore self` command — both noted as out of scope in the new spec.

Design is written up in `zmbackupdocs` (same branch name,
[specs/15-self-backup.md](https://github.com/lucascbeyeler/zmbackupdocs/blob/claude/local-database-nas-options-8d0hi9/specs/15-self-backup.md)
and [specs/03-configuration.md §8](https://github.com/lucascbeyeler/zmbackupdocs/blob/claude/local-database-nas-options-8d0hi9/specs/03-configuration.md)),
per this repo's convention of specs first/alongside code.

## Test plan

- [x] `./gradlew compileJava compileTestJava` — clean compile (JDK 17)
- [x] `./gradlew test` — full suite green: 492 tests, 0 failures, 0 errors, 1 pre-existing skip
- [x] New tests added: `BackupTypeTest` (SELF self-conflict), `BackupServiceTest` (SELF resolves
      to "nothing found" when unsupported, successful export, failure path, lockBackup/--force),
      `SqliteMetadataStoreTest` (`exportSelfBackup` produces a readable, data-intact snapshot),
      `BackupConfigTest`/`AppConfigTest`/`YamlConfigLoaderTest` (`metadataDir` default/override),
      `AppContextTest` (separate `metadataDir` places `sessions.sqlite3`/`zmbackup.pid` there
      instead of `workDir`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjvqW3E9GHdHNFNtQ6Q1fe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjvqW3E9GHdHNFNtQ6Q1fe)_