### PR TITLE
Include the exception's stack trace when logging a WARNING/ERROR

### DIFF
--- a/app/src/main/java/io/zmbackup/app/LocalSyslogAppender.java
+++ b/app/src/main/java/io/zmbackup/app/LocalSyslogAppender.java
@@ -36,7 +36,7 @@ public final class LocalSyslogAppender extends UnsynchronizedAppenderBase<ILoggi
         command.add("-i");
         command.add("-p");
         command.add(priority);
-        command.add(event.getFormattedMessage());
+        command.add(ZmlogLayout.messageOf(event));
         try {
             Process process = new ProcessBuilder(command)
                     .redirectOutput(Redirect.DISCARD)

--- a/app/src/main/java/io/zmbackup/app/ZmlogLayout.java
+++ b/app/src/main/java/io/zmbackup/app/ZmlogLayout.java
@@ -2,6 +2,8 @@ package io.zmbackup.app;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import ch.qos.logback.core.LayoutBase;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -17,8 +19,17 @@ public final class ZmlogLayout extends LayoutBase<ILoggingEvent> {
     public String doLayout(ILoggingEvent event) {
         String timestamp = TIMESTAMP.format(
                 Instant.ofEpochMilli(event.getTimeStamp()).atZone(ZoneId.systemDefault()));
-        return timestamp + " [" + FACILITY + "." + severityOf(event.getLevel()) + "] " + event.getFormattedMessage()
+        return timestamp + " [" + FACILITY + "." + severityOf(event.getLevel()) + "] " + messageOf(event)
                 + System.lineSeparator();
+    }
+
+    static String messageOf(ILoggingEvent event) {
+        IThrowableProxy throwableProxy = event.getThrowableProxy();
+        if (throwableProxy == null) {
+            return event.getFormattedMessage();
+        }
+        return event.getFormattedMessage() + System.lineSeparator()
+                + ThrowableProxyUtil.asString(throwableProxy).stripTrailing();
     }
 
     static String severityOf(Level level) {

--- a/app/src/test/java/io/zmbackup/app/LocalSyslogAppenderTest.java
+++ b/app/src/test/java/io/zmbackup/app/LocalSyslogAppenderTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.ContextBase;
 import ch.qos.logback.core.status.Status;
@@ -56,6 +57,23 @@ class LocalSyslogAppenderTest {
 
         List<Status> statuses = context.getStatusManager().getCopyOfStatusList();
         assertTrue(statuses.stream().anyMatch(s -> s.getLevel() == Status.ERROR), "expected an error status");
+    }
+
+    @Test
+    void includesTheStackTraceWhenTheEventCarriesAThrowable() throws Exception {
+        Path receivedArgs = tempDir.resolve("received-args.log");
+        LocalSyslogAppender appender = new LocalSyslogAppender(stubLoggerCommand(receivedArgs));
+        appender.start();
+
+        LoggingEvent event = eventOf(Level.WARN, "Backup failed for account@example.com");
+        event.setThrowableProxy(new ThrowableProxy(new IOException("connection reset")));
+        appender.doAppend(event);
+
+        String content = Files.readString(receivedArgs);
+        assertTrue(
+                content.contains("Backup failed for account@example.com" + System.lineSeparator()
+                        + "java.io.IOException: connection reset"),
+                "unexpected content: " + content);
     }
 
     private static LoggingEvent eventOf(Level level, String message) {

--- a/app/src/test/java/io/zmbackup/app/ZmlogLayoutTest.java
+++ b/app/src/test/java/io/zmbackup/app/ZmlogLayoutTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxy;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 class ZmlogLayoutTest {
@@ -37,6 +39,23 @@ class ZmlogLayoutTest {
         String line = layoutOf(Level.DEBUG, "detail");
 
         assertTrue(line.contains("[local7.info] detail"), "unexpected line: " + line);
+    }
+
+    @Test
+    void appendsTheStackTraceWhenTheEventCarriesAThrowable() {
+        LoggingEvent event = new LoggingEvent();
+        event.setLevel(Level.WARN);
+        event.setMessage("Backup failed for account@example.com");
+        event.setTimeStamp(System.currentTimeMillis());
+        event.setThrowableProxy(new ThrowableProxy(new IOException("connection reset")));
+
+        String line = new ZmlogLayout().doLayout(event);
+
+        assertTrue(
+                line.contains("[local7.warn] Backup failed for account@example.com"
+                        + System.lineSeparator() + "java.io.IOException: connection reset"),
+                "unexpected line: " + line);
+        assertTrue(line.contains("\tat "), "expected a stack frame in: " + line);
     }
 
     private static String layoutOf(Level level, String message) {


### PR DESCRIPTION
## Summary

- `ZmlogLayout.doLayout` and `LocalSyslogAppender.append` both rendered a log line from `event.getFormattedMessage()` alone, so any throwable attached to a `LOG.log(Level.WARNING, message, e)` call (e.g. `BackupService.backupOne`'s `"Backup failed for <identifier>"`) never reached `logFile` or syslog — an operator was left with the bare message and no way to diagnose the actual failure.
- This is exactly what @milauria hit in [#214](https://github.com/lucascbeyeler/zmbackup/issues/214): `backup full` failed with `Session full-... (FULL): FAILED, size 25.5K`, and the log showed only `Backup failed for <identifier>` with nothing indicating the underlying cause.
- Adds a shared `ZmlogLayout.messageOf(event)` that appends the throwable's stack trace (`ThrowableProxyUtil.asString(...)`) after the message when one is attached, and uses it from both `ZmlogLayout` (file) and `LocalSyslogAppender` (syslog), so the root cause of a failure now shows up in both places.

## Test plan

- [x] `ZmlogLayoutTest.appendsTheStackTraceWhenTheEventCarriesAThrowable` — the file line format now includes the exception's stack trace when one is attached.
- [x] `LocalSyslogAppenderTest.includesTheStackTraceWhenTheEventCarriesAThrowable` — the `logger` command now receives the stack trace too.
- [x] Existing `ZmlogLayoutTest`/`LocalSyslogAppenderTest` cases (no-throwable path) still pass unchanged.
- [x] `./gradlew :app:test --tests "io.zmbackup.app.ZmlogLayoutTest" --tests "io.zmbackup.app.LocalSyslogAppenderTest"` passes locally.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kcfrdxh4p7nZ3ZcsucrXx8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kcfrdxh4p7nZ3ZcsucrXx8)_